### PR TITLE
feat: MVP hardening — patch comment/reopen, sub-path exports, bundle E2E, dedup flagValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,65 @@ GitHub centralizes the social layer around git: identity, access control, issue 
 - **Identity is self-sovereign** — DIDs replace GitHub usernames. Portable across providers.
 - **Every user owns their namespace** — your issues, stars, and contributions live on your DWN, not a central server.
 - **Access control is protocol-level** — roles (maintainer, triager, contributor) are DWN records with cryptographic authorization.
-- **Git transport is DID-addressed** — `git remote add origin did:dht:abc123` resolves via the DID document.
+- **Git transport is DID-addressed** — `git clone did::did:dht:abc123/my-repo` resolves via the DID document.
 - **Packages are DID-scoped** — no global namespace squatting, cryptographic provenance by default.
+- **Repos are self-healing** — git bundles stored as DWN records enable any host to restore a repo on demand.
+
+## What Works Today
+
+`dwn-git` has a working MVP covering the full lifecycle:
+
+### CLI (`dwn-git`)
+
+```bash
+dwn-git init my-repo              # Create a repo record + bare git repo
+dwn-git serve                     # Start git transport server with ref sync + bundle sync
+
+dwn-git issue create "Bug report" # Create issue #1 with sequential numbering
+dwn-git issue show 1              # Show issue details + comments
+dwn-git issue comment 1 "On it"  # Add a comment
+dwn-git issue close 1             # Close an issue
+dwn-git issue reopen 1            # Reopen a closed issue
+dwn-git issue list                # List all issues
+
+dwn-git patch create "Add X"     # Create a patch (pull request) with sequential numbering
+dwn-git patch show 1              # Show patch details + reviews
+dwn-git patch comment 1 "LGTM"  # Add a review comment
+dwn-git patch merge 1             # Merge a patch
+dwn-git patch close 2             # Close without merging
+dwn-git patch reopen 2            # Reopen a closed patch
+dwn-git patch list                # List all patches
+
+dwn-git repo info                 # Show repo metadata + collaborators
+dwn-git repo add-collaborator <did> maintainer
+dwn-git repo remove-collaborator <did>
+
+dwn-git log                       # Activity feed (recent issues + patches)
+dwn-git setup                     # Configure git for DID-based remotes
+dwn-git clone did:dht:abc/repo   # Clone via DID resolution
+```
+
+### Git Transport
+
+- **Smart HTTP server** — serves `git clone`, `git push` via native git protocol
+- **DID-signed push auth** — pushers prove DID ownership, server checks DWN role records
+- **Ref mirroring** — branch/tag refs sync to DWN records after each push (enables subscriptions)
+- **Bundle sync** — git bundles sync to DWN records after each push (full + incremental + squash)
+- **Cold-start restore** — repos auto-restore from DWN bundles when a host has no local copy
+
+### Git Remote Helper
+
+- `git-remote-did` — resolves `did::` URLs to git endpoints via DID document service discovery
+- `git-remote-did-credential` — generates DID-signed push tokens for authentication
 
 ## Architecture
 
 See [PLAN.md](./PLAN.md) for the full architecture document covering:
 
 - Prior art analysis (Radicle, ForgeFed, git-bug)
-- 10 composable DWN protocol definitions (repo, issues, patches, CI, releases, registry, social, notifications, wiki, org)
+- 11 composable DWN protocol definitions (repo, refs, issues, patches, CI, releases, registry, social, notifications, wiki, org)
 - DID-addressed git remotes and transport
+- Decentralized bundle storage (`$squash`, encryption model, cold-start restore)
 - DID-scoped package registry
 - Namespace-based contribution model (no spam by design)
 - Indexer integration patterns
@@ -26,9 +75,54 @@ See [PLAN.md](./PLAN.md) for the full architecture document covering:
 - Technical challenges and mitigations
 - Implementation roadmap with phased milestones
 
