### PR TITLE
feat: Phase 5 — indexer service for repo discovery and aggregation

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1318,7 +1318,7 @@ Registry CLI with 5 subcommands and 20 CLI tests — 525 total tests, 1282 asser
 
 ### Phase 5: Ecosystem
 
-- [ ] **Indexer service**: repo discovery, star aggregation, external contribution surfacing
+- [x] **Indexer service**: repo discovery, star aggregation, external contribution surfacing
 - [x] **Web UI**: read-only repo/issue/PR viewer
 - [ ] **VS Code extension**: native IDE integration
 - [x] **GitHub migration tool**: import repos, issues, PRs from GitHub

--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ dwn-git migrate releases owner/repo
 dwn-git web                       # Start read-only web UI on port 8080
 dwn-git web --port 3000           # Custom port
 
+# Indexer (repo discovery + aggregation)
+dwn-git indexer                   # Start indexer on port 8090
+dwn-git indexer --seed <did>      # Discover DIDs from a seed user
+dwn-git indexer --interval 30     # Crawl every 30 seconds
+
 # Activity & identity
 dwn-git log                       # Activity feed (recent issues + patches)
 dwn-git whoami                    # Show connected DID
@@ -135,6 +140,17 @@ dwn-git whoami                    # Show connected DID
 - `dwn-git migrate all owner/repo` — import repo metadata, issues, pull requests, and releases
 - Supports pagination, error handling, and author attribution
 - GitHub author info embedded in body as `[migrated from GitHub — @username]` prefix
