### PR TITLE
feat: decentralized git bundle storage with DWN records

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,10 +5,10 @@
     "": {
       "name": "@enbox/dwn-git",
       "dependencies": {
-        "@enbox/api": "0.2.4",
-        "@enbox/crypto": "0.0.5",
-        "@enbox/dids": "0.0.6",
-        "@enbox/dwn-sdk-js": "0.0.8",
+        "@enbox/api": "0.3.0",
+        "@enbox/crypto": "0.0.6",
+        "@enbox/dids": "0.0.7",
+        "@enbox/dwn-sdk-js": "0.1.0",
       },
       "devDependencies": {
         "@eslint/js": "9.7.0",
@@ -29,19 +29,19 @@
 
     "@dnsquery/dns-packet": ["@dnsquery/dns-packet@6.1.1", "", { "dependencies": { "@leichtgewicht/ip-codec": "^2.0.4", "utf8-codec": "^1.0.0" } }, "sha512-WXTuFvL3G+74SchFAtz3FgIYVOe196ycvGsMgvSH/8Goptb1qpIQtIuM4SOK9G9lhMWYpHxnXyy544ZhluFOew=="],
 
-    "@enbox/agent": ["@enbox/agent@0.1.9", "", { "dependencies": { "@enbox/common": "0.0.4", "@enbox/crypto": "0.0.5", "@enbox/dids": "0.0.6", "@enbox/dwn-clients": "0.0.6", "@enbox/dwn-sdk-js": "0.0.8", "@scure/bip39": "1.2.2", "abstract-level": "1.0.4", "ed25519-keygen": "0.4.11", "level": "8.0.0", "ms": "2.1.3", "ulidx": "2.1.0" } }, "sha512-YPKElTbq9hCvvqfklT1PjEve1HIBahoxMInSoo4k6rfjh/Il1shQKy/QLlJQ6P9g2eKCmgjeZzq36vgi+UjZJA=="],
+    "@enbox/agent": ["@enbox/agent@0.2.0", "", { "dependencies": { "@enbox/common": "0.0.5", "@enbox/crypto": "0.0.6", "@enbox/dids": "0.0.7", "@enbox/dwn-clients": "0.0.7", "@enbox/dwn-sdk-js": "0.1.0", "@scure/bip39": "1.2.2", "abstract-level": "1.0.4", "ed25519-keygen": "0.4.11", "level": "8.0.0", "ms": "2.1.3", "ulidx": "2.1.0" } }, "sha512-ow++PQXQsGZeuFFfJGFeuJUvPlEWAbuBLprIaS/U+iDw7i/yW1Kf6b+viRaUP96LN/z08WqvlVlIpkTi/ZoyPw=="],
 
-    "@enbox/api": ["@enbox/api@0.2.4", "", { "dependencies": { "@enbox/agent": "0.1.9", "@enbox/common": "0.0.4", "@enbox/dwn-clients": "0.0.6" } }, "sha512-30JO3aOnNW9VPjo2ANOGPA7/TIvjuX5b5+xfYORQwjtQLdUSUCa1aFg1UlAeE9cI9I0SDaDndaFrQt8Z+ICfOQ=="],
+    "@enbox/api": ["@enbox/api@0.3.0", "", { "dependencies": { "@enbox/agent": "0.2.0", "@enbox/common": "0.0.5", "@enbox/dwn-clients": "0.0.7" } }, "sha512-ahTO7kKkMJjCCt3BTf13tK5bdZJeDIFYUC2gb6dyIxoalihJYqW/eHGepR23LX/3JyCVfCFuht3K4i2Mg3NGkg=="],
 
-    "@enbox/common": ["@enbox/common@0.0.4", "", { "dependencies": { "@isaacs/ttlcache": "1.4.1", "level": "8.0.1", "multiformats": "13.1.0" } }, "sha512-h4tgu+QwgkiiRYpWsBFSpq6WWcM9+sevMP/ZrIImLpEw/bYbSGjwh8kfGjWJ4lYLU2OlC4/2dExC0sbvVtjI5A=="],
+    "@enbox/common": ["@enbox/common@0.0.5", "", { "dependencies": { "@isaacs/ttlcache": "1.4.1", "level": "8.0.1", "multiformats": "13.1.0" } }, "sha512-Zwb7s4JTzfXtHrFDA0MM6gfFcN65qVey6vNTG6gAM1xXwO0WDlovZxvKa2wLEXPW7Zf/ojwuPpCPCpJ4+Y7byA=="],
 
-    "@enbox/crypto": ["@enbox/crypto@0.0.5", "", { "dependencies": { "@enbox/common": "0.0.4", "@noble/ciphers": "0.5.3", "@noble/curves": "1.3.0", "@noble/hashes": "1.4.0", "cborg": "^4.5.8" } }, "sha512-p3lh8zYPjikPyhgDpRA4lj2fhffkItQrkFG0ZY/XS2oygqgAm8C1mQCXlAuVEsKD534fGhMOnbIeKTubEQ74wQ=="],
+    "@enbox/crypto": ["@enbox/crypto@0.0.6", "", { "dependencies": { "@enbox/common": "0.0.5", "@noble/ciphers": "0.5.3", "@noble/curves": "1.3.0", "@noble/hashes": "1.4.0", "cborg": "^4.5.8" } }, "sha512-FEXM1VCcvrd1yxIHPbc7H2nTwdwl9PnfiIz0x8Y4oCg0AOEC/2kH9SFmPAGYPJInZqLgrAarMQkS+Dn8LPKdTQ=="],
 
-    "@enbox/dids": ["@enbox/dids@0.0.6", "", { "dependencies": { "@decentralized-identity/ion-sdk": "1.0.4", "@dnsquery/dns-packet": "6.1.1", "@enbox/common": "0.0.4", "@enbox/crypto": "0.0.5", "abstract-level": "1.0.4", "bencode": "4.0.0", "level": "8.0.1", "ms": "2.1.3" } }, "sha512-cRLt6LDcTZWg/UvKBUAR8u9Qm7Hs6wIruKMPIUfDY8M3CEFRWvcdViVx21MgjtjdjaGWXQrHyKdOO1H/bgVpdQ=="],
+    "@enbox/dids": ["@enbox/dids@0.0.7", "", { "dependencies": { "@decentralized-identity/ion-sdk": "1.0.4", "@dnsquery/dns-packet": "6.1.1", "@enbox/common": "0.0.5", "@enbox/crypto": "0.0.6", "abstract-level": "1.0.4", "bencode": "4.0.0", "level": "8.0.1", "ms": "2.1.3" } }, "sha512-/adZ+WTTRlThxMCr+oFja154PMRXSnEVocMxdP607wSKwTw3UkXBQ8Jz7wbX0b2iR46MreiEtLD0ecoDYiqeGw=="],
 
-    "@enbox/dwn-clients": ["@enbox/dwn-clients@0.0.6", "", { "dependencies": { "@enbox/common": "0.0.4", "@enbox/crypto": "0.0.5", "@enbox/dwn-sdk-js": "0.0.8", "ms": "2.1.3" } }, "sha512-PSK2/Lw3/V8RbjtVTkPNr1+C2LGn8U4x1PZTMWgKDJAM7Zq2pXILAFbfJUIRkOs5W2AwbGdadNiPu6+4VwilJg=="],
+    "@enbox/dwn-clients": ["@enbox/dwn-clients@0.0.7", "", { "dependencies": { "@enbox/common": "0.0.5", "@enbox/crypto": "0.0.6", "@enbox/dwn-sdk-js": "0.1.0", "ms": "2.1.3" } }, "sha512-WXZZgvbYIqSS1ct7jqfAb07zvMLg1mPOYyuEN8aNU0ovHNoVK+tliSLPYykx1qxJcBGBD+kJAJXIQR3rndTQtw=="],
 
-    "@enbox/dwn-sdk-js": ["@enbox/dwn-sdk-js@0.0.8", "", { "dependencies": { "@enbox/crypto": "0.0.5", "@enbox/dids": "0.0.6", "@ipld/dag-cbor": "9.0.3", "@js-temporal/polyfill": "0.4.4", "@noble/ciphers": "0.5.3", "@noble/curves": "1.4.2", "@noble/ed25519": "2.0.0", "@noble/secp256k1": "2.0.0", "abstract-level": "1.0.3", "ajv": "8.18.0", "interface-blockstore": "5.2.3", "interface-store": "5.1.2", "ipfs-unixfs-exporter": "13.1.5", "ipfs-unixfs-importer": "15.1.5", "level": "8.0.0", "lodash": "4.17.21", "lru-cache": "9.1.2", "mitt": "^3.0.1", "multiformats": "11.0.2", "uint8arrays": "5.1.0", "ulidx": "2.1.0" } }, "sha512-a3Kj30+YvcpUT8B3pBTYJEATbhbYcCpslO3jaE+MsIPuDOrMhZObAixvbNJya+Yh2YA17nKnqoyba+sIU9IG1A=="],
+    "@enbox/dwn-sdk-js": ["@enbox/dwn-sdk-js@0.1.0", "", { "dependencies": { "@enbox/crypto": "0.0.6", "@enbox/dids": "0.0.7", "@ipld/dag-cbor": "9.0.3", "@js-temporal/polyfill": "0.4.4", "@noble/ciphers": "0.5.3", "@noble/curves": "1.4.2", "@noble/ed25519": "2.0.0", "@noble/secp256k1": "2.0.0", "abstract-level": "1.0.3", "ajv": "8.18.0", "interface-blockstore": "5.2.3", "interface-store": "5.1.2", "ipfs-unixfs-exporter": "13.1.5", "ipfs-unixfs-importer": "15.1.5", "level": "8.0.0", "lodash": "4.17.21", "lru-cache": "9.1.2", "mitt": "^3.0.1", "multiformats": "11.0.2", "uint8arrays": "5.1.0", "ulidx": "2.1.0" } }, "sha512-iW10d+fRCeoYZ0mKeaaob25Z615xIT34QO8jPgCObzBheilFH3bUnDkCDDuVBeef4jt9VRVlU1nFC9Kn4+I9+g=="],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
 

--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
     "bun": ">=1.0.0"
   },
   "dependencies": {
-    "@enbox/api": "0.2.4",
-    "@enbox/crypto": "0.0.5",
-    "@enbox/dids": "0.0.6",
-    "@enbox/dwn-sdk-js": "0.0.8"
+    "@enbox/api": "0.3.0",
+    "@enbox/crypto": "0.0.6",
+    "@enbox/dids": "0.0.7",
+    "@enbox/dwn-sdk-js": "0.1.0"
   },
   "devDependencies": {
     "@eslint/js": "9.7.0",

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -96,7 +96,9 @@ export async function connectAgent(password: string): Promise<AgentContext> {
   const org = web5.using(ForgeOrgProtocol);
 
   // Install / verify all protocols (idempotent).
-  await repo.configure();
+  // Repo protocol requires encryption: webhook has encryptionRequired: true,
+  // and bundle records are optionally encrypted based on repo visibility.
+  await repo.configure({ encryption: true });
   await refs.configure();
   await issues.configure();
   await patches.configure();

--- a/src/cli/repo-context.ts
+++ b/src/cli/repo-context.ts
@@ -1,19 +1,28 @@
 /**
- * Shared helper to locate the repo record's contextId.
+ * Shared helper to locate the repo record's contextId and visibility.
  *
  * All composing protocols (issues, patches) need the repo's `contextId`
  * as the `parentContextId` for their top-level writes (via `$ref`).
+ * The `visibility` tag determines whether bundle records are encrypted.
  *
  * @module
  */
 
 import type { AgentContext } from './agent.js';
 
+/** Repo context returned by {@link getRepoContext}. */
+export type RepoContext = {
+  /** The repo record's contextId (used as parentContextId for child records). */
+  contextId: string;
+  /** Repo visibility — controls encryption of bundle records. */
+  visibility: 'public' | 'private';
+};
+
 /**
- * Query the local DWN for the singleton repo record and return its contextId.
+ * Query the local DWN for the singleton repo record and return its context.
  * Exits with an error if no repo has been initialized.
  */
-export async function getRepoContextId(ctx: AgentContext): Promise<string> {
+export async function getRepoContext(ctx: AgentContext): Promise<RepoContext> {
   const { records } = await ctx.repo.records.query('repo');
 
   if (records.length === 0) {
@@ -21,11 +30,26 @@ export async function getRepoContextId(ctx: AgentContext): Promise<string> {
     process.exit(1);
   }
 
-  const contextId = records[0].contextId;
+  const record = records[0];
+
+  const contextId = record.contextId;
   if (!contextId) {
     console.error('Repository record has no contextId — this should not happen.');
     process.exit(1);
   }
 
+  const visibility = (record.tags?.visibility as 'public' | 'private') ?? 'public';
+
+  return { contextId, visibility };
+}
+
+/**
+ * Query the local DWN for the singleton repo record and return its contextId.
+ * Exits with an error if no repo has been initialized.
+ *
+ * @deprecated Use {@link getRepoContext} instead to also get visibility.
+ */
+export async function getRepoContextId(ctx: AgentContext): Promise<string> {
+  const { contextId } = await getRepoContext(ctx);
   return contextId;
 }

--- a/src/git-server/bundle-restore.ts
+++ b/src/git-server/bundle-restore.ts
@@ -1,0 +1,217 @@
+/**
+ * Bundle restore — reconstructs a bare git repo from DWN bundle records.
+ *
+ * When a commodity git host receives a clone request for a repo it doesn't
+ * have on disk, it resolves the owner's DID, reads bundle records from
+ * the owner's DWN, and reconstructs the bare repo locally.
+ *
+ * Restore flow:
+ * 1. Query the owner's DWN for bundle records (via the repo's contextId)
+ * 2. Find the most recent full bundle (isFull: true)
+ * 3. Clone from the full bundle to create a bare repo
+ * 4. Apply any incremental bundles (in chronological order) that are newer
+ * 5. The restored repo is now ready to serve clones and accept pushes
+ *
+ * @module
+ */
+
+import type { ForgeRepoProtocol } from '../repo.js';
+import type { ForgeRepoSchemaMap } from '../repo.js';
+import type { TypedWeb5 } from '@enbox/api';
+
+import { DateSort } from '@enbox/dwn-sdk-js';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { mkdir, unlink, writeFile } from 'node:fs/promises';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Options for restoring a repository from DWN bundles. */
+export type BundleRestoreOptions = {
+  /** The typed ForgeRepoProtocol Web5 handle for the owner's DWN. */
+  repo: TypedWeb5<typeof ForgeRepoProtocol.definition, ForgeRepoSchemaMap>;
+
+  /** Path where the bare repository should be created. */
+  repoPath: string;
+};
+
+/** Result of a bundle restore operation. */
+export type BundleRestoreResult = {
+  /** Whether the restore succeeded. */
+  success: boolean;
+
+  /** Number of bundles applied (1 full + N incrementals). */
+  bundlesApplied: number;
+
+  /** The tip commit SHA after restore. */
+  tipCommit?: string;
+
+  /** Error message if restore failed. */
+  error?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Restore a bare git repository from DWN bundle records.
+ *
+ * Queries the owner's DWN for bundle records, downloads the most recent
+ * full bundle, clones from it, then applies any incremental bundles.
+ *
+ * @param options - Restore configuration
+ * @returns Result of the restore operation
+ */
+export async function restoreFromBundles(
+  options: BundleRestoreOptions,
+): Promise<BundleRestoreResult> {
+  const { repo, repoPath } = options;
+
+  // 1. Query for the most recent full bundle.
+  const { records: fullBundles } = await repo.records.query('repo/bundle', {
+    filter   : { tags: { isFull: true } },
+    dateSort : DateSort.CreatedDescending,
+  });
+
+  if (fullBundles.length === 0) {
+    return { success: false, bundlesApplied: 0, error: 'No full bundle found in DWN' };
+  }
+
+  const latestFull = fullBundles[0];
+  const fullTimestamp = latestFull.dateCreated;
+
+  // 2. Download the full bundle to a temp file.
+  const fullBundlePath = tempBundlePath();
+  try {
+    const fullBlob = await latestFull.data.blob();
+    const fullBlobData = Buffer.from(await fullBlob.arrayBuffer());
+    await writeFile(fullBundlePath, fullBlobData);
+
+    // 3. Clone from the full bundle to create the bare repo.
+    await ensureParentDir(repoPath);
+    await spawnChecked('git', ['clone', '--bare', fullBundlePath, repoPath]);
+
+    let bundlesApplied = 1;
+
+    // 4. Query for incremental bundles newer than the full bundle.
+    const { records: incrementals } = await repo.records.query('repo/bundle', {
+      filter   : { tags: { isFull: false } },
+      dateSort : DateSort.CreatedAscending,
+    });
+
+    // Apply incremental bundles in chronological order.
+    for (const incBundle of incrementals) {
+      // Only apply incrementals that are newer than the full bundle.
+      if (incBundle.dateCreated <= fullTimestamp) { continue; }
+
+      const incPath = tempBundlePath();
+      try {
+        const incBlob = await incBundle.data.blob();
+        const incData = Buffer.from(await incBlob.arrayBuffer());
+        await writeFile(incPath, incData);
+
+        // Fetch all refs from the incremental bundle into the bare repo.
+        // The explicit refspec is required because bundles don't have a HEAD
+        // ref, and `git fetch` without a refspec tries to fetch HEAD.
+        await spawnChecked('git', ['fetch', incPath, 'refs/*:refs/*', '--update-head-ok'], repoPath);
+        bundlesApplied++;
+      } finally {
+        await unlink(incPath).catch(() => {});
+      }
+    }
+
+    // 5. Get the tip commit.
+    const tipCommit = await getTipCommit(repoPath);
+
+    return { success: true, bundlesApplied, tipCommit };
+  } catch (err) {
+    return {
+      success        : false,
+      bundlesApplied : 0,
+      error          : (err as Error).message,
+    };
+  } finally {
+    await unlink(fullBundlePath).catch(() => {});
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Generate a unique temp file path for a bundle. */
+function tempBundlePath(): string {
+  return join(tmpdir(), `dwn-git-restore-${Date.now()}-${Math.random().toString(36).slice(2)}.bundle`);
+}
+
+/** Ensure the parent directory of a path exists. */
+async function ensureParentDir(filePath: string): Promise<void> {
+  const parentDir = join(filePath, '..');
+  if (!existsSync(parentDir)) {
+    await mkdir(parentDir, { recursive: true });
+  }
+}
+
+/**
+ * Get the tip commit SHA from a bare repo.
+ *
+ * In bare repos restored from bundles, HEAD may be a dangling symbolic ref
+ * (e.g. `refs/heads/master` doesn't exist but `refs/heads/main` does).
+ * Falls back to the first ref SHA if HEAD doesn't resolve to a commit.
+ */
+async function getTipCommit(repoPath: string): Promise<string> {
+  // Try HEAD first.
+  const headResult = await spawnCollectOptional('git', ['rev-parse', 'HEAD'], repoPath);
+  if (headResult && /^[0-9a-f]{40}$/.test(headResult)) {
+    return headResult;
+  }
+
+  // HEAD didn't resolve; get the first ref.
+  const refResult = await spawnCollectOptional(
+    'git', ['for-each-ref', '--format=%(objectname)', '--count=1', 'refs/'], repoPath,
+  );
+  return refResult || 'unknown';
+}
+
+/** Spawn a process, collect stdout, return trimmed output or null on failure. */
+function spawnCollectOptional(cmd: string, args: string[], cwd: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    const child = spawn(cmd, args, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+    const chunks: Buffer[] = [];
+
+    child.stdout!.on('data', (chunk: Buffer) => chunks.push(chunk));
+    child.on('error', () => resolve(null));
+    child.on('exit', (code) => {
+      if (code !== 0) {
+        resolve(null);
+      } else {
+        const result = Buffer.concat(chunks).toString('utf-8').trim();
+        resolve(result || null);
+      }
+    });
+  });
+}
+
+/** Spawn a process and reject if it exits with non-zero code. */
+function spawnChecked(cmd: string, args: string[], cwd?: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+    const stderrChunks: Buffer[] = [];
+
+    child.stderr!.on('data', (chunk: Buffer) => stderrChunks.push(chunk));
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code !== 0) {
+        const stderr = Buffer.concat(stderrChunks).toString('utf-8');
+        reject(new Error(`${cmd} ${args.join(' ')} exited with code ${code}: ${stderr}`));
+      } else {
+        resolve();
+      }
+    });
+  });
+}

--- a/src/git-server/bundle-sync.ts
+++ b/src/git-server/bundle-sync.ts
@@ -1,0 +1,300 @@
+/**
+ * Git bundle → DWN sync — creates/updates a git bundle as a DWN record.
+ *
+ * After a successful `git push`, this module generates a `git bundle` from
+ * the bare repository and writes it as a ForgeRepo `bundle` record.
+ * Incremental bundles are created when a previous bundle exists; periodic
+ * squash writes compact all incrementals into a single full bundle.
+ *
+ * Bundle sync flow:
+ * 1. Query existing bundle records for the repo (sorted by timestamp desc)
+ * 2. If no bundles exist → create full bundle (`git bundle create --all`)
+ * 3. If bundles exist → create incremental bundle since last tip commit
+ * 4. Every N pushes (configurable), create a squash bundle (full bundle
+ *    with `squash: true`) which purges all older bundle records
+ *
+ * The bundle data (binary `application/x-git-bundle`) is stored as the
+ * record payload. Queryable metadata is stored in tags.
+ *
+ * @module
+ */
+
+import type { ForgeRepoProtocol } from '../repo.js';
+import type { ForgeRepoSchemaMap } from '../repo.js';
+import type { OnPushComplete } from './ref-sync.js';
+import type { TypedWeb5 } from '@enbox/api';
+
+import { DateSort } from '@enbox/dwn-sdk-js';
+import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { readFile, stat, unlink } from 'node:fs/promises';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Options for creating a bundle syncer. */
+export type BundleSyncOptions = {
+  /** The typed ForgeRepoProtocol Web5 handle. */
+  repo: TypedWeb5<typeof ForgeRepoProtocol.definition, ForgeRepoSchemaMap>;
+
+  /** The repo's contextId (from the ForgeRepoProtocol repo record). */
+  repoContextId: string;
+
+  /**
+   * Repo visibility — controls whether bundle records are encrypted.
+   *
+   * - `'private'` → bundles are JWE-encrypted (only key-holders can read)
+   * - `'public'`  → bundles are plaintext (IPFS-friendly, globally readable)
+   *
+   * The protocol must be installed with `encryption: true` for private repos
+   * to work (this injects `$encryption` keys on all protocol paths).
+   *
+   * @default 'public'
+   */
+  visibility?: 'public' | 'private';
+
+  /**
+   * Number of incremental bundles to accumulate before squashing.
+   * When this threshold is reached, the next bundle write is a squash
+   * that replaces all older bundles with a single full bundle.
+   *
+   * @default 5
+   */
+  squashThreshold?: number;
+};
+
+/** Metadata about a generated git bundle. */
+export type BundleInfo = {
+  /** Path to the bundle file on disk. */
+  path: string;
+  /** SHA of the tip commit (HEAD of default branch). */
+  tipCommit: string;
+  /** Whether this is a full bundle (all refs) or incremental. */
+  isFull: boolean;
+  /** Number of refs included in the bundle. */
+  refCount: number;
+  /** File size in bytes. */
+  size: number;
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an `onPushComplete` callback that syncs a git bundle to a DWN record.
+ *
+ * @param options - Bundle sync configuration
+ * @returns An async callback to invoke after a successful push
+ */
+export function createBundleSyncer(options: BundleSyncOptions): OnPushComplete {
+  const { repo, repoContextId, visibility = 'public', squashThreshold = 5 } = options;
+  const encrypt = visibility === 'private';
+
+  return async (_did: string, _repoName: string, repoPath: string): Promise<void> => {
+    // Query existing bundle records, newest first.
+    const { records: existingBundles } = await repo.records.query('repo/bundle', {
+      filter   : { tags: { isFull: true } },
+      dateSort : DateSort.CreatedDescending,
+    });
+
+    // Also query incremental bundles.
+    const { records: incrementalBundles } = await repo.records.query('repo/bundle', {
+      filter   : { tags: { isFull: false } },
+      dateSort : DateSort.CreatedDescending,
+    });
+
+    const totalBundles = existingBundles.length + incrementalBundles.length;
+
+    // Determine the last tip commit from the most recent bundle (full or incremental).
+    let lastTipCommit: string | undefined;
+    if (incrementalBundles.length > 0 && incrementalBundles[0].tags) {
+      lastTipCommit = incrementalBundles[0].tags.tipCommit as string;
+    } else if (existingBundles.length > 0 && existingBundles[0].tags) {
+      lastTipCommit = existingBundles[0].tags.tipCommit as string;
+    }
+
+    // Decide whether to create a full or incremental bundle.
+    const shouldSquash = totalBundles > 0 && totalBundles >= squashThreshold;
+    const isIncremental = !shouldSquash && lastTipCommit !== undefined;
+
+    let bundleInfo: BundleInfo;
+    try {
+      if (isIncremental) {
+        // Create incremental bundle: only objects reachable from --all but not from lastTipCommit.
+        bundleInfo = await createIncrementalBundle(repoPath, lastTipCommit!);
+      } else {
+        // Create full bundle: all refs, all objects.
+        bundleInfo = await createFullBundle(repoPath);
+      }
+    } catch (err) {
+      console.error(`bundle-sync: failed to create bundle: ${(err as Error).message}`);
+      return;
+    }
+
+    try {
+      // Read the bundle data from disk.
+      const bundleData = new Uint8Array(await readFile(bundleInfo.path));
+
+      const tags = {
+        tipCommit : bundleInfo.tipCommit,
+        isFull    : bundleInfo.isFull,
+        refCount  : bundleInfo.refCount,
+        size      : bundleInfo.size,
+      };
+
+      const createOptions: any = {
+        data            : bundleData,
+        dataFormat      : 'application/x-git-bundle',
+        tags,
+        parentContextId : repoContextId,
+        encryption      : encrypt,
+      };
+
+      if (shouldSquash) {
+        // Squash write: creates a new bundle record and purges all older ones.
+        createOptions.squash = true;
+      }
+
+      await repo.records.create('repo/bundle', createOptions);
+    } finally {
+      // Clean up the temp bundle file.
+      await unlink(bundleInfo.path).catch(() => {});
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Bundle creation
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a full git bundle containing all refs and all reachable objects.
+ *
+ * @param repoPath - Path to the bare git repository
+ * @returns Bundle metadata and file path
+ */
+export async function createFullBundle(repoPath: string): Promise<BundleInfo> {
+  const bundlePath = join(tmpdir(), `dwn-git-bundle-${Date.now()}-${Math.random().toString(36).slice(2)}.bundle`);
+
+  await spawnChecked('git', ['bundle', 'create', bundlePath, '--all'], repoPath);
+
+  const tipCommit = await getTipCommit(repoPath);
+  const refCount = await getRefCount(repoPath);
+  const fileInfo = await stat(bundlePath);
+
+  return {
+    path   : bundlePath,
+    tipCommit,
+    isFull : true,
+    refCount,
+    size   : fileInfo.size,
+  };
+}
+
+/**
+ * Create an incremental git bundle containing only objects since a base commit.
+ *
+ * The bundle uses the base commit as a prerequisite, meaning the consumer
+ * must already have it to apply the incremental bundle.
+ *
+ * @param repoPath - Path to the bare git repository
+ * @param baseCommit - The commit SHA to use as the prerequisite (exclude point)
+ * @returns Bundle metadata and file path
+ */
+export async function createIncrementalBundle(
+  repoPath: string,
+  baseCommit: string,
+): Promise<BundleInfo> {
+  const bundlePath = join(tmpdir(), `dwn-git-bundle-${Date.now()}-${Math.random().toString(36).slice(2)}.bundle`);
+
+  // `--all ^<base>` means: include all refs, exclude objects reachable from base.
+  await spawnChecked('git', ['bundle', 'create', bundlePath, '--all', `^${baseCommit}`], repoPath);
+
+  const tipCommit = await getTipCommit(repoPath);
+  const refCount = await getRefCount(repoPath);
+  const fileInfo = await stat(bundlePath);
+
+  return {
+    path   : bundlePath,
+    tipCommit,
+    isFull : false,
+    refCount,
+    size   : fileInfo.size,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the tip commit SHA (HEAD of the default branch).
+ * Falls back to the first ref if HEAD is unset.
+ */
+async function getTipCommit(repoPath: string): Promise<string> {
+  try {
+    const sha = (await spawnCollectStdout('git', ['rev-parse', 'HEAD'], repoPath)).trim();
+    // In bare repos, HEAD may be a dangling symbolic ref (e.g. refs/heads/master
+    // doesn't exist). `git rev-parse HEAD` outputs the literal string "HEAD" in
+    // that case instead of a 40-hex SHA.
+    if (/^[0-9a-f]{40}$/.test(sha)) {
+      return sha;
+    }
+  } catch {
+    // rev-parse failed entirely — fall through to for-each-ref.
+  }
+
+  // HEAD didn't resolve; get the first ref.
+  const output = await spawnCollectStdout(
+    'git', ['for-each-ref', '--format=%(objectname)', '--count=1', 'refs/'], repoPath,
+  );
+  return output.trim();
+}
+
+/** Count the number of refs (branches + tags) in the repo. */
+async function getRefCount(repoPath: string): Promise<number> {
+  const output = await spawnCollectStdout(
+    'git', ['for-each-ref', '--format=x', 'refs/heads/', 'refs/tags/'], repoPath,
+  );
+  return output.split('\n').filter((l) => l.trim()).length;
+}
+
+/** Spawn a process and reject if it exits with non-zero code. */
+function spawnChecked(cmd: string, args: string[], cwd: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+    const stderrChunks: Buffer[] = [];
+
+    child.stderr!.on('data', (chunk: Buffer) => stderrChunks.push(chunk));
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code !== 0) {
+        const stderr = Buffer.concat(stderrChunks).toString('utf-8');
+        reject(new Error(`${cmd} ${args.join(' ')} exited with code ${code}: ${stderr}`));
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+/** Spawn a process, collect stdout, and return it as a string. */
+function spawnCollectStdout(cmd: string, args: string[], cwd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+    const chunks: Buffer[] = [];
+
+    child.stdout!.on('data', (chunk: Buffer) => chunks.push(chunk));
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code !== 0) {
+        reject(new Error(`${cmd} ${args.join(' ')} exited with code ${code}`));
+      } else {
+        resolve(Buffer.concat(chunks).toString('utf-8'));
+      }
+    });
+  });
+}

--- a/src/git-server/server.ts
+++ b/src/git-server/server.ts
@@ -55,6 +55,13 @@ export type GitServerOptions = {
    * @see GitHttpHandlerOptions.onPushComplete
    */
   onPushComplete?: (did: string, repo: string, repoPath: string) => Promise<void>;
+
+  /**
+   * Optional callback invoked when a repo is not found on disk.
+   * Implementations can restore the repo from DWN bundle records.
+   * @see GitHttpHandlerOptions.onRepoNotFound
+   */
+  onRepoNotFound?: (did: string, repo: string, repoPath: string) => Promise<boolean>;
 };
 
 /** A running git server instance. */
@@ -87,6 +94,7 @@ export async function createGitServer(options: GitServerOptions): Promise<GitSer
     pathPrefix,
     authenticatePush,
     onPushComplete,
+    onRepoNotFound,
   } = options;
 
   const backend = new GitBackend({ basePath });
@@ -96,6 +104,7 @@ export async function createGitServer(options: GitServerOptions): Promise<GitSer
     pathPrefix,
     authenticatePush,
     onPushComplete,
+    onRepoNotFound,
   });
 
   const server = createServer(async (req, res) => {

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -53,6 +53,14 @@ export type WebhookData = {
   active : boolean;
 };
 
+/**
+ * Data shape for a git bundle record.
+ *
+ * The record payload is the raw git bundle binary (`application/x-git-bundle`).
+ * Queryable metadata (tipCommit, isFull, etc.) is stored in record tags.
+ */
+export type BundleData = Uint8Array;
+
 // ---------------------------------------------------------------------------
 // Schema map
 // ---------------------------------------------------------------------------
@@ -60,6 +68,7 @@ export type WebhookData = {
 /** Maps protocol type names to their TypeScript data shapes. */
 export type ForgeRepoSchemaMap = {
   repo : RepoData;
+  bundle : BundleData;
   settings : SettingsData;
   readme : string;
   license : string;
@@ -108,6 +117,9 @@ export const ForgeRepoDefinition = {
       schema      : 'https://enbox.org/schemas/forge/topic',
       dataFormats : ['application/json'],
     },
+    bundle: {
+      dataFormats: ['application/x-git-bundle'],
+    },
     webhook: {
       schema             : 'https://enbox.org/schemas/forge/webhook',
       dataFormats        : ['application/json'],
@@ -155,6 +167,22 @@ export const ForgeRepoDefinition = {
           $requiredTags       : ['did'],
           $allowUndefinedTags : false,
           did                 : { type: 'string' },
+        },
+      },
+
+      bundle: {
+        $squash  : true,
+        $actions : [
+          { who: 'anyone', can: ['read'] },
+          { role: 'repo/maintainer', can: ['create', 'squash'] },
+        ],
+        $tags: {
+          $requiredTags       : ['tipCommit', 'isFull'],
+          $allowUndefinedTags : false,
+          tipCommit           : { type: 'string' },
+          isFull              : { type: 'boolean' },
+          refCount            : { type: 'integer' },
+          size                : { type: 'integer' },
         },
       },
 

--- a/tests/bundle-restore.spec.ts
+++ b/tests/bundle-restore.spec.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests for restoring a bare git repo from DWN bundle records.
+ *
+ * Tests the `restoreFromBundles` function end-to-end: creates a Web5
+ * agent, pushes commits, syncs bundles to DWN, then restores to a new
+ * directory and verifies the repository content matches.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+
+import { exec as execCb } from 'node:child_process';
+import { promisify } from 'node:util';
+import { existsSync, rmSync } from 'node:fs';
+
+import { Web5 } from '@enbox/api';
+import { Web5UserAgent } from '@enbox/agent';
+
+import { createBundleSyncer } from '../src/git-server/bundle-sync.js';
+import { GitBackend } from '../src/git-server/git-backend.js';
+import { restoreFromBundles } from '../src/git-server/bundle-restore.js';
+
+import { ForgeRepoProtocol } from '../src/repo.js';
+
+const exec = promisify(execCb);
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DATA_PATH = '__TESTDATA__/bundle-restore-agent';
+const REPOS_PATH = '__TESTDATA__/bundle-restore-repos';
+const WORK_PATH = '__TESTDATA__/bundle-restore-work';
+const RESTORE_PATH = '__TESTDATA__/bundle-restore-output';
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('restoreFromBundles', () => {
+  let repoPath: string;
+  let repoContextId: string;
+  let repoHandle: ReturnType<InstanceType<typeof Web5>['using']>;
+
+  beforeAll(async () => {
+    rmSync(DATA_PATH, { recursive: true, force: true });
+    rmSync(REPOS_PATH, { recursive: true, force: true });
+    rmSync(WORK_PATH, { recursive: true, force: true });
+    rmSync(RESTORE_PATH, { recursive: true, force: true });
+
+    // Create agent + Web5 instance.
+    const agent = await Web5UserAgent.create({ dataPath: DATA_PATH });
+    await agent.initialize({ password: 'restore-test' });
+    await agent.start({ password: 'restore-test' });
+
+    const identities = await agent.identity.list();
+    let identity = identities[0];
+    if (!identity) {
+      identity = await agent.identity.create({
+        didMethod : 'jwk',
+        metadata  : { name: 'Restore Test' },
+      });
+    }
+
+    const { web5 } = await Web5.connect({
+      agent,
+      connectedDid : identity.did.uri,
+      sync         : 'off',
+    });
+
+    repoHandle = web5.using(ForgeRepoProtocol);
+    // Skip encryption: true — the test DID (did:jwk Ed25519) lacks X25519.
+    await repoHandle.configure();
+
+    // Create a repo record.
+    const { record } = await repoHandle.records.create('repo', {
+      data : { name: 'restore-test', description: '', defaultBranch: 'main', dwnEndpoints: [] },
+      tags : { name: 'restore-test', visibility: 'public' },
+    });
+    repoContextId = record.contextId!;
+
+    // Set up bare repo with multiple commits.
+    const backend = new GitBackend({ basePath: REPOS_PATH });
+    repoPath = await backend.initRepo('did:dht:restoretest', 'restore-test');
+
+    await exec(`git clone "${repoPath}" "${WORK_PATH}"`);
+    await exec('git config user.email "test@test.com"', { cwd: WORK_PATH });
+    await exec('git config user.name "Test"', { cwd: WORK_PATH });
+    await exec('git checkout -b main', { cwd: WORK_PATH });
+    await exec('echo "line 1" > file.txt', { cwd: WORK_PATH });
+    await exec('git add file.txt', { cwd: WORK_PATH });
+    await exec('git commit -m "first commit"', { cwd: WORK_PATH });
+    await exec('git push -u origin main', { cwd: WORK_PATH });
+
+    // Sync full bundle to DWN.
+    const syncer = createBundleSyncer({
+      repo          : repoHandle as any,
+      repoContextId : repoContextId,
+      visibility    : 'public',
+    });
+    await syncer('did:dht:restoretest', 'restore-test', repoPath);
+
+    // Push a second commit and sync an incremental bundle.
+    await exec('echo "line 2" >> file.txt', { cwd: WORK_PATH });
+    await exec('git add file.txt', { cwd: WORK_PATH });
+    await exec('git commit -m "second commit"', { cwd: WORK_PATH });
+    await exec('git push origin main', { cwd: WORK_PATH });
+
+    await syncer('did:dht:restoretest', 'restore-test', repoPath);
+  }, 30000);
+
+  afterAll(() => {
+    rmSync(DATA_PATH, { recursive: true, force: true });
+    rmSync(REPOS_PATH, { recursive: true, force: true });
+    rmSync(WORK_PATH, { recursive: true, force: true });
+    rmSync(RESTORE_PATH, { recursive: true, force: true });
+  });
+
+  it('should restore a bare repo from DWN bundles', async () => {
+    const restoredRepoPath = `${RESTORE_PATH}/restored.git`;
+
+    const result = await restoreFromBundles({
+      repo     : repoHandle as any,
+      repoPath : restoredRepoPath,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.bundlesApplied).toBeGreaterThanOrEqual(1);
+    expect(result.tipCommit).toMatch(/^[0-9a-f]{40}$/);
+
+    // Verify the restored repo is a valid bare git repo.
+    expect(existsSync(`${restoredRepoPath}/HEAD`)).toBe(true);
+  });
+
+  it('should restore all commits including incrementals', async () => {
+    const restoredRepoPath = `${RESTORE_PATH}/restored-full.git`;
+
+    const result = await restoreFromBundles({
+      repo     : repoHandle as any,
+      repoPath : restoredRepoPath,
+    });
+
+    expect(result.success).toBe(true);
+    // Should have applied full + incremental bundle = 2 bundles.
+    expect(result.bundlesApplied).toBe(2);
+
+    // Verify both commits are present.
+    const { stdout } = await exec('git log --oneline main', { cwd: restoredRepoPath });
+    expect(stdout).toContain('first commit');
+    expect(stdout).toContain('second commit');
+  });
+
+  it('should restore file content matching the original repo', async () => {
+    const restoredRepoPath = `${RESTORE_PATH}/restored-content.git`;
+    const clonePath = `${RESTORE_PATH}/restored-clone`;
+
+    await restoreFromBundles({
+      repo     : repoHandle as any,
+      repoPath : restoredRepoPath,
+    });
+
+    // Clone from the restored bare repo to verify content.
+    // Explicit --branch is needed because restored bare repos may have
+    // HEAD pointing to a non-existent default branch (master vs main).
+    await exec(`git clone --branch main "${restoredRepoPath}" "${clonePath}"`);
+    const { stdout } = await exec('cat file.txt', { cwd: clonePath });
+    expect(stdout.trim()).toBe('line 1\nline 2');
+
+    rmSync(clonePath, { recursive: true, force: true });
+  });
+
+  it('should return failure when no bundles exist', async () => {
+    // Create a fresh Web5 agent with no bundle records.
+    const freshDataPath = `${DATA_PATH}-fresh`;
+    rmSync(freshDataPath, { recursive: true, force: true });
+
+    const freshAgent = await Web5UserAgent.create({ dataPath: freshDataPath });
+    await freshAgent.initialize({ password: 'fresh-test' });
+    await freshAgent.start({ password: 'fresh-test' });
+
+    const identities = await freshAgent.identity.list();
+    let identity = identities[0];
+    if (!identity) {
+      identity = await freshAgent.identity.create({
+        didMethod : 'jwk',
+        metadata  : { name: 'Fresh Test' },
+      });
+    }
+
+    const { web5: freshWeb5 } = await Web5.connect({
+      agent        : freshAgent,
+      connectedDid : identity.did.uri,
+      sync         : 'off',
+    });
+
+    const freshRepo = freshWeb5.using(ForgeRepoProtocol);
+    await freshRepo.configure();
+
+    // Create a repo record (but no bundles).
+    await freshRepo.records.create('repo', {
+      data : { name: 'empty-repo', description: '', defaultBranch: 'main', dwnEndpoints: [] },
+      tags : { name: 'empty-repo', visibility: 'public' },
+    });
+
+    const result = await restoreFromBundles({
+      repo     : freshRepo as any,
+      repoPath : `${RESTORE_PATH}/should-not-exist.git`,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('No full bundle found');
+    expect(existsSync(`${RESTORE_PATH}/should-not-exist.git`)).toBe(false);
+
+    rmSync(freshDataPath, { recursive: true, force: true });
+  });
+
+  it('should restore the tip commit matching the original', async () => {
+    const restoredRepoPath = `${RESTORE_PATH}/restored-tip.git`;
+
+    // Get the original tip commit.
+    const { stdout: originalTip } = await exec('git rev-parse main', { cwd: repoPath });
+
+    const result = await restoreFromBundles({
+      repo     : repoHandle as any,
+      repoPath : restoredRepoPath,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.tipCommit).toBe(originalTip.trim());
+  });
+});

--- a/tests/bundle-sync.spec.ts
+++ b/tests/bundle-sync.spec.ts
@@ -1,0 +1,338 @@
+/**
+ * Tests for git bundle creation and DWN synchronization.
+ *
+ * Tests the `createFullBundle`, `createIncrementalBundle`, and
+ * `createBundleSyncer` functions against real bare git repos and a
+ * live Web5 agent.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+
+import { exec as execCb } from 'node:child_process';
+import { promisify } from 'node:util';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+
+import { DateSort } from '@enbox/dwn-sdk-js';
+import { Web5 } from '@enbox/api';
+import { Web5UserAgent } from '@enbox/agent';
+
+import { ForgeRepoProtocol } from '../src/repo.js';
+import { GitBackend } from '../src/git-server/git-backend.js';
+import { createBundleSyncer, createFullBundle, createIncrementalBundle } from '../src/git-server/bundle-sync.js';
+
+const exec = promisify(execCb);
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DATA_PATH = '__TESTDATA__/bundle-sync-agent';
+const REPOS_PATH = '__TESTDATA__/bundle-sync-repos';
+const WORK_PATH = '__TESTDATA__/bundle-sync-work';
+const TEST_DID = 'did:dht:bundlesynctest';
+const TEST_REPO = 'bundle-test';
+
+// ---------------------------------------------------------------------------
+// createFullBundle / createIncrementalBundle (pure git — no DWN needed)
+// ---------------------------------------------------------------------------
+
+describe('createFullBundle', () => {
+  let backend: GitBackend;
+  let repoPath: string;
+  let firstCommitSha: string;
+
+  beforeAll(async () => {
+    rmSync(REPOS_PATH, { recursive: true, force: true });
+    rmSync(WORK_PATH, { recursive: true, force: true });
+
+    backend = new GitBackend({ basePath: REPOS_PATH });
+    repoPath = await backend.initRepo(TEST_DID, TEST_REPO);
+
+    // Seed the bare repo with a commit via a working clone.
+    await exec(`git clone "${repoPath}" "${WORK_PATH}"`);
+    await exec('git config user.email "test@test.com"', { cwd: WORK_PATH });
+    await exec('git config user.name "Test"', { cwd: WORK_PATH });
+    await exec('git checkout -b main', { cwd: WORK_PATH });
+    await exec('echo "hello" > README.md', { cwd: WORK_PATH });
+    await exec('git add README.md', { cwd: WORK_PATH });
+    await exec('git commit -m "initial commit"', { cwd: WORK_PATH });
+    await exec('git push -u origin main', { cwd: WORK_PATH });
+
+    // Get the commit SHA from the working clone (HEAD resolves correctly here).
+    const { stdout } = await exec('git rev-parse HEAD', { cwd: WORK_PATH });
+    firstCommitSha = stdout.trim();
+  });
+
+  afterAll(() => {
+    rmSync(REPOS_PATH, { recursive: true, force: true });
+    rmSync(WORK_PATH, { recursive: true, force: true });
+  });
+
+  it('should create a valid full bundle with all refs', async () => {
+    const info = await createFullBundle(repoPath);
+
+    expect(info.isFull).toBe(true);
+    expect(info.tipCommit).toBe(firstCommitSha);
+    expect(info.refCount).toBeGreaterThanOrEqual(1);
+    expect(info.size).toBeGreaterThan(0);
+    expect(existsSync(info.path)).toBe(true);
+
+    // Verify the bundle is a valid git bundle.
+    const { stdout } = await exec(`git bundle verify "${info.path}"`);
+    expect(stdout + '').toBeDefined();
+
+    // Clean up the temp file.
+    rmSync(info.path, { force: true });
+  });
+
+  it('should produce a bundle file with application/x-git-bundle header', async () => {
+    const info = await createFullBundle(repoPath);
+
+    // Git bundles start with "# v2 git bundle\n" or "# v3 git bundle\n".
+    const header = readFileSync(info.path, 'utf-8').slice(0, 20);
+    expect(header).toMatch(/^# v[23] git bundle/);
+
+    rmSync(info.path, { force: true });
+  });
+});
+
+describe('createIncrementalBundle', () => {
+  let backend: GitBackend;
+  let repoPath: string;
+  let baseCommit: string;
+
+  beforeAll(async () => {
+    rmSync(REPOS_PATH, { recursive: true, force: true });
+    rmSync(WORK_PATH, { recursive: true, force: true });
+
+    backend = new GitBackend({ basePath: REPOS_PATH });
+    repoPath = await backend.initRepo(TEST_DID, TEST_REPO);
+
+    // Seed with first commit.
+    await exec(`git clone "${repoPath}" "${WORK_PATH}"`);
+    await exec('git config user.email "test@test.com"', { cwd: WORK_PATH });
+    await exec('git config user.name "Test"', { cwd: WORK_PATH });
+    await exec('git checkout -b main', { cwd: WORK_PATH });
+    await exec('echo "v1" > file.txt', { cwd: WORK_PATH });
+    await exec('git add file.txt', { cwd: WORK_PATH });
+    await exec('git commit -m "first"', { cwd: WORK_PATH });
+    await exec('git push -u origin main', { cwd: WORK_PATH });
+
+    const { stdout: sha1 } = await exec('git rev-parse HEAD', { cwd: WORK_PATH });
+    baseCommit = sha1.trim();
+
+    // Push a second commit.
+    await exec('echo "v2" >> file.txt', { cwd: WORK_PATH });
+    await exec('git add file.txt', { cwd: WORK_PATH });
+    await exec('git commit -m "second"', { cwd: WORK_PATH });
+    await exec('git push origin main', { cwd: WORK_PATH });
+  });
+
+  afterAll(() => {
+    rmSync(REPOS_PATH, { recursive: true, force: true });
+    rmSync(WORK_PATH, { recursive: true, force: true });
+  });
+
+  it('should create an incremental bundle since base commit', async () => {
+    const info = await createIncrementalBundle(repoPath, baseCommit);
+
+    expect(info.isFull).toBe(false);
+    expect(info.tipCommit).not.toBe(baseCommit);
+    expect(info.refCount).toBeGreaterThanOrEqual(1);
+    expect(info.size).toBeGreaterThan(0);
+    expect(existsSync(info.path)).toBe(true);
+
+    // The incremental bundle should be smaller than a full bundle.
+    const fullInfo = await createFullBundle(repoPath);
+    // Can't guarantee size relationship for small repos, but both should be valid.
+    expect(fullInfo.size).toBeGreaterThan(0);
+
+    rmSync(info.path, { force: true });
+    rmSync(fullInfo.path, { force: true });
+  });
+
+  it('should produce a bundle with prerequisites', async () => {
+    const info = await createIncrementalBundle(repoPath, baseCommit);
+
+    // Incremental bundles contain prerequisite lines (starting with -)
+    // in their header.
+    const header = readFileSync(info.path, 'utf-8');
+    const lines = header.split('\n');
+    const prereqLines = lines.filter((l) => l.startsWith('-'));
+    expect(prereqLines.length).toBeGreaterThanOrEqual(1);
+
+    rmSync(info.path, { force: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createBundleSyncer — full DWN integration
+// ---------------------------------------------------------------------------
+
+describe('createBundleSyncer (DWN integration)', () => {
+  let repoPath: string;
+  let repoContextId: string;
+  let repoHandle: ReturnType<InstanceType<typeof Web5>['using']>;
+
+  beforeAll(async () => {
+    rmSync(DATA_PATH, { recursive: true, force: true });
+    rmSync(REPOS_PATH, { recursive: true, force: true });
+    rmSync(WORK_PATH, { recursive: true, force: true });
+
+    // Create agent + Web5 instance.
+    const agent = await Web5UserAgent.create({ dataPath: DATA_PATH });
+    await agent.initialize({ password: 'bundle-test' });
+    await agent.start({ password: 'bundle-test' });
+
+    const identities = await agent.identity.list();
+    let identity = identities[0];
+    if (!identity) {
+      identity = await agent.identity.create({
+        didMethod : 'jwk',
+        metadata  : { name: 'Bundle Test' },
+      });
+    }
+
+    const { web5 } = await Web5.connect({
+      agent,
+      connectedDid : identity.did.uri,
+      sync         : 'off',
+    });
+
+    repoHandle = web5.using(ForgeRepoProtocol);
+    // Skip encryption: true — the test DID (did:jwk Ed25519) lacks X25519.
+    // Production uses encryption: true for webhook support; bundle encryption
+    // is tested separately with an appropriate DID.
+    await repoHandle.configure();
+
+    // Create a repo record.
+    const { record } = await repoHandle.records.create('repo', {
+      data : { name: 'bundle-test', description: '', defaultBranch: 'main', dwnEndpoints: [] },
+      tags : { name: 'bundle-test', visibility: 'public' },
+    });
+    repoContextId = record.contextId!;
+
+    // Set up bare repo with commits.
+    const backend = new GitBackend({ basePath: REPOS_PATH });
+    repoPath = await backend.initRepo('did:dht:bundletest', 'bundle-test');
+
+    await exec(`git clone "${repoPath}" "${WORK_PATH}"`);
+    await exec('git config user.email "test@test.com"', { cwd: WORK_PATH });
+    await exec('git config user.name "Test"', { cwd: WORK_PATH });
+    await exec('git checkout -b main', { cwd: WORK_PATH });
+    await exec('echo "hello from bundle test" > README.md', { cwd: WORK_PATH });
+    await exec('git add README.md', { cwd: WORK_PATH });
+    await exec('git commit -m "initial commit"', { cwd: WORK_PATH });
+    await exec('git push -u origin main', { cwd: WORK_PATH });
+  }, 30000);
+
+  afterAll(() => {
+    rmSync(DATA_PATH, { recursive: true, force: true });
+    rmSync(REPOS_PATH, { recursive: true, force: true });
+    rmSync(WORK_PATH, { recursive: true, force: true });
+  });
+
+  it('should create a full bundle record on first sync', async () => {
+    const syncer = createBundleSyncer({
+      repo          : repoHandle as any,
+      repoContextId : repoContextId,
+      visibility    : 'public',
+    });
+
+    await syncer('did:dht:bundletest', 'bundle-test', repoPath);
+
+    // Query bundle records.
+    const { records } = await (repoHandle as any).records.query('repo/bundle', {
+      dateSort: DateSort.CreatedDescending,
+    });
+
+    expect(records.length).toBe(1);
+
+    const record = records[0];
+    expect(record.tags.isFull).toBe(true);
+    expect(record.tags.tipCommit).toMatch(/^[0-9a-f]{40}$/);
+    expect(record.tags.refCount).toBeGreaterThanOrEqual(1);
+    expect(record.tags.size).toBeGreaterThan(0);
+    expect(record.dataFormat).toBe('application/x-git-bundle');
+  });
+
+  it('should create incremental bundles on subsequent syncs', async () => {
+    // Push another commit.
+    await exec('echo "update" >> README.md', { cwd: WORK_PATH });
+    await exec('git add README.md', { cwd: WORK_PATH });
+    await exec('git commit -m "second commit"', { cwd: WORK_PATH });
+    await exec('git push origin main', { cwd: WORK_PATH });
+
+    const syncer = createBundleSyncer({
+      repo          : repoHandle as any,
+      repoContextId : repoContextId,
+      visibility    : 'public',
+    });
+
+    await syncer('did:dht:bundletest', 'bundle-test', repoPath);
+
+    // Should now have 2 bundle records: 1 full + 1 incremental.
+    const { records: fullRecords } = await (repoHandle as any).records.query('repo/bundle', {
+      filter   : { tags: { isFull: true } },
+      dateSort : DateSort.CreatedDescending,
+    });
+    const { records: incRecords } = await (repoHandle as any).records.query('repo/bundle', {
+      filter   : { tags: { isFull: false } },
+      dateSort : DateSort.CreatedDescending,
+    });
+
+    expect(fullRecords.length).toBe(1);
+    expect(incRecords.length).toBe(1);
+    expect(incRecords[0].tags.isFull).toBe(false);
+  });
+
+  it('should squash when threshold is reached', async () => {
+    // Use a low threshold so we trigger squash quickly.
+    const syncer = createBundleSyncer({
+      repo            : repoHandle as any,
+      repoContextId   : repoContextId,
+      visibility      : 'public',
+      squashThreshold : 2,
+    });
+
+    // Push another commit to trigger squash (already have 2 bundles).
+    await exec('echo "squash trigger" >> README.md', { cwd: WORK_PATH });
+    await exec('git add README.md', { cwd: WORK_PATH });
+    await exec('git commit -m "third commit (squash)"', { cwd: WORK_PATH });
+    await exec('git push origin main', { cwd: WORK_PATH });
+
+    await syncer('did:dht:bundletest', 'bundle-test', repoPath);
+
+    // After squash, the DWN should process the squash resumable task.
+    // Give it a moment for the resumable task to complete.
+    await new Promise((r) => setTimeout(r, 500));
+
+    // Query all bundles — squash should have purged older ones.
+    const { records } = await (repoHandle as any).records.query('repo/bundle', {
+      dateSort: DateSort.CreatedDescending,
+    });
+
+    // After squash, only the squash bundle (full) should remain.
+    // Older records are purged asynchronously by the DWN resumable task.
+    expect(records.length).toBeGreaterThanOrEqual(1);
+
+    // The most recent bundle should be a full bundle.
+    expect(records[0].tags.isFull).toBe(true);
+    expect(records[0].tags.tipCommit).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it('should store retrievable bundle data', async () => {
+    const { records } = await (repoHandle as any).records.query('repo/bundle', {
+      filter   : { tags: { isFull: true } },
+      dateSort : DateSort.CreatedDescending,
+    });
+
+    expect(records.length).toBeGreaterThanOrEqual(1);
+
+    const blob = await records[0].data.blob();
+    const bytes = new Uint8Array(await blob.arrayBuffer());
+
+    // Git bundle header: "# v2 git bundle\n" or "# v3 git bundle\n".
+    const header = new TextDecoder().decode(bytes.slice(0, 20));
+    expect(header).toMatch(/^# v[23] git bundle/);
+  });
+});

--- a/tests/protocols.spec.ts
+++ b/tests/protocols.spec.ts
@@ -42,6 +42,7 @@ describe('@enbox/dwn-git', () => {
 
     it('should define all expected types', () => {
       expect(ForgeRepoDefinition.types.repo).toBeDefined();
+      expect(ForgeRepoDefinition.types.bundle).toBeDefined();
       expect(ForgeRepoDefinition.types.settings).toBeDefined();
       expect(ForgeRepoDefinition.types.readme).toBeDefined();
       expect(ForgeRepoDefinition.types.license).toBeDefined();
@@ -95,12 +96,39 @@ describe('@enbox/dwn-git', () => {
       expect(anyoneAction!.can).toContain('read');
     });
 
-    it('should nest settings, readme, license, topic, webhook under repo', () => {
+    it('should nest settings, readme, license, topic, webhook, bundle under repo', () => {
       expect(ForgeRepoDefinition.structure.repo.settings).toBeDefined();
       expect(ForgeRepoDefinition.structure.repo.readme).toBeDefined();
       expect(ForgeRepoDefinition.structure.repo.license).toBeDefined();
       expect(ForgeRepoDefinition.structure.repo.topic).toBeDefined();
       expect(ForgeRepoDefinition.structure.repo.webhook).toBeDefined();
+      expect(ForgeRepoDefinition.structure.repo.bundle).toBeDefined();
+    });
+
+    it('should enable $squash on bundle records', () => {
+      expect(ForgeRepoDefinition.structure.repo.bundle.$squash).toBe(true);
+    });
+
+    it('should accept application/x-git-bundle data format for bundles', () => {
+      expect(ForgeRepoDefinition.types.bundle.dataFormats).toEqual(['application/x-git-bundle']);
+    });
+
+    it('should require tipCommit and isFull tags on bundle records', () => {
+      expect(ForgeRepoDefinition.structure.repo.bundle.$tags?.$requiredTags).toContain('tipCommit');
+      expect(ForgeRepoDefinition.structure.repo.bundle.$tags?.$requiredTags).toContain('isFull');
+      expect(ForgeRepoDefinition.structure.repo.bundle.$tags?.$allowUndefinedTags).toBe(false);
+    });
+
+    it('should allow anyone to read and maintainers to create/squash bundles', () => {
+      const actions = ForgeRepoDefinition.structure.repo.bundle.$actions;
+      const anyoneAction = actions!.find((a) => 'who' in a && a.who === 'anyone');
+      expect(anyoneAction).toBeDefined();
+      expect(anyoneAction!.can).toContain('read');
+
+      const maintainerAction = actions!.find((a) => 'role' in a && a.role === 'repo/maintainer');
+      expect(maintainerAction).toBeDefined();
+      expect(maintainerAction!.can).toContain('create');
+      expect(maintainerAction!.can).toContain('squash');
     });
 
     it('should wrap definition via defineProtocol()', () => {


### PR DESCRIPTION
## Summary

- **Bundle storage in DWN**: Git bundles (`application/x-git-bundle`) are stored as DWN records with `$squash` compaction. This enables full repository decentralization — code itself lives in DWN, not just the social layer.
- **Auto-restore on cold start**: When a clone/fetch hits a repo not on disk, the server auto-restores from DWN bundle records (full + incrementals). Enables commodity git hosts to serve repos they've never seen before.
- **Per-write encryption**: Public repos → plaintext bundles (IPFS-friendly), private repos → JWE-encrypted bundles. Controlled by repo visibility tag, not protocol-level `encryptionRequired`.

## Changes

### Protocol (`src/repo.ts`)
- `bundle` type: `$squash: true`, `application/x-git-bundle`, tags (`tipCommit`, `isFull`, `refCount`, `size`)
- Auth: anyone can read, `repo/maintainer` can create + squash
- `BundleData = Uint8Array` in SchemaMap

### Bundle sync (`src/git-server/bundle-sync.ts`) — NEW
- `createBundleSyncer(options)` → `onPushComplete` callback
- Full bundle: `git bundle create --all`
- Incremental bundle: `git bundle create --all ^<base>`
- Squash: every N pushes (default 5), full bundle with `squash: true` purges older records
- `visibility` option controls `encryption` flag on writes

### Bundle restore (`src/git-server/bundle-restore.ts`) — NEW
- `restoreFromBundles(options)` → queries full + incremental bundles, reconstructs bare repo
- Applies incrementals chronologically after cloning from full bundle
- Agent layer auto-decrypts encrypted bundles for authorized readers

### Auto-restore wiring
- `onRepoNotFound` callback added to `GitHttpHandlerOptions` / `GitServerOptions`
- All three repo-exists checks (`info/refs`, `upload-pack`, `receive-pack`) try auto-restore before 404
- `serve.ts` wires `restoreFromBundles` as the `onRepoNotFound` handler

### Supporting changes
- `getRepoContextId()` → `getRepoContext()` (also returns `visibility` tag)
- `agent.ts`: `repo.configure({ encryption: true })` for webhook + bundle encryption support
- Fix `getTipCommit()` in bare repos where HEAD is a dangling symbolic ref
- Fix `git fetch` from bundles: explicit `refs/*:refs/*` refspec (bundles lack HEAD)

## Tests

- **8 bundle-sync tests**: full bundle creation, incremental bundles, bundle header/prerequisites validation, DWN integration (first sync, incremental sync, squash, data retrieval)
- **5 bundle-restore tests**: restore from bundles, incremental application, content verification, failure on empty DWN, tip commit match
- **435 total pass**, 0 fail, lint clean, build clean

## Builds on

This PR includes the changes from `feat/mvp-polish` (PR #7) plus the new bundle storage work.