+## Protocols
+
+| Protocol | URI | Purpose |
+|---|---|---|
+| `forge-repo` | `forge/repo` | Repository metadata, collaborator roles, bundles, settings |
+| `forge-refs` | `forge/refs` | Git ref records (branches, tags) for DWN subscriptions |
+| `forge-issues` | `forge/issues` | Issues, comments, labels, status changes, assignments |
+| `forge-patches` | `forge/patches` | Pull requests, revisions, reviews, merge results |
+| `forge-ci` | `forge/ci` | Check suites, check runs, artifacts |
+| `forge-releases` | `forge/releases` | Release management, immutable assets, signatures |
+| `forge-registry` | `forge/registry` | Package publishing, versions, tarballs, attestations |
+| `forge-social` | `forge/social` | Stars, follows, activity feeds |
+| `forge-notifications` | `forge/notifications` | Personal notification inbox |
+| `forge-wiki` | `forge/wiki` | Collaborative documentation pages |
+| `forge-org` | `forge/org` | Organizations, teams, team membership |
+
+## Installation
+
+```bash
+bun install @enbox/dwn-git
+```
+
+### Sub-path Exports
+
+```typescript
+// Protocol definitions and types
+import { ForgeRepoProtocol, ForgeIssuesProtocol } from '@enbox/dwn-git';
+
+// Git transport server
+import { createGitServer, createBundleSyncer, restoreFromBundles } from '@enbox/dwn-git/git-server';
+
+// Git remote helper utilities
+import { parseDidUrl, resolveGitEndpoint } from '@enbox/dwn-git/git-remote';
+```
+
+## Development
+
+```bash
+bun install            # Install dependencies
+bun run build          # Build (clean + tsc)
+bun run lint           # Lint (ESLint, zero warnings)
+bun run lint:fix       # Auto-fix lint issues
+bun test               # Run all tests (453 tests)
+```
+
 ## Status
 
-**Phase: Design** — protocol definitions and architecture are being refined. No implementation yet.
+**Phase 2 complete** — working MVP with CLI, git transport, DID-signed push auth, ref mirroring, bundle storage, and 453 tests (1147 assertions). See PLAN.md Section 12 for the full roadmap.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,14 @@
     ".": {
       "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.js"
+    },
+    "./git-server": {
+      "types": "./dist/types/git-server/index.d.ts",
+      "import": "./dist/esm/git-server/index.js"
+    },
+    "./git-remote": {
+      "types": "./dist/types/git-remote/index.d.ts",
+      "import": "./dist/esm/git-remote/index.js"
     }
   },
   "keywords": [

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -9,6 +9,7 @@
 
 import type { AgentContext } from '../agent.js';
 
+import { flagValue } from '../flags.js';
 import { GitBackend } from '../../git-server/git-backend.js';
 
 // ---------------------------------------------------------------------------
@@ -65,13 +66,4 @@ export async function initCommand(ctx: AgentContext, args: string[]): Promise<vo
   console.log(`  Git path:  ${gitPath}`);
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
-/** Extract the value following a flag in argv. */
-function flagValue(args: string[], flag: string): string | undefined {
-  const idx = args.indexOf(flag);
-  if (idx === -1 || idx + 1 >= args.length) { return undefined; }
-  return args[idx + 1];
-}

--- a/src/cli/commands/issue.ts
+++ b/src/cli/commands/issue.ts
@@ -14,6 +14,7 @@
 
 import type { AgentContext } from '../agent.js';
 
+import { flagValue } from '../flags.js';
 import { getRepoContextId } from '../repo-context.js';
 
 // ---------------------------------------------------------------------------
@@ -281,12 +282,6 @@ async function issueList(ctx: AgentContext, args: string[]): Promise<void> {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function flagValue(args: string[], flag: string): string | undefined {
-  const idx = args.indexOf(flag);
-  if (idx === -1 || idx + 1 >= args.length) { return undefined; }
-  return args[idx + 1];
-}
 
 /**
  * Get the next sequential issue number by querying existing issues.

--- a/src/cli/commands/log.ts
+++ b/src/cli/commands/log.ts
@@ -11,6 +11,7 @@
 
 import type { AgentContext } from '../agent.js';
 
+import { flagValue } from '../flags.js';
 import { getRepoContextId } from '../repo-context.js';
 
 // ---------------------------------------------------------------------------
@@ -102,12 +103,4 @@ export async function logCommand(ctx: AgentContext, args: string[]): Promise<voi
   }
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
-function flagValue(args: string[], flag: string): string | undefined {
-  const idx = args.indexOf(flag);
-  if (idx === -1 || idx + 1 >= args.length) { return undefined; }
-  return args[idx + 1];
-}

--- a/src/cli/commands/repo.ts
+++ b/src/cli/commands/repo.ts
@@ -13,6 +13,7 @@
 
 import type { AgentContext } from '../agent.js';
 
+import { flagValue } from '../flags.js';
 import { getRepoContextId } from '../repo-context.js';
 
 // ---------------------------------------------------------------------------
@@ -156,13 +157,4 @@ async function removeCollaborator(ctx: AgentContext, args: string[]): Promise<vo
   }
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
-/** Extract the value following a flag in argv. */
-function flagValue(args: string[], flag: string): string | undefined {
-  const idx = args.indexOf(flag);
-  if (idx === -1 || idx + 1 >= args.length) { return undefined; }
-  return args[idx + 1];
-}

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -26,6 +26,7 @@ import { createDwnPushAuthorizer } from '../../git-server/push-authorizer.js';
 import { createGitServer } from '../../git-server/server.js';
 import { createPushAuthenticator } from '../../git-server/auth.js';
 import { createRefSyncer } from '../../git-server/ref-sync.js';
+import { flagValue } from '../flags.js';
 import { getRepoContext } from '../repo-context.js';
 import { registerGitService } from '../../git-server/did-service.js';
 import { restoreFromBundles } from '../../git-server/bundle-restore.js';
@@ -149,13 +150,4 @@ export async function serveCommand(ctx: AgentContext, args: string[]): Promise<v
   });
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
-/** Extract the value following a flag in argv. */
-function flagValue(args: string[], flag: string): string | undefined {
-  const idx = args.indexOf(flag);
-  if (idx === -1 || idx + 1 >= args.length) { return undefined; }
-  return args[idx + 1];
-}

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -13,11 +13,11 @@
  * @module
  */
 