+
+### Indexer Service
+
+- Crawls distributed DWN records and builds materialized views for discovery and aggregation
+- **DID discovery** — follows the social graph (stars + follows) to find new users and repos
+- **Repo search** — full-text search by name, description, topic, or language
+- **Star aggregation** — counts stars across DWNs (stars live on each starrer's DWN)
+- **Trending repos** — ranked by recent star activity within a time window
+- **User profiles** — repo count, total stars received, follower/following counts
+- **REST API** — `/api/repos`, `/api/repos/search?q=`, `/api/repos/trending`, `/api/users/:did`, `/api/stats`
+- Start with `dwn-git indexer [--port <port>] [--interval <sec>] [--seed <did>]`
 
 ## Architecture
 
@@ -198,7 +214,7 @@ bun test               # Run all tests
 
 ## Status
 
-**Phase 5 in progress** — working MVP with CLI commands for all 11 protocols, git transport, DID-signed push auth, ref mirroring, bundle storage, package registry, GitHub migration tool, and read-only web UI. 570+ tests across 15 test files. See PLAN.md Section 12 for the full roadmap.
+**Phase 5 in progress** — working MVP with CLI commands for all 11 protocols, git transport, DID-signed push auth, ref mirroring, bundle storage, package registry, GitHub migration tool, read-only web UI, and indexer service. 610+ tests across 16 test files. See PLAN.md Section 12 for the full roadmap.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
     "./git-remote": {
       "types": "./dist/types/git-remote/index.d.ts",
       "import": "./dist/esm/git-remote/index.js"
+    },
+    "./indexer": {
+      "types": "./dist/types/indexer/index.d.ts",
+      "import": "./dist/esm/indexer/index.js"
     }
   },
   "keywords": [

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -43,6 +43,7 @@
  *   dwn-git migrate pulls <owner/repo>          Import PRs as patches
  *   dwn-git migrate releases <owner/repo>       Import releases
  *   dwn-git web [--port <port>]                Start the read-only web UI
+ *   dwn-git indexer [--port] [--interval] [--seed]  Start the indexer service
  *   dwn-git log                                Show recent activity
  *   dwn-git serve [--port <port>]              Start the git transport server
  *   dwn-git whoami                             Show connected DID
@@ -58,6 +59,7 @@
 import { ciCommand } from './commands/ci.js';
 import { cloneCommand } from './commands/clone.js';
 import { connectAgent } from './agent.js';
+import { indexerCommand } from '../indexer/main.js';
 import { initCommand } from './commands/init.js';
 import { issueCommand } from './commands/issue.js';
 import { logCommand } from './commands/log.js';
@@ -158,6 +160,9 @@ function printUsage(): void {
   console.log('');
   console.log('  web [--port <port>]                         Start read-only web UI (default: 8080)');
   console.log('');
+  console.log('  indexer [--port <port>] [--interval <sec>]  Start the indexer service');
+  console.log('  indexer --seed <did>                        Discover DIDs from a seed');
+  console.log('');
   console.log('  log                                         Show recent activity');
   console.log('  whoami                                      Show connected DID');
   console.log('  help                                        Show this message\n');
@@ -166,6 +171,8 @@ function printUsage(): void {
   console.log('  DWN_GIT_PORT      server port for `serve` (default: 9418)');
   console.log('  DWN_GIT_WEB_PORT  web UI port for `web` (default: 8080)');
   console.log('  DWN_GIT_REPOS     base path for bare repos (default: ./repos)');
+  console.log('  DWN_GIT_INDEXER_PORT      indexer API port (default: 8090)');
+  console.log('  DWN_GIT_INDEXER_INTERVAL  crawl interval in seconds (default: 60)');
   console.log('  GITHUB_TOKEN      GitHub API token for migration (optional, higher rate limits)');
 }
 
@@ -273,6 +280,10 @@ async function main(): Promise<void> {
 
     case 'web':
       await webCommand(ctx, rest);
+      break;
+
+    case 'indexer':
+      await indexerCommand(ctx, rest);
       break;
 
     case 'log':

--- a/src/indexer/api.ts
+++ b/src/indexer/api.ts
@@ -1,0 +1,162 @@
+/**
+ * Indexer REST API — serves JSON responses from the materialized views
+ * in the IndexerStore.
+ *
+ * Endpoints:
+ *
+ *   GET /api/repos                   List all repos (sorted by stars)
+ *   GET /api/repos/search?q=<query>  Search repos by name/topic/language
+ *   GET /api/repos/trending          Trending repos (recent star activity)
+ *   GET /api/repos/:did              Repo detail for a specific DID
+ *   GET /api/repos/:did/stars        Stars for a specific repo
+ *   GET /api/users/:did              User profile summary
+ *   GET /api/stats                   Indexer statistics
+ *
+ * All responses are JSON with `Content-Type: application/json`.
+ *
+ * @module
+ */
+
+import type { Server } from 'node:http';
+
+import { createServer } from 'node:http';
+
+import type { IndexerStore } from './store.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ApiServerOptions = {
+  store : IndexerStore;
+  port : number;
+};
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+/** Route an incoming request to the appropriate API handler. */
+export function handleApiRequest(
+  store: IndexerStore,
+  url: URL,
+): { status: number; body: string } {
+  const path = url.pathname;
+
+  // GET /api/stats
+  if (path === '/api/stats') {
+    return json(200, store.getStats());
+  }
+
+  // GET /api/repos/search?q=<query>
+  if (path === '/api/repos/search') {
+    const q = url.searchParams.get('q') ?? '';
+    const limit = parseInt(url.searchParams.get('limit') ?? '50', 10);
+    if (!q) {
+      return json(400, { error: 'Missing query parameter: q' });
+    }
+    return json(200, store.search(q, limit));
+  }
+
+  // GET /api/repos/trending
+  if (path === '/api/repos/trending') {
+    const limit = parseInt(url.searchParams.get('limit') ?? '20', 10);
+    const days = parseInt(url.searchParams.get('days') ?? '7', 10);
+    return json(200, store.getTrending(limit, days * 24 * 60 * 60 * 1000));
+  }
+
+  // GET /api/repos (list all)
+  if (path === '/api/repos') {
+    const language = url.searchParams.get('language');
+    const topic = url.searchParams.get('topic');
+    if (language) {
+      return json(200, store.getReposByLanguage(language));
+    }
+    if (topic) {
+      return json(200, store.getReposByTopic(topic));
+    }
+    return json(200, store.getReposWithStars());
+  }
+
+  // GET /api/repos/:did/stars
+  const starsMatch = path.match(/^\/api\/repos\/(did:[a-z0-9]+:[a-zA-Z0-9._:%-]+)\/stars$/);
+  if (starsMatch) {
+    const did = starsMatch[1];
+    const repo = store.getRepo(did);
+    if (!repo) { return json(404, { error: 'Repo not found' }); }
+    return json(200, {
+      starCount : store.getStarCount(repo.did, repo.recordId),
+      stars     : store.getStarsForRepo(repo.did, repo.recordId),
+    });
+  }
+
+  // GET /api/repos/:did
+  const repoMatch = path.match(/^\/api\/repos\/(did:[a-z0-9]+:[a-zA-Z0-9._:%-]+)$/);
+  if (repoMatch) {
+    const did = repoMatch[1];
+    const repo = store.getRepo(did);
+    if (!repo) { return json(404, { error: 'Repo not found' }); }
+    return json(200, {
+      ...repo,
+      starCount: store.getStarCount(repo.did, repo.recordId),
+    });
+  }
+
+  // GET /api/users/:did
+  const userMatch = path.match(/^\/api\/users\/(did:[a-z0-9]+:[a-zA-Z0-9._:%-]+)$/);
+  if (userMatch) {
+    const did = userMatch[1];
+    return json(200, store.getUserProfile(did));
+  }
+
+  return json(404, { error: 'Not found' });
+}
+
+// ---------------------------------------------------------------------------
+// Server
+// ---------------------------------------------------------------------------
+
+/** Start the indexer API server. */
+export function startApiServer(options: ApiServerOptions): Server {
+  const { store, port } = options;
+
+  const server = createServer((req, res) => {
+    try {
+      const url = new URL(req.url ?? '/', `http://localhost:${port}`);
+      const result = handleApiRequest(store, url);
+
+      res.writeHead(result.status, {
+        'Content-Type'                : 'application/json; charset=utf-8',
+        'Access-Control-Allow-Origin' : '*',
+      });
+      res.end(result.body);
+    } catch (err) {
+      console.error(`[indexer-api] Error: ${(err as Error).message}`);
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Internal server error' }));
+    }
+  });
+
+  server.listen(port, () => {
+    console.log(`[indexer-api] Listening on http://localhost:${port}`);
+    console.log('[indexer-api] Endpoints:');
+    console.log('  GET /api/repos                  List all repos');
+    console.log('  GET /api/repos/search?q=<query> Search repos');
+    console.log('  GET /api/repos/trending          Trending repos');
+    console.log('  GET /api/repos/:did              Repo detail');
+    console.log('  GET /api/repos/:did/stars         Star list');
+    console.log('  GET /api/users/:did              User profile');
+    console.log('  GET /api/stats                   Indexer stats');
+    console.log('');
+  });
+
+  return server;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function json(status: number, data: unknown): { status: number; body: string } {
+  return { status, body: JSON.stringify(data) };
+}

--- a/src/indexer/crawler.ts
+++ b/src/indexer/crawler.ts
@@ -1,0 +1,290 @@
+/**
+ * DWN record crawler — queries remote DWNs to build the indexer's
+ * materialized views.
+ *
+ * Uses the `from` parameter on TypedWeb5 queries so the SDK routes
+ * each request to the target DID's DWN endpoint (resolved from their
+ * DID document).  All queried records are `published: true` and have
+ * `{ who: 'anyone', can: ['read'] }`, so no permission grants are
+ * needed.
+ *
+ * The crawler operates incrementally — it tracks the last crawl
+ * timestamp per DID and only processes records created after that
+ * point.
+ *
+ * @module
+ */
+
+import type { AgentContext } from '../cli/agent.js';
+import type { IndexedRepo, IndexerStore } from './store.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Options for a crawl run. */
+export type CrawlOptions = {
+  /** Maximum DIDs to crawl per run. */
+  maxDids? : number;
+  /** Crawl only these DIDs (overrides store DID list). */
+  dids? : string[];
+};
+
+/** Result of a crawl run. */
+export type CrawlResult = {
+  crawledDids : number;
+  newRepos : number;
+  newStars : number;
+  newFollows : number;
+  errors : { did: string; error: string }[];
+};
+
+// ---------------------------------------------------------------------------
+// Crawler
+// ---------------------------------------------------------------------------
+
+/** Crawls DWN records from registered DIDs and populates the store. */
+export class IndexerCrawler {
+  private readonly _ctx : AgentContext;
+  private readonly _store : IndexerStore;
+
+  public constructor(ctx: AgentContext, store: IndexerStore) {
+    this._ctx = ctx;
+    this._store = store;
+  }
+
+  /**
+   * Run a single crawl pass over all registered DIDs.
+   *
+   * For each DID, queries repos, stars, and follows.  Errors on
+   * individual DIDs are captured and returned, not thrown.
+   */
+  public async crawl(options?: CrawlOptions): Promise<CrawlResult> {
+    const dids = (options?.dids ?? this._store.getDids()).slice(0, options?.maxDids);
+    const result: CrawlResult = {
+      crawledDids : 0,
+      newRepos    : 0,
+      newStars    : 0,
+      newFollows  : 0,
+      errors      : [],
+    };
+
+    for (const did of dids) {
+      try {
+        const counts = await this.crawlDid(did);
+        result.newRepos += counts.repos;
+        result.newStars += counts.stars;
+        result.newFollows += counts.follows;
+        result.crawledDids++;
+        this._store.setCursor(did, new Date().toISOString());
+      } catch (err) {
+        result.errors.push({ did, error: (err as Error).message });
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Crawl a single DID — queries repos, stars, follows, and repo
+   * metadata (issues, patches, releases counts).
+   */
+  public async crawlDid(did: string): Promise<{ repos: number; stars: number; follows: number }> {
+    const from = did === this._ctx.did ? undefined : did;
+    let repos = 0;
+    let stars = 0;
+    let follows = 0;
+
+    // ---------------------------------------------------------------
+    // Repos
+    // ---------------------------------------------------------------
+    const { records: repoRecords } = await this._ctx.repo.records.query('repo', { from });
+
+    for (const rec of repoRecords) {
+      const data = await rec.data.json();
+      const tags = rec.tags as Record<string, string> | undefined;
+      const contextId = rec.contextId ?? '';
+
+      // Count open issues.
+      const { records: issues } = await this._ctx.issues.records.query('repo/issue', {
+        from,
+        filter: { contextId, tags: { status: 'open' } },
+      });
+
+      // Count open patches.
+      const { records: patches } = await this._ctx.patches.records.query('repo/patch', {
+        from,
+        filter: { contextId, tags: { status: 'open' } },
+      });
+
+      // Count releases.
+      const { records: releases } = await this._ctx.releases.records.query('repo/release' as any, {
+        from,
+        filter: { contextId },
+      });
+
+      // Fetch topics.
+      const { records: topicRecords } = await this._ctx.repo.records.query('repo/topic' as any, {
+        from,
+        filter: { contextId },
+      });
+      const topics: string[] = [];
+      for (const t of topicRecords) {
+        const tTags = t.tags as Record<string, string> | undefined;
+        if (tTags?.name) { topics.push(tTags.name); }
+      }
+
+      const indexed: IndexedRepo = {
+        did,
+        recordId      : rec.id,
+        contextId,
+        name          : data.name ?? 'unnamed',
+        description   : data.description ?? '',
+        defaultBranch : data.defaultBranch ?? 'main',
+        visibility    : tags?.visibility ?? 'public',
+        language      : tags?.language ?? '',
+        topics,
+        openIssues    : issues.length,
+        openPatches   : patches.length,
+        releaseCount  : releases.length,
+        lastUpdated   : rec.dateCreated ?? new Date().toISOString(),
+        indexedAt     : new Date().toISOString(),
+      };
+
+      this._store.putRepo(indexed);
+      repos++;
+    }
+
+    // ---------------------------------------------------------------
+    // Stars (on this user's DWN)
+    // ---------------------------------------------------------------
+    const { records: starRecords } = await this._ctx.social.records.query('star', { from });
+
+    for (const rec of starRecords) {
+      const tags = rec.tags as Record<string, string> | undefined;
+      if (tags?.repoDid && tags?.repoRecordId) {
+        this._store.putStar({
+          starrerDid   : did,
+          repoDid      : tags.repoDid,
+          repoRecordId : tags.repoRecordId,
+          dateCreated  : rec.dateCreated ?? '',
+        });
+        stars++;
+
+        // Discover new DIDs from star targets.
+        this._store.addDid(tags.repoDid);
+      }
+    }
+
+    // ---------------------------------------------------------------
+    // Follows (on this user's DWN)
+    // ---------------------------------------------------------------
+    const { records: followRecords } = await this._ctx.social.records.query('follow', { from });
+
+    for (const rec of followRecords) {
+      const tags = rec.tags as Record<string, string> | undefined;
+      if (tags?.targetDid) {
+        this._store.putFollow({
+          followerDid : did,
+          targetDid   : tags.targetDid,
+          dateCreated : rec.dateCreated ?? '',
+        });
+        follows++;
+
+        // Discover new DIDs from follow targets.
+        this._store.addDid(tags.targetDid);
+      }
+    }
+
+    return { repos, stars, follows };
+  }
+
+  /**
+   * Discover DIDs by following the social graph from a seed DID.
+   *
+   * Queries stars and follows for the seed DID, adds discovered DIDs
+   * to the store, and optionally recurses to a given depth.
+   */
+  public async discover(seedDid: string, depth: number = 1): Promise<string[]> {
+    const discovered = new Set<string>();
+    const queue = [seedDid];
+    let currentDepth = 0;
+
+    while (queue.length > 0 && currentDepth < depth) {
+      const batch = [...queue];
+      queue.length = 0;
+
+      for (const did of batch) {
+        if (discovered.has(did)) { continue; }
+        discovered.add(did);
+        this._store.addDid(did);
+
+        try {
+          const from = did === this._ctx.did ? undefined : did;
+
+          // Stars reveal repo owner DIDs.
+          const { records: starRecords } = await this._ctx.social.records.query('star', { from });
+          for (const rec of starRecords) {
+            const tags = rec.tags as Record<string, string> | undefined;
+            if (tags?.repoDid && !discovered.has(tags.repoDid)) {
+              queue.push(tags.repoDid);
+            }
+          }
+
+          // Follows reveal user DIDs.
+          const { records: followRecords } = await this._ctx.social.records.query('follow', { from });
+          for (const rec of followRecords) {
+            const tags = rec.tags as Record<string, string> | undefined;
+            if (tags?.targetDid && !discovered.has(tags.targetDid)) {
+              queue.push(tags.targetDid);
+            }
+          }
+        } catch {
+          // Skip unreachable DIDs.
+        }
+      }
+
+      currentDepth++;
+    }
+
+    return [...discovered];
+  }
+
+  /**
+   * Start a periodic crawl loop.  Crawls all DIDs, then waits
+   * `intervalMs` before the next pass.  Returns a cleanup function
+   * to stop the loop.
+   */
+  public startLoop(intervalMs: number = 60_000): () => void {
+    let running = true;
+
+    const loop = async (): Promise<void> => {
+      while (running) {
+        try {
+          const result = await this.crawl();
+          const stats = this._store.getStats();
+          console.log(
+            `[indexer] Crawled ${result.crawledDids} DIDs: `
+            + `${result.newRepos} repos, ${result.newStars} stars, ${result.newFollows} follows`
+            + (result.errors.length > 0 ? ` (${result.errors.length} errors)` : '')
+            + ` | Total: ${stats.dids} DIDs, ${stats.repos} repos, ${stats.stars} stars`,
+          );
+        } catch (err) {
+          console.error(`[indexer] Crawl error: ${(err as Error).message}`);
+        }
+
+        // Wait for the next cycle.
+        await new Promise<void>((resolve) => {
+          const timer = setTimeout(resolve, intervalMs);
+          const check = setInterval(() => {
+            if (!running) { clearTimeout(timer); clearInterval(check); resolve(); }
+          }, 500);
+        });
+      }
+    };
+
+    loop();
+
+    return (): void => { running = false; };
+  }
+}

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Indexer module — crawls DWN records and serves aggregated views.
+ *
+ * @module
+ */
+
+export { handleApiRequest, startApiServer } from './api.js';
+export type { ApiServerOptions } from './api.js';
+
+export { IndexerCrawler } from './crawler.js';
+export type { CrawlOptions, CrawlResult } from './crawler.js';
+
+export { IndexerStore } from './store.js';
+export type {
+  CrawlCursor,
+  IndexedFollow,
+  IndexedRepo,
+  IndexedStar,
+  RepoWithStars,
+  SearchResult,
+  UserProfile,
+} from './store.js';

--- a/src/indexer/main.ts
+++ b/src/indexer/main.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env bun
+/**
+ * Indexer entry point — starts the crawler loop and REST API server.
+ *
+ * Usage:
+ *   dwn-git indexer [--port <api-port>] [--interval <seconds>] [--seed <did>]
+ *
+ * Environment:
+ *   DWN_GIT_PASSWORD       Vault password (prompted if not set)
+ *   DWN_GIT_INDEXER_PORT   API port (default: 8090)
+ *   DWN_GIT_INDEXER_INTERVAL  Crawl interval in seconds (default: 60)
+ *
+ * The indexer requires a local Web5 agent for signing DWN query
+ * messages.  On first run it initializes the agent vault.  Subsequent
+ * runs unlock the existing vault.
+ *
+ * @module
+ */
+
+import type { AgentContext } from '../cli/agent.js';
+
+import { flagValue } from '../cli/flags.js';
+import { IndexerCrawler } from './crawler.js';
+import { IndexerStore } from './store.js';
+import { startApiServer } from './api.js';
+
+// ---------------------------------------------------------------------------
+// Command
+// ---------------------------------------------------------------------------
+
+export async function indexerCommand(ctx: AgentContext, args: string[]): Promise<void> {
+  const port = parseInt(
+    flagValue(args, '--port') ?? process.env.DWN_GIT_INDEXER_PORT ?? '8090', 10,
+  );
+  const intervalSec = parseInt(
+    flagValue(args, '--interval') ?? process.env.DWN_GIT_INDEXER_INTERVAL ?? '60', 10,
+  );
+  const seedDid = flagValue(args, '--seed');
+
+  const store = new IndexerStore();
+  const crawler = new IndexerCrawler(ctx, store);
+
+  // Seed the local agent's DID.
+  store.addDid(ctx.did);
+
+  // If a seed DID is provided, discover DIDs from its social graph.
+  if (seedDid) {
+    console.log(`[indexer] Discovering DIDs from seed: ${seedDid}`);
+    const discovered = await crawler.discover(seedDid, 2);
+    console.log(`[indexer] Discovered ${discovered.length} DIDs`);
+  }
+
+  // Initial crawl before starting the API.
+  console.log('[indexer] Running initial crawl...');
+  const result = await crawler.crawl();
+  console.log(
+    `[indexer] Initial crawl complete: ${result.crawledDids} DIDs, `
+    + `${result.newRepos} repos, ${result.newStars} stars, ${result.newFollows} follows`,
+  );
+  if (result.errors.length > 0) {
+    console.log(`[indexer] ${result.errors.length} errors during initial crawl`);
+  }
+
+  // Start the periodic crawl loop.
+  const stopCrawler = crawler.startLoop(intervalSec * 1000);
+
+  // Start the API server.
+  startApiServer({ store, port });
+
+  console.log(`[indexer] Crawl interval: ${intervalSec}s`);
+  console.log('[indexer] Press Ctrl+C to stop.\n');
+
+  // Handle shutdown.
+  process.on('SIGINT', () => {
+    console.log('\n[indexer] Shutting down...');
+    stopCrawler();
+    process.exit(0);
+  });
+
+  // Keep the process alive.
+  await new Promise(() => {});
+}

--- a/src/indexer/store.ts
+++ b/src/indexer/store.ts
@@ -1,0 +1,358 @@
+/**
+ * In-memory indexer store — maintains materialized views of data
+ * crawled from distributed DWN records.
+ *
+ * Each entity is keyed by a unique composite identifier (DID + recordId
+ * or similar) and stored in a Map.  Aggregation methods compute star
+ * counts, trending scores, search results, etc. on the fly.
+ *
+ * A production deployment would back this with PostgreSQL or similar,
+ * but the in-memory implementation keeps the MVP dependency-free and
+ * testable.
+ *
+ * @module
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Indexed repo metadata. */
+export type IndexedRepo = {
+  did : string;
+  recordId : string;
+  contextId : string;
+  name : string;
+  description : string;
+  defaultBranch : string;
+  visibility : string;
+  language : string;
+  topics : string[];
+  openIssues : number;
+  openPatches : number;
+  releaseCount : number;
+  lastUpdated : string;
+  indexedAt : string;
+};
+
+/** Indexed star record. */
+export type IndexedStar = {
+  starrerDid : string;
+  repoDid : string;
+  repoRecordId : string;
+  dateCreated : string;
+};
+
+/** Indexed follow record. */
+export type IndexedFollow = {
+  followerDid : string;
+  targetDid : string;
+  dateCreated : string;
+};
+
+/** Crawl cursor — tracks progress per DID for incremental crawling. */
+export type CrawlCursor = {
+  did : string;
+  lastCrawled : string;
+};
+
+/** Aggregated repo view with star count. */
+export type RepoWithStars = IndexedRepo & { starCount: number };
+
+/** Search result with relevance score. */
+export type SearchResult = RepoWithStars & { score: number };
+
+/** User profile summary. */
+export type UserProfile = {
+  did : string;
+  repoCount : number;
+  starCount : number;
+  followerCount : number;
+  followingCount : number;
+};
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+/** In-memory indexer store. */
+export class IndexerStore {
+  /** Repos keyed by `did:recordId`. */
+  private _repos = new Map<string, IndexedRepo>();
+
+  /** Stars keyed by `starrerDid:repoDid:repoRecordId`. */
+  private _stars = new Map<string, IndexedStar>();
+
+  /** Follows keyed by `followerDid:targetDid`. */
+  private _follows = new Map<string, IndexedFollow>();
+
+  /** Known DIDs to crawl. */
+  private _dids = new Set<string>();
+
+  /** Per-DID crawl cursors. */
+  private _cursors = new Map<string, CrawlCursor>();
+
+  // -----------------------------------------------------------------------
+  // DID management
+  // -----------------------------------------------------------------------
+
+  /** Register a DID for crawling. */
+  public addDid(did: string): void {
+    this._dids.add(did);
+  }
+
+  /** Remove a DID from the crawl list. */
+  public removeDid(did: string): void {
+    this._dids.delete(did);
+  }
+
+  /** Get all registered DIDs. */
+  public getDids(): string[] {
+    return [...this._dids];
+  }
+
+  /** Get the crawl cursor for a DID. */
+  public getCursor(did: string): CrawlCursor | undefined {
+    return this._cursors.get(did);
+  }
+
+  /** Update the crawl cursor for a DID. */
+  public setCursor(did: string, lastCrawled: string): void {
+    this._cursors.set(did, { did, lastCrawled });
+  }
+
+  // -----------------------------------------------------------------------
+  // Repo operations
+  // -----------------------------------------------------------------------
+
+  /** Upsert an indexed repo. */
+  public putRepo(repo: IndexedRepo): void {
+    this._repos.set(`${repo.did}:${repo.recordId}`, repo);
+    this._dids.add(repo.did);
+  }
+
+  /** Get an indexed repo by DID (returns first match). */
+  public getRepo(did: string): IndexedRepo | undefined {
+    for (const repo of this._repos.values()) {
+      if (repo.did === did) { return repo; }
+    }
+    return undefined;
+  }
+
+  /** Get all indexed repos. */
+  public getAllRepos(): IndexedRepo[] {
+    return [...this._repos.values()];
+  }
+
+  // -----------------------------------------------------------------------
+  // Star operations
+  // -----------------------------------------------------------------------
+
+  /** Upsert an indexed star. */
+  public putStar(star: IndexedStar): void {
+    this._stars.set(`${star.starrerDid}:${star.repoDid}:${star.repoRecordId}`, star);
+    this._dids.add(star.starrerDid);
+  }
+
+  /** Remove a star. */
+  public removeStar(starrerDid: string, repoDid: string, repoRecordId: string): void {
+    this._stars.delete(`${starrerDid}:${repoDid}:${repoRecordId}`);
+  }
+
+  /** Get star count for a repo. */
+  public getStarCount(repoDid: string, repoRecordId: string): number {
+    let count = 0;
+    for (const star of this._stars.values()) {
+      if (star.repoDid === repoDid && star.repoRecordId === repoRecordId) { count++; }
+    }
+    return count;
+  }
+
+  /** Get all stars for a repo. */
+  public getStarsForRepo(repoDid: string, repoRecordId: string): IndexedStar[] {
+    const result: IndexedStar[] = [];
+    for (const star of this._stars.values()) {
+      if (star.repoDid === repoDid && star.repoRecordId === repoRecordId) { result.push(star); }
+    }
+    return result;
+  }
+
+  /** Get all repos starred by a user. */
+  public getStarredByUser(did: string): IndexedStar[] {
+    const result: IndexedStar[] = [];
+    for (const star of this._stars.values()) {
+      if (star.starrerDid === did) { result.push(star); }
+    }
+    return result;
+  }
+
+  // -----------------------------------------------------------------------
+  // Follow operations
+  // -----------------------------------------------------------------------
+
+  /** Upsert an indexed follow. */
+  public putFollow(follow: IndexedFollow): void {
+    this._follows.set(`${follow.followerDid}:${follow.targetDid}`, follow);
+    this._dids.add(follow.followerDid);
+    this._dids.add(follow.targetDid);
+  }
+
+  /** Remove a follow. */
+  public removeFollow(followerDid: string, targetDid: string): void {
+    this._follows.delete(`${followerDid}:${targetDid}`);
+  }
+
+  /** Get follower count for a user. */
+  public getFollowerCount(did: string): number {
+    let count = 0;
+    for (const f of this._follows.values()) {
+      if (f.targetDid === did) { count++; }
+    }
+    return count;
+  }
+
+  /** Get following count for a user. */
+  public getFollowingCount(did: string): number {
+    let count = 0;
+    for (const f of this._follows.values()) {
+      if (f.followerDid === did) { count++; }
+    }
+    return count;
+  }
+
+  // -----------------------------------------------------------------------
+  // Aggregation queries
+  // -----------------------------------------------------------------------
+
+  /** Get repos with star counts, sorted by star count descending. */
+  public getReposWithStars(): RepoWithStars[] {
+    return this.getAllRepos()
+      .map((r) => ({ ...r, starCount: this.getStarCount(r.did, r.recordId) }))
+      .sort((a, b) => b.starCount - a.starCount);
+  }
+
+  /**
+   * Trending repos — sorted by recent star activity.
+   *
+   * Trending is computed as the number of stars received within
+   * `windowMs` (default: 7 days), weighted by recency.
+   */
+  public getTrending(limit: number = 20, windowMs: number = 7 * 24 * 60 * 60 * 1000): RepoWithStars[] {
+    const now = Date.now();
+    const cutoff = new Date(now - windowMs).toISOString();
+
+    // Count recent stars per repo.
+    const recentStars = new Map<string, number>();
+    for (const star of this._stars.values()) {
+      if (star.dateCreated >= cutoff) {
+        const key = `${star.repoDid}:${star.repoRecordId}`;
+        recentStars.set(key, (recentStars.get(key) ?? 0) + 1);
+      }
+    }
+
+    return this.getReposWithStars()
+      .map((r) => {
+        const key = `${r.did}:${r.recordId}`;
+        const recent = recentStars.get(key) ?? 0;
+        return { ...r, _trending: recent };
+      })
+      .sort((a, b) => (b as any)._trending - (a as any)._trending || b.starCount - a.starCount)
+      .slice(0, limit)
+      .map(({ ...r }) => { delete (r as any)._trending; return r; });
+  }
+
+  /**
+   * Search repos by name, description, topics, or language.
+   *
+   * Returns results sorted by relevance score.  Scoring:
+   *   - Name exact match: 10
+   *   - Name prefix match: 5
+   *   - Name substring match: 3
+   *   - Topic match: 4
+   *   - Language match: 2
+   *   - Description substring match: 1
+   *   - Star count bonus: 0.1 per star (capped at 5)
+   */
+  public search(query: string, limit: number = 50): SearchResult[] {
+    const q = query.toLowerCase();
+    const results: SearchResult[] = [];
+
+    for (const r of this.getReposWithStars()) {
+      let score = 0;
+      const name = r.name.toLowerCase();
+      const desc = r.description.toLowerCase();
+
+      if (name === q) { score += 10; }
+      else if (name.startsWith(q)) { score += 5; }
+      else if (name.includes(q)) { score += 3; }
+
+      if (r.topics.some((t) => t.toLowerCase() === q)) { score += 4; }
+      if (r.language.toLowerCase() === q) { score += 2; }
+      if (desc.includes(q)) { score += 1; }
+
+      // Star bonus.
+      score += Math.min(r.starCount * 0.1, 5);
+
+      if (score > 0) {
+        results.push({ ...r, score });
+      }
+    }
+
+    return results
+      .sort((a, b) => b.score - a.score)
+      .slice(0, limit);
+  }
+
+  /** Get user profile summary. */
+  public getUserProfile(did: string): UserProfile {
+    const repos = this.getAllRepos().filter((r) => r.did === did);
+    let totalStars = 0;
+    for (const r of repos) {
+      totalStars += this.getStarCount(r.did, r.recordId);
+    }
+    return {
+      did,
+      repoCount      : repos.length,
+      starCount      : totalStars,
+      followerCount  : this.getFollowerCount(did),
+      followingCount : this.getFollowingCount(did),
+    };
+  }
+
+  /**
+   * List repos by language, sorted by star count.
+   */
+  public getReposByLanguage(language: string): RepoWithStars[] {
+    const lang = language.toLowerCase();
+    return this.getReposWithStars()
+      .filter((r) => r.language.toLowerCase() === lang);
+  }
+
+  /**
+   * List repos by topic, sorted by star count.
+   */
+  public getReposByTopic(topic: string): RepoWithStars[] {
+    const t = topic.toLowerCase();
+    return this.getReposWithStars()
+      .filter((r) => r.topics.some((tp) => tp.toLowerCase() === t));
+  }
+
+  /** Get store statistics. */
+  public getStats(): { dids: number; repos: number; stars: number; follows: number } {
+    return {
+      dids    : this._dids.size,
+      repos   : this._repos.size,
+      stars   : this._stars.size,
+      follows : this._follows.size,
+    };
+  }
+
+  /** Clear all data. */
+  public clear(): void {
+    this._repos.clear();
+    this._stars.clear();
+    this._follows.clear();
+    this._dids.clear();
+    this._cursors.clear();
+  }
+}

--- a/tests/indexer.spec.ts
+++ b/tests/indexer.spec.ts
@@ -1,0 +1,546 @@
+/**
+ * Indexer tests — exercises the IndexerStore, IndexerCrawler, and REST
+ * API against a real Web5 agent with seeded DWN records.
+ *
+ * The test agent is created once in `beforeAll`, records are seeded,
+ * then the crawler indexes them and the API is verified.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+
+import { rmSync } from 'node:fs';
+
+import { Web5 } from '@enbox/api';
+import { Web5UserAgent } from '@enbox/agent';
+
+import type { AgentContext } from '../src/cli/agent.js';
+
+import { ForgeCiProtocol } from '../src/ci.js';
+import { ForgeIssuesProtocol } from '../src/issues.js';
+import { ForgeNotificationsProtocol } from '../src/notifications.js';
+import { ForgeOrgProtocol } from '../src/org.js';
+import { ForgePatchesProtocol } from '../src/patches.js';
+import { ForgeRefsProtocol } from '../src/refs.js';
+import { ForgeRegistryProtocol } from '../src/registry.js';
+import { ForgeReleasesProtocol } from '../src/releases.js';
+import { ForgeRepoProtocol } from '../src/repo.js';
+import { ForgeSocialProtocol } from '../src/social.js';
+import { ForgeWikiProtocol } from '../src/wiki.js';
+import { handleApiRequest } from '../src/indexer/api.js';
+import { IndexerCrawler } from '../src/indexer/crawler.js';
+import { IndexerStore } from '../src/indexer/store.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DATA_PATH = '__TESTDATA__/indexer-agent';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function apiUrl(path: string): URL {
+  return new URL(path, 'http://localhost:8090');
+}
+
+function parseJson(body: string): any {
+  return JSON.parse(body);
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('dwn-git indexer', () => {
+  let ctx: AgentContext;
+  let store: IndexerStore;
+  let crawler: IndexerCrawler;
+
+  beforeAll(async () => {
+    rmSync(DATA_PATH, { recursive: true, force: true });
+
+    const agent = await Web5UserAgent.create({ dataPath: DATA_PATH });
+    await agent.initialize({ password: 'test-password' });
+    await agent.start({ password: 'test-password' });
+
+    const identities = await agent.identity.list();
+    let identity = identities[0];
+    if (!identity) {
+      identity = await agent.identity.create({
+        didMethod : 'jwk',
+        metadata  : { name: 'Indexer Test' },
+      });
+    }
+
+    const result = await Web5.connect({
+      agent,
+      connectedDid : identity.did.uri,
+      sync         : 'off',
+    });
+    const { web5, did } = result;
+
+    const repo = web5.using(ForgeRepoProtocol);
+    const refs = web5.using(ForgeRefsProtocol);
+    const issues = web5.using(ForgeIssuesProtocol);
+    const patches = web5.using(ForgePatchesProtocol);
+    const ci = web5.using(ForgeCiProtocol);
+    const releases = web5.using(ForgeReleasesProtocol);
+    const registry = web5.using(ForgeRegistryProtocol);
+    const social = web5.using(ForgeSocialProtocol);
+    const notifications = web5.using(ForgeNotificationsProtocol);
+    const wiki = web5.using(ForgeWikiProtocol);
+    const org = web5.using(ForgeOrgProtocol);
+
+    await repo.configure();
+    await refs.configure();
+    await issues.configure();
+    await patches.configure();
+    await ci.configure();
+    await releases.configure();
+    await registry.configure();
+    await social.configure();
+    await notifications.configure();
+    await wiki.configure();
+    await org.configure();
+
+    ctx = {
+      did, repo, refs, issues, patches, ci, releases,
+      registry, social, notifications, wiki, org, web5,
+    };
+
+    // -----------------------------------------------------------------------
+    // Seed data
+    // -----------------------------------------------------------------------
+
+    // 1. Create a repo record.
+    const { record: repoRec } = await ctx.repo.records.create('repo', {
+      data : { name: 'awesome-lib', description: 'A great library', defaultBranch: 'main', dwnEndpoints: [] },
+      tags : { name: 'awesome-lib', visibility: 'public', language: 'TypeScript' },
+    });
+    const repoContextId = repoRec!.contextId ?? '';
+
+    // 2. Create open issues.
+    await ctx.issues.records.create('repo/issue', {
+      data            : { title: 'Bug report', body: 'Something broke.', number: 1 },
+      tags            : { status: 'open', number: '1' },
+      parentContextId : repoContextId,
+    });
+    await ctx.issues.records.create('repo/issue', {
+      data            : { title: 'Feature request', body: 'Add X.', number: 2 },
+      tags            : { status: 'open', number: '2' },
+      parentContextId : repoContextId,
+    });
+    // 3. Create a closed issue.
+    await ctx.issues.records.create('repo/issue', {
+      data            : { title: 'Old bug', body: 'Fixed.', number: 3 },
+      tags            : { status: 'closed', number: '3' },
+      parentContextId : repoContextId,
+    });
+
+    // 4. Create an open patch.
+    await ctx.patches.records.create('repo/patch', {
+      data            : { title: 'Fix bug', body: 'Fixes #1.', number: 1 },
+      tags            : { status: 'open', baseBranch: 'main', number: '1' },
+      parentContextId : repoContextId,
+    });
+
+    // 5. Create a release.
+    await ctx.releases.records.create('repo/release' as any, {
+      data            : { name: 'v1.0.0', body: 'First release.' },
+      tags            : { tagName: 'v1.0.0' },
+      parentContextId : repoContextId,
+    } as any);
+
+    // 6. Create a star (starring own repo for testing).
+    await ctx.social.records.create('star', {
+      data : { repoDid: did, repoRecordId: repoRec!.id },
+      tags : { repoDid: did, repoRecordId: repoRec!.id },
+    });
+
+    // 7. Create a follow (following self for testing).
+    await ctx.social.records.create('follow', {
+      data : { targetDid: did },
+      tags : { targetDid: did },
+    });
+
+    store = new IndexerStore();
+    crawler = new IndexerCrawler(ctx, store);
+  });
+
+  afterAll(() => {
+    rmSync(DATA_PATH, { recursive: true, force: true });
+  });
+
+  // =========================================================================
+  // IndexerStore (unit tests)
+  // =========================================================================
+
+  describe('IndexerStore', () => {
+    let unitStore: IndexerStore;
+
+    beforeEach(() => {
+      unitStore = new IndexerStore();
+    });
+
+    it('should manage DIDs', () => {
+      unitStore.addDid('did:jwk:a');
+      unitStore.addDid('did:jwk:b');
+      expect(unitStore.getDids()).toHaveLength(2);
+      unitStore.removeDid('did:jwk:a');
+      expect(unitStore.getDids()).toHaveLength(1);
+    });
+
+    it('should store and retrieve repos', () => {
+      unitStore.putRepo({
+        did           : 'did:jwk:a', recordId      : 'r1', contextId     : 'c1', name          : 'test',
+        description   : '', defaultBranch : 'main', visibility    : 'public',
+        language      : 'TypeScript', topics        : ['web'], openIssues    : 0,
+        openPatches   : 0, releaseCount  : 0, lastUpdated   : '', indexedAt     : '',
+      });
+      expect(unitStore.getRepo('did:jwk:a')).toBeDefined();
+      expect(unitStore.getRepo('did:jwk:a')!.name).toBe('test');
+      expect(unitStore.getAllRepos()).toHaveLength(1);
+    });
+
+    it('should compute star counts', () => {
+      unitStore.putStar({
+        starrerDid   : 'did:jwk:b', repoDid      : 'did:jwk:a',
+        repoRecordId : 'r1', dateCreated  : new Date().toISOString(),
+      });
+      unitStore.putStar({
+        starrerDid   : 'did:jwk:c', repoDid      : 'did:jwk:a',
+        repoRecordId : 'r1', dateCreated  : new Date().toISOString(),
+      });
+      expect(unitStore.getStarCount('did:jwk:a', 'r1')).toBe(2);
+      expect(unitStore.getStarsForRepo('did:jwk:a', 'r1')).toHaveLength(2);
+      expect(unitStore.getStarredByUser('did:jwk:b')).toHaveLength(1);
+    });
+
+    it('should remove stars', () => {
+      unitStore.putStar({
+        starrerDid   : 'did:jwk:b', repoDid      : 'did:jwk:a',
+        repoRecordId : 'r1', dateCreated  : '',
+      });
+      unitStore.removeStar('did:jwk:b', 'did:jwk:a', 'r1');
+      expect(unitStore.getStarCount('did:jwk:a', 'r1')).toBe(0);
+    });
+
+    it('should compute follower and following counts', () => {
+      unitStore.putFollow({ followerDid: 'did:jwk:a', targetDid: 'did:jwk:b', dateCreated: '' });
+      unitStore.putFollow({ followerDid: 'did:jwk:c', targetDid: 'did:jwk:b', dateCreated: '' });
+      expect(unitStore.getFollowerCount('did:jwk:b')).toBe(2);
+      expect(unitStore.getFollowingCount('did:jwk:a')).toBe(1);
+    });
+
+    it('should remove follows', () => {
+      unitStore.putFollow({ followerDid: 'did:jwk:a', targetDid: 'did:jwk:b', dateCreated: '' });
+      unitStore.removeFollow('did:jwk:a', 'did:jwk:b');
+      expect(unitStore.getFollowerCount('did:jwk:b')).toBe(0);
+    });
+
+    it('should search repos by name', () => {
+      unitStore.putRepo({
+        did           : 'did:jwk:a', recordId      : 'r1', contextId     : 'c1', name          : 'awesome-lib',
+        description   : 'A great library', defaultBranch : 'main', visibility    : 'public',
+        language      : 'TypeScript', topics        : ['web'], openIssues    : 0,
+        openPatches   : 0, releaseCount  : 0, lastUpdated   : '', indexedAt     : '',
+      });
+      unitStore.putRepo({
+        did           : 'did:jwk:b', recordId      : 'r2', contextId     : 'c2', name          : 'other-thing',
+        description   : '', defaultBranch : 'main', visibility    : 'public',
+        language      : 'Rust', topics        : [], openIssues    : 0,
+        openPatches   : 0, releaseCount  : 0, lastUpdated   : '', indexedAt     : '',
+      });
+
+      const results = unitStore.search('awesome');
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe('awesome-lib');
+      expect(results[0].score).toBeGreaterThan(0);
+    });
+
+    it('should search repos by topic', () => {
+      unitStore.putRepo({
+        did           : 'did:jwk:a', recordId      : 'r1', contextId     : 'c1', name          : 'lib',
+        description   : '', defaultBranch : 'main', visibility    : 'public',
+        language      : '', topics        : ['web', 'framework'], openIssues    : 0,
+        openPatches   : 0, releaseCount  : 0, lastUpdated   : '', indexedAt     : '',
+      });
+
+      const results = unitStore.search('web');
+      expect(results).toHaveLength(1);
+    });
+
+    it('should search repos by language', () => {
+      unitStore.putRepo({
+        did           : 'did:jwk:a', recordId      : 'r1', contextId     : 'c1', name          : 'lib',
+        description   : '', defaultBranch : 'main', visibility    : 'public',
+        language      : 'TypeScript', topics        : [], openIssues    : 0,
+        openPatches   : 0, releaseCount  : 0, lastUpdated   : '', indexedAt     : '',
+      });
+
+      const results = unitStore.search('typescript');
+      expect(results).toHaveLength(1);
+    });
+
+    it('should compute trending repos', () => {
+      unitStore.putRepo({
+        did           : 'did:jwk:a', recordId      : 'r1', contextId     : 'c1', name          : 'trending-repo',
+        description   : '', defaultBranch : 'main', visibility    : 'public',
+        language      : '', topics        : [], openIssues    : 0,
+        openPatches   : 0, releaseCount  : 0, lastUpdated   : '', indexedAt     : '',
+      });
+      // Add recent stars.
+      unitStore.putStar({
+        starrerDid   : 'did:jwk:b', repoDid      : 'did:jwk:a',
+        repoRecordId : 'r1', dateCreated  : new Date().toISOString(),
+      });
+      unitStore.putStar({
+        starrerDid   : 'did:jwk:c', repoDid      : 'did:jwk:a',
+        repoRecordId : 'r1', dateCreated  : new Date().toISOString(),
+      });
+
+      const trending = unitStore.getTrending(10);
+      expect(trending).toHaveLength(1);
+      expect(trending[0].name).toBe('trending-repo');
+      expect(trending[0].starCount).toBe(2);
+    });
+
+    it('should filter repos by language', () => {
+      unitStore.putRepo({
+        did           : 'did:jwk:a', recordId      : 'r1', contextId     : 'c1', name          : 'ts-lib',
+        description   : '', defaultBranch : 'main', visibility    : 'public',
+        language      : 'TypeScript', topics        : [], openIssues    : 0,
+        openPatches   : 0, releaseCount  : 0, lastUpdated   : '', indexedAt     : '',
+      });
+      unitStore.putRepo({
+        did           : 'did:jwk:b', recordId      : 'r2', contextId     : 'c2', name          : 'rust-lib',
+        description   : '', defaultBranch : 'main', visibility    : 'public',
+        language      : 'Rust', topics        : [], openIssues    : 0,
+        openPatches   : 0, releaseCount  : 0, lastUpdated   : '', indexedAt     : '',
+      });
+
+      expect(unitStore.getReposByLanguage('TypeScript')).toHaveLength(1);
+      expect(unitStore.getReposByLanguage('Rust')).toHaveLength(1);
+      expect(unitStore.getReposByLanguage('Go')).toHaveLength(0);
+    });
+
+    it('should filter repos by topic', () => {
+      unitStore.putRepo({
+        did           : 'did:jwk:a', recordId      : 'r1', contextId     : 'c1', name          : 'web-lib',
+        description   : '', defaultBranch : 'main', visibility    : 'public',
+        language      : '', topics        : ['web', 'http'], openIssues    : 0,
+        openPatches   : 0, releaseCount  : 0, lastUpdated   : '', indexedAt     : '',
+      });
+
+      expect(unitStore.getReposByTopic('web')).toHaveLength(1);
+      expect(unitStore.getReposByTopic('cli')).toHaveLength(0);
+    });
+
+    it('should build user profiles', () => {
+      unitStore.putRepo({
+        did           : 'did:jwk:a', recordId      : 'r1', contextId     : 'c1', name          : 'repo1',
+        description   : '', defaultBranch : 'main', visibility    : 'public',
+        language      : '', topics        : [], openIssues    : 0,
+        openPatches   : 0, releaseCount  : 0, lastUpdated   : '', indexedAt     : '',
+      });
+      unitStore.putStar({
+        starrerDid   : 'did:jwk:b', repoDid      : 'did:jwk:a',
+        repoRecordId : 'r1', dateCreated  : '',
+      });
+      unitStore.putFollow({
+        followerDid: 'did:jwk:c', targetDid: 'did:jwk:a', dateCreated: '',
+      });
+
+      const profile = unitStore.getUserProfile('did:jwk:a');
+      expect(profile.repoCount).toBe(1);
+      expect(profile.starCount).toBe(1);
+      expect(profile.followerCount).toBe(1);
+    });
+
+    it('should return stats', () => {
+      unitStore.addDid('did:jwk:a');
+      unitStore.putRepo({
+        did           : 'did:jwk:a', recordId      : 'r1', contextId     : 'c1', name          : 'x',
+        description   : '', defaultBranch : 'main', visibility    : 'public',
+        language      : '', topics        : [], openIssues    : 0,
+        openPatches   : 0, releaseCount  : 0, lastUpdated   : '', indexedAt     : '',
+      });
+      const stats = unitStore.getStats();
+      expect(stats.dids).toBeGreaterThanOrEqual(1);
+      expect(stats.repos).toBe(1);
+    });
+
+    it('should clear all data', () => {
+      unitStore.addDid('did:jwk:a');
+      unitStore.putRepo({
+        did           : 'did:jwk:a', recordId      : 'r1', contextId     : 'c1', name          : 'x',
+        description   : '', defaultBranch : 'main', visibility    : 'public',
+        language      : '', topics        : [], openIssues    : 0,
+        openPatches   : 0, releaseCount  : 0, lastUpdated   : '', indexedAt     : '',
+      });
+      unitStore.clear();
+      expect(unitStore.getStats().dids).toBe(0);
+      expect(unitStore.getStats().repos).toBe(0);
+    });
+
+    it('should manage crawl cursors', () => {
+      unitStore.setCursor('did:jwk:a', '2025-01-01T00:00:00Z');
+      const cursor = unitStore.getCursor('did:jwk:a');
+      expect(cursor).toBeDefined();
+      expect(cursor!.lastCrawled).toBe('2025-01-01T00:00:00Z');
+    });
+  });
+
+  // =========================================================================
+  // IndexerCrawler (integration with real DWN)
+  // =========================================================================
+
+  describe('IndexerCrawler', () => {
+    it('should crawl the local DID and index repos', async () => {
+      store.clear();
+      store.addDid(ctx.did);
+      const result = await crawler.crawl();
+
+      expect(result.crawledDids).toBe(1);
+      expect(result.newRepos).toBeGreaterThanOrEqual(1);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should index repo metadata correctly', async () => {
+      const repo = store.getRepo(ctx.did);
+      expect(repo).toBeDefined();
+      expect(repo!.name).toBe('awesome-lib');
+      expect(repo!.description).toBe('A great library');
+      expect(repo!.visibility).toBe('public');
+      expect(repo!.language).toBe('TypeScript');
+    });
+
+    it('should count open issues and patches', async () => {
+      const repo = store.getRepo(ctx.did);
+      expect(repo).toBeDefined();
+      expect(repo!.openIssues).toBe(2);
+      expect(repo!.openPatches).toBe(1);
+    });
+
+    it('should count releases', async () => {
+      const repo = store.getRepo(ctx.did);
+      expect(repo).toBeDefined();
+      expect(repo!.releaseCount).toBe(1);
+    });
+
+    it('should index stars', async () => {
+      expect(store.getStarCount(ctx.did, store.getRepo(ctx.did)!.recordId)).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should index follows', async () => {
+      expect(store.getFollowerCount(ctx.did)).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should set crawl cursor after crawling', async () => {
+      const cursor = store.getCursor(ctx.did);
+      expect(cursor).toBeDefined();
+      expect(cursor!.lastCrawled).toBeTruthy();
+    });
+
+    it('should handle errors gracefully for unreachable DIDs', async () => {
+      store.addDid('did:jwk:unreachable');
+      const result = await crawler.crawl({ dids: ['did:jwk:unreachable'] });
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].did).toBe('did:jwk:unreachable');
+    });
+
+    it('should crawl a single DID directly', async () => {
+      const counts = await crawler.crawlDid(ctx.did);
+      expect(counts.repos).toBeGreaterThanOrEqual(1);
+      expect(counts.stars).toBeGreaterThanOrEqual(1);
+      expect(counts.follows).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // =========================================================================
+  // Indexer REST API
+  // =========================================================================
+
+  describe('REST API', () => {
+    it('GET /api/stats should return indexer statistics', () => {
+      const res = handleApiRequest(store, apiUrl('/api/stats'));
+      expect(res.status).toBe(200);
+      const data = parseJson(res.body);
+      expect(data.dids).toBeGreaterThanOrEqual(1);
+      expect(data.repos).toBeGreaterThanOrEqual(1);
+    });
+
+    it('GET /api/repos should list all repos with star counts', () => {
+      const res = handleApiRequest(store, apiUrl('/api/repos'));
+      expect(res.status).toBe(200);
+      const data = parseJson(res.body);
+      expect(data.length).toBeGreaterThanOrEqual(1);
+      expect(data[0].name).toBe('awesome-lib');
+      expect(data[0].starCount).toBeGreaterThanOrEqual(1);
+    });
+
+    it('GET /api/repos?language=TypeScript should filter by language', () => {
+      const res = handleApiRequest(store, apiUrl('/api/repos?language=TypeScript'));
+      expect(res.status).toBe(200);
+      const data = parseJson(res.body);
+      expect(data.length).toBeGreaterThanOrEqual(1);
+      expect(data[0].language).toBe('TypeScript');
+    });
+
+    it('GET /api/repos/search?q=awesome should search repos', () => {
+      const res = handleApiRequest(store, apiUrl('/api/repos/search?q=awesome'));
+      expect(res.status).toBe(200);
+      const data = parseJson(res.body);
+      expect(data.length).toBeGreaterThanOrEqual(1);
+      expect(data[0].name).toContain('awesome');
+    });
+
+    it('GET /api/repos/search without q should return 400', () => {
+      const res = handleApiRequest(store, apiUrl('/api/repos/search'));
+      expect(res.status).toBe(400);
+    });
+
+    it('GET /api/repos/trending should return trending repos', () => {
+      const res = handleApiRequest(store, apiUrl('/api/repos/trending'));
+      expect(res.status).toBe(200);
+      const data = parseJson(res.body);
+      expect(Array.isArray(data)).toBe(true);
+    });
+
+    it('GET /api/repos/:did should return repo detail', () => {
+      const res = handleApiRequest(store, apiUrl(`/api/repos/${ctx.did}`));
+      expect(res.status).toBe(200);
+      const data = parseJson(res.body);
+      expect(data.name).toBe('awesome-lib');
+      expect(data.starCount).toBeGreaterThanOrEqual(1);
+      expect(data.openIssues).toBe(2);
+    });
+
+    it('GET /api/repos/:did should return 404 for unknown DID', () => {
+      const res = handleApiRequest(store, apiUrl('/api/repos/did:jwk:nonexistent'));
+      expect(res.status).toBe(404);
+    });
+
+    it('GET /api/repos/:did/stars should return star list', () => {
+      const res = handleApiRequest(store, apiUrl(`/api/repos/${ctx.did}/stars`));
+      expect(res.status).toBe(200);
+      const data = parseJson(res.body);
+      expect(data.starCount).toBeGreaterThanOrEqual(1);
+      expect(data.stars.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('GET /api/users/:did should return user profile', () => {
+      const res = handleApiRequest(store, apiUrl(`/api/users/${ctx.did}`));
+      expect(res.status).toBe(200);
+      const data = parseJson(res.body);
+      expect(data.did).toBe(ctx.did);
+      expect(data.repoCount).toBeGreaterThanOrEqual(1);
+      expect(data.followerCount).toBeGreaterThanOrEqual(1);
+    });
+
+    it('GET /api/unknown should return 404', () => {
+      const res = handleApiRequest(store, apiUrl('/api/unknown'));
+      expect(res.status).toBe(404);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add an indexer service that crawls distributed DWN records and builds materialized views for discovery, search, and aggregation
- **DID discovery** via social graph traversal — follows stars and follows to find new users/repos organically
- REST API with 7 endpoints for repos, search, trending, user profiles, and stats
- `dwn-git indexer` CLI command with periodic crawl loop
- 36 new tests (85 assertions) — **610 pass, 0 fail, 1488 assertions** across 16 test files

## Architecture

The fundamental challenge: social data is distributed by design. Stars live on the starrer's DWN, follows on the follower's DWN. The indexer solves aggregation by crawling many DWNs and computing materialized views.

```
                    ┌─────────────────┐
                    │  IndexerCrawler  │  crawls DIDs using `from:` queries
                    │                 │  discovers new DIDs via social graph
                    └────────┬────────┘
                             │ populates
                    ┌────────▼────────┐
                    │  IndexerStore   │  in-memory: repos, stars, follows
                    │                 │  aggregation: search, trending, profiles
                    └────────┬────────┘
                             │ serves
                    ┌────────▼────────┐
                    │   REST API      │  /api/repos, /search, /trending, etc.
                    └─────────────────┘
```

## REST API Endpoints

| Endpoint | Description |
|---|---|
| `GET /api/repos` | List all repos sorted by stars (filter: `?language=`, `?topic=`) |
| `GET /api/repos/search?q=<query>` | Search by name, description, topic, or language |
| `GET /api/repos/trending` | Trending repos by recent star activity (`?days=`, `?limit=`) |
| `GET /api/repos/:did` | Repo detail with star count and issue/patch counts |
| `GET /api/repos/:did/stars` | Star list for a repo |
| `GET /api/users/:did` | User profile: repo count, stars, followers, following |
| `GET /api/stats` | Indexer statistics: DIDs, repos, stars, follows |

## New files

| File | Purpose |
|---|---|
| `src/indexer/store.ts` | In-memory store with aggregation queries (search, trending, profiles) |
| `src/indexer/crawler.ts` | DWN record crawler with `from:` queries and social graph discovery |
| `src/indexer/api.ts` | REST API server with 7 JSON endpoints |
| `src/indexer/main.ts` | `indexerCommand()` — CLI entry point with crawl loop |
| `src/indexer/index.ts` | Barrel exports |
| `tests/indexer.spec.ts` | 36 tests: store unit tests, crawler integration, API endpoints |