-import { existsSync, mkdirSync, symlinkSync, unlinkSync } from 'node:fs';
-
 import { homedir } from 'node:os';
-
+import { existsSync, mkdirSync, symlinkSync, unlinkSync } from 'node:fs';
 import { join, resolve } from 'node:path';
+
+import { flagValue } from '../flags.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -94,12 +94,4 @@ export async function setupCommand(args: string[]): Promise<void> {
   console.log('  dwn-git clone <did>/<repo>');
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
-function flagValue(args: string[], flag: string): string | undefined {
-  const idx = args.indexOf(flag);
-  if (idx === -1 || idx + 1 >= args.length) { return undefined; }
-  return args[idx + 1];
-}

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared CLI argument helpers.
+ *
+ * @module
+ */
+
+/** Extract the value following a flag in argv (e.g. `--port 8080`). */
+export function flagValue(args: string[], flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  if (idx === -1 || idx + 1 >= args.length) { return undefined; }
+  return args[idx + 1];
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -74,7 +74,10 @@ function printUsage(): void {
   console.log('');
   console.log('  patch create <title> [--base ...] [--head ...]  Open a patch (PR)');
   console.log('  patch show <number>                         Show patch details and reviews');
+  console.log('  patch comment <number> <body>               Add a comment/review');
   console.log('  patch merge <number>                        Merge a patch');
+  console.log('  patch close <number>                        Close a patch');
+  console.log('  patch reopen <number>                       Reopen a closed patch');
   console.log('  patch list [--status <status>]              List patches');
   console.log('');
   console.log('  log                                         Show recent activity');

--- a/src/git-remote/index.ts
+++ b/src/git-remote/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Git remote helper — DID-based remote transport for git.
+ *
+ * @module git-remote
+ */
+
+export * from './credential-helper.js';
+export * from './parse-url.js';
+export * from './resolve.js';
+export * from './service.js';

--- a/src/git-server/index.ts
+++ b/src/git-server/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Git transport server — smart HTTP git backend with DID-based push auth.
+ *
+ * @module git-server
+ */
+
+export * from './auth.js';
+export * from './bundle-restore.js';
+export * from './bundle-sync.js';
+export * from './did-service.js';
+export * from './git-backend.js';
+export * from './http-handler.js';
+export * from './push-authorizer.js';
+export * from './ref-sync.js';
+export * from './server.js';
+export * from './verify.js';

--- a/src/git-server/server.ts
+++ b/src/git-server/server.ts
@@ -149,7 +149,8 @@ export async function createGitServer(options: GitServerOptions): Promise<GitSer
         }
       }
       res.end();
-    } catch {
+    } catch (err) {
+      console.error(`Git HTTP handler error: ${(err as Error).message}`);
       res.writeHead(500);
       res.end('Internal Server Error');
     }

--- a/tests/cli.spec.ts
+++ b/tests/cli.spec.ts
@@ -408,10 +408,63 @@ describe('dwn-git CLI commands', () => {
       expect(logs.some((l) => l.includes('already merged'))).toBe(true);
     });
 
+    it('should add a comment to a patch', async () => {
+      const { patchCommand } = await import('../src/cli/commands/patch.js');
+      const logs = await captureLog(() => patchCommand(ctx, ['comment', '2', 'Looks good to me']));
+      expect(logs.some((l) => l.includes('Added comment to patch #2'))).toBe(true);
+    });
+
+    it('should show review comments in patch detail', async () => {
+      const { patchCommand } = await import('../src/cli/commands/patch.js');
+      const logs = await captureLog(() => patchCommand(ctx, ['show', '2']));
+      expect(logs.some((l) => l.includes('Reviews (1)'))).toBe(true);
+      expect(logs.some((l) => l.includes('COMMENTED'))).toBe(true);
+      expect(logs.some((l) => l.includes('Looks good to me'))).toBe(true);
+    });
+
+    it('should fail comment without body', async () => {
+      const { patchCommand } = await import('../src/cli/commands/patch.js');
+      const { errors, exitCode } = await captureError(() => patchCommand(ctx, ['comment', '2']));
+      expect(exitCode).toBe(1);
+      expect(errors[0]).toContain('Usage');
+    });
+
+    it('should fail comment for non-existent patch', async () => {
+      const { patchCommand } = await import('../src/cli/commands/patch.js');
+      const { errors, exitCode } = await captureError(() => patchCommand(ctx, ['comment', '99', 'hello']));
+      expect(exitCode).toBe(1);
+      expect(errors[0]).toContain('not found');
+    });
+
     it('should close a patch', async () => {
       const { patchCommand } = await import('../src/cli/commands/patch.js');
       const logs = await captureLog(() => patchCommand(ctx, ['close', '2']));
       expect(logs.some((l) => l.includes('Closed patch #2'))).toBe(true);
+    });
+
+    it('should reopen a closed patch', async () => {
+      const { patchCommand } = await import('../src/cli/commands/patch.js');
+      const logs = await captureLog(() => patchCommand(ctx, ['reopen', '2']));
+      expect(logs.some((l) => l.includes('Reopened patch #2'))).toBe(true);
+    });
+
+    it('should not reopen an already open patch', async () => {
+      const { patchCommand } = await import('../src/cli/commands/patch.js');
+      const logs = await captureLog(() => patchCommand(ctx, ['reopen', '2']));
+      expect(logs.some((l) => l.includes('already open'))).toBe(true);
+    });
+
+    it('should not reopen a merged patch', async () => {
+      const { patchCommand } = await import('../src/cli/commands/patch.js');
+      const logs = await captureLog(() => patchCommand(ctx, ['reopen', '1']));
+      expect(logs.some((l) => l.includes('cannot be reopened'))).toBe(true);
+    });
+
+    it('should fail reopen for non-existent patch', async () => {
+      const { patchCommand } = await import('../src/cli/commands/patch.js');
+      const { errors, exitCode } = await captureError(() => patchCommand(ctx, ['reopen', '99']));
+      expect(exitCode).toBe(1);
+      expect(errors[0]).toContain('not found');
     });
 
     it('should list all patches with numbers', async () => {

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -21,12 +21,14 @@ import { Web5UserAgent } from '@enbox/agent';
 import type { AgentContext } from '../src/cli/agent.js';
 import type { GitServer } from '../src/git-server/server.js';
 
+import { createBundleSyncer } from '../src/git-server/bundle-sync.js';
 import { createGitServer } from '../src/git-server/server.js';
 import { createRefSyncer } from '../src/git-server/ref-sync.js';
 import { ForgeRefsProtocol } from '../src/refs.js';
 import { ForgeRepoProtocol } from '../src/repo.js';
 import { GitBackend } from '../src/git-server/git-backend.js';
 import { readGitRefs } from '../src/git-server/ref-sync.js';
+import { restoreFromBundles } from '../src/git-server/bundle-restore.js';
 
 const exec = promisify(execCb);
 
@@ -201,4 +203,165 @@ describe('E2E: init → serve → clone → push → verify', () => {
 
     rmSync(secondClone, { recursive: true, force: true });
   });
+});
+
+// ===========================================================================
+// E2E: Bundle round-trip — push → bundle sync → cold start → clone
+// ===========================================================================
+
+describe('E2E: push → bundle sync → cold start → clone via restore', () => {
+  let did: string;
+  let repoContextId: string;
+  let repoHandle: ReturnType<typeof Web5.prototype.using<typeof ForgeRepoProtocol>>;
+  let refsHandle: ReturnType<typeof Web5.prototype.using<typeof ForgeRefsProtocol>>;
+  let server: GitServer;
+  let cloneUrl: string;
+
+  const BUNDLE_DATA_PATH = '__TESTDATA__/bundle-e2e-agent';
+  const BUNDLE_REPOS_PATH = '__TESTDATA__/bundle-e2e-repos';
+  const BUNDLE_CLONE_PATH = '__TESTDATA__/bundle-e2e-clone';
+  const BUNDLE_RESTORE_REPOS = '__TESTDATA__/bundle-e2e-restore-repos';
+  const BUNDLE_RESTORE_CLONE = '__TESTDATA__/bundle-e2e-restore-clone';
+
+  beforeAll(async () => {
+    rmSync(BUNDLE_DATA_PATH, { recursive: true, force: true });
+    rmSync(BUNDLE_REPOS_PATH, { recursive: true, force: true });
+    rmSync(BUNDLE_CLONE_PATH, { recursive: true, force: true });
+    rmSync(BUNDLE_RESTORE_REPOS, { recursive: true, force: true });
+    rmSync(BUNDLE_RESTORE_CLONE, { recursive: true, force: true });
+
+    // --- Step 1: Create Web5 agent ---
+    const agent = await Web5UserAgent.create({ dataPath: BUNDLE_DATA_PATH });
+    await agent.initialize({ password: 'bundle-e2e' });
+    await agent.start({ password: 'bundle-e2e' });
+
+    const identities = await agent.identity.list();
+    let identity = identities[0];
+    if (!identity) {
+      identity = await agent.identity.create({
+        didMethod : 'jwk',
+        metadata  : { name: 'Bundle E2E Test' },
+      });
+    }
+
+    const { web5, did: agentDid } = await Web5.connect({
+      agent,
+      connectedDid : identity.did.uri,
+      sync         : 'off',
+    });
+    did = agentDid;
+
+    repoHandle = web5.using(ForgeRepoProtocol);
+    refsHandle = web5.using(ForgeRefsProtocol);
+    await repoHandle.configure();
+    await refsHandle.configure();
+
+    // --- Step 2: Create repo record ---
+    const { record } = await repoHandle.records.create('repo', {
+      data : { name: 'bundle-test-repo', description: '', defaultBranch: 'main', dwnEndpoints: [] },
+      tags : { name: 'bundle-test-repo', visibility: 'public' },
+    });
+    repoContextId = record.contextId!;
+
+    // --- Step 3: Init bare git repo ---
+    const backend = new GitBackend({ basePath: BUNDLE_REPOS_PATH });
+    await backend.initRepo(did, 'bundle-test-repo');
+
+    // --- Step 4: Start git server with both ref sync AND bundle sync ---
+    const refSyncer = createRefSyncer({
+      refs          : refsHandle,
+      repoContextId : repoContextId,
+    });
+
+    const bundleSyncer = createBundleSyncer({
+      repo          : repoHandle,
+      repoContextId : repoContextId,
+      visibility    : 'public',
+    });
+
+    // Chain both syncers as onPushComplete.
+    const onPushComplete = async (pushDid: string, repoName: string, repoPath: string): Promise<void> => {
+      await refSyncer(pushDid, repoName, repoPath);
+      await bundleSyncer(pushDid, repoName, repoPath);
+    };
+
+    server = await createGitServer({
+      basePath       : BUNDLE_REPOS_PATH,
+      port           : 0,
+      onPushComplete : onPushComplete,
+    });
+
+    cloneUrl = `http://localhost:${server.port}/${did}/bundle-test-repo`;
+  }, 30000);
+
+  afterAll(async () => {
+    try { if (server) { await server.stop(); } } catch { /* may already be stopped */ }
+    rmSync(BUNDLE_DATA_PATH, { recursive: true, force: true });
+    rmSync(BUNDLE_REPOS_PATH, { recursive: true, force: true });
+    rmSync(BUNDLE_CLONE_PATH, { recursive: true, force: true });
+    rmSync(BUNDLE_RESTORE_REPOS, { recursive: true, force: true });
+    rmSync(BUNDLE_RESTORE_CLONE, { recursive: true, force: true });
+  });
+
+  it('should push a commit and trigger bundle sync to DWN', async () => {
+    // Clone the empty repo, commit, and push.
+    rmSync(BUNDLE_CLONE_PATH, { recursive: true, force: true });
+    await exec(`git clone "${cloneUrl}" "${BUNDLE_CLONE_PATH}"`);
+    await exec('git config user.email "bundle@test.com"', { cwd: BUNDLE_CLONE_PATH });
+    await exec('git config user.name "Bundle Test"', { cwd: BUNDLE_CLONE_PATH });
+    await exec('git checkout -b main', { cwd: BUNDLE_CLONE_PATH });
+    await exec('echo "bundle round-trip content" > README.md', { cwd: BUNDLE_CLONE_PATH });
+    await exec('git add README.md', { cwd: BUNDLE_CLONE_PATH });
+    await exec('git commit -m "bundle test commit"', { cwd: BUNDLE_CLONE_PATH });
+    await exec('git push -u origin main', { cwd: BUNDLE_CLONE_PATH });
+
+    // Wait for the async onPushComplete to finish.
+    await new Promise((r) => setTimeout(r, 1000));
+  });
+
+  it('should have a bundle record in the DWN', async () => {
+    const { records } = await repoHandle.records.query('repo/bundle', {});
+    expect(records.length).toBeGreaterThanOrEqual(1);
+
+    // Verify the bundle metadata.
+    const bundle = records[0];
+    const tags = bundle.tags as Record<string, unknown>;
+    expect(tags.isFull).toBe(true);
+    expect(tags.tipCommit).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it('should restore the repo from bundles on cold start and serve a clone', async () => {
+    // Stop the original server.
+    await server.stop();
+
+    // Start a new server with a CLEAN repos directory (simulates cold start).
+    // Wire onRepoNotFound to restoreFromBundles.
+    const restoreServer = await createGitServer({
+      basePath       : BUNDLE_RESTORE_REPOS,
+      port           : 0,
+      onRepoNotFound : async (_repoDid: string, _repoName: string, repoPath: string): Promise<boolean> => {
+        const result = await restoreFromBundles({ repo: repoHandle, repoPath });
+        return result.success;
+      },
+    });
+
+    try {
+      const restoreCloneUrl = `http://localhost:${restoreServer.port}/${did}/bundle-test-repo`;
+
+      // Clone from the restore server — triggers onRepoNotFound → restoreFromBundles.
+      rmSync(BUNDLE_RESTORE_CLONE, { recursive: true, force: true });
+      await exec(`git clone --branch main "${restoreCloneUrl}" "${BUNDLE_RESTORE_CLONE}"`);
+
+      // Verify the clone has the content.
+      expect(existsSync(`${BUNDLE_RESTORE_CLONE}/.git`)).toBe(true);
+      const { stdout } = await exec('cat README.md', { cwd: BUNDLE_RESTORE_CLONE });
+      expect(stdout).toContain('bundle round-trip content');
+
+      // Verify the git log has the commit.
+      const { stdout: logOutput } = await exec('git log --oneline', { cwd: BUNDLE_RESTORE_CLONE });
+      expect(logOutput).toContain('bundle test commit');
+    } finally {
+      await restoreServer.stop();
+    }
+  }, 30000);
 });


### PR DESCRIPTION
## Summary

MVP hardening pass addressing gaps identified in the comprehensive audit. Completes all pre-Phase 3 cleanup items.

### Changes

- **`patch comment` and `patch reopen` CLI subcommands** — creates reviews with `verdict: 'comment'` and reopens closed patches (cannot reopen merged). 8 new CLI tests.
- **Shared `flagValue()` utility** — extracted duplicated flag parsing from 7 command files into `src/cli/flags.ts`
- **Sub-path exports** — `@enbox/dwn-git/git-server` and `@enbox/dwn-git/git-remote` barrel re-exports with proper `exports` map in package.json
- **Server error logging** — `server.ts` catch block now logs errors before returning 500
- **E2E bundle round-trip test** — push → bundle sync to DWN → delete bare repo → restore from bundles → clone and verify content
- **PLAN.md updated** — new Section 6 (Decentralized Bundle Storage), updated directory structure, protocol/test counts
- **README.md rewritten** — reflects working MVP with CLI usage, transport features, protocol table, installation instructions

### Test results

453 tests, 1147 assertions, 0 failures across 14 test files. Lint and build pass clean.