### PR TITLE
feat: Phase 5 — GitHub API compatibility shim

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1320,9 +1320,9 @@ Registry CLI with 5 subcommands and 20 CLI tests — 525 total tests, 1282 asser
 
 - [x] **Indexer service**: repo discovery, star aggregation, external contribution surfacing
 - [x] **Web UI**: read-only repo/issue/PR viewer
-- [ ] **VS Code extension**: native IDE integration
+- [ ] **VS Code extension**: native IDE integration (separate repo, post-stabilization)
 - [x] **GitHub migration tool**: import repos, issues, PRs from GitHub
-- [ ] **GitHub API compatibility shim** (optional)
+- [x] **GitHub API compatibility shim**: read-only Phase 1 (10 endpoints)
 
 ---
 
@@ -1370,18 +1370,27 @@ dwn-git/
 │   │   ├── parse-url.ts        # DID URL parser (did::, did://)
 │   │   ├── resolve.ts          # DID resolution + endpoint discovery
 │   │   └── service.ts          # GitTransport DID service type utilities
-│   └── git-server/             # Git transport sidecar server
+│   ├── git-server/             # Git transport sidecar server
+│   │   ├── index.ts            # Barrel re-export
+│   │   ├── auth.ts             # DID-signed push authentication
+│   │   ├── bundle-restore.ts   # Restore bare repos from DWN bundle records
+│   │   ├── bundle-sync.ts      # Post-push bundle sync to DWN
+│   │   ├── did-service.ts      # DID service registration
+│   │   ├── git-backend.ts      # Bare repo management (init, upload-pack, receive-pack)
+│   │   ├── http-handler.ts     # Smart HTTP protocol handler (with onRepoNotFound)
+│   │   ├── push-authorizer.ts  # DWN-backed push authorization
+│   │   ├── ref-sync.ts         # Git ref → DWN record mirroring
+│   │   ├── server.ts           # Node.js HTTP server bridge
+│   │   └── verify.ts           # DID signature verification
+│   └── github-shim/            # GitHub API compatibility shim
 │       ├── index.ts            # Barrel re-export
-│       ├── auth.ts             # DID-signed push authentication
-│       ├── bundle-restore.ts   # Restore bare repos from DWN bundle records
-│       ├── bundle-sync.ts      # Post-push bundle sync to DWN
-│       ├── did-service.ts      # DID service registration
-│       ├── git-backend.ts      # Bare repo management (init, upload-pack, receive-pack)
-│       ├── http-handler.ts     # Smart HTTP protocol handler (with onRepoNotFound)
-│       ├── push-authorizer.ts  # DWN-backed push authorization
-│       ├── ref-sync.ts         # Git ref → DWN record mirroring
-│       ├── server.ts           # Node.js HTTP server bridge
-│       └── verify.ts           # DID signature verification
+│       ├── helpers.ts          # numericId, fromOpt, pagination, response builders
+│       ├── server.ts           # HTTP server, router, handleShimRequest
+│       ├── repos.ts            # GET /repos/:did/:repo
+│       ├── issues.ts           # GET /repos/:did/:repo/issues{/:number{/comments}}
+│       ├── pulls.ts            # GET /repos/:did/:repo/pulls{/:number{/reviews}}
+│       ├── releases.ts         # GET /repos/:did/:repo/releases{/tags/:tag}
+│       └── users.ts            # GET /users/:did
 ├── schemas/                    # JSON Schema files (34 files)
 │   ├── repo/
 │   ├── refs/
@@ -1408,5 +1417,6 @@ dwn-git/
     ├── push-authorizer.spec.ts # DWN push authorization tests
     ├── ref-sync.spec.ts        # Ref sync tests
     ├── verify.spec.ts          # Signature verification tests
-    └── credential-helper.spec.ts # Credential helper tests
+    ├── credential-helper.spec.ts # Credential helper tests
+    └── github-shim.spec.ts     # GitHub API shim tests (56 tests)
 ```

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ dwn-git indexer                   # Start indexer on port 8090
 dwn-git indexer --seed <did>      # Discover DIDs from a seed user
 dwn-git indexer --interval 30     # Crawl every 30 seconds
 
+# GitHub API compatibility shim
+dwn-git github-api                # Start shim on port 8181
+dwn-git github-api --port 9000    # Custom port
+
 # Activity & identity
 dwn-git log                       # Activity feed (recent issues + patches)
 dwn-git whoami                    # Show connected DID
@@ -151,6 +155,16 @@ dwn-git whoami                    # Show connected DID
 - **User profiles** — repo count, total stars received, follower/following counts
 - **REST API** — `/api/repos`, `/api/repos/search?q=`, `/api/repos/trending`, `/api/users/:did`, `/api/stats`
 - Start with `dwn-git indexer [--port <port>] [--interval <sec>] [--seed <did>]`
+
+### GitHub API Compatibility Shim
+
+- Read-only HTTP server that translates GitHub REST API v3 requests into DWN queries
+- Allows existing GitHub-compatible tools (VS Code extensions, `gh` CLI, CI systems) to read DWN data
+- DID is used as the GitHub "owner" in URLs: `GET /repos/:did/:repo/issues`
+- 10 Phase 1 endpoints: repo info, issues (list/detail/comments), pulls (list/detail/reviews), releases (list/by-tag), user profile
+- GitHub-compatible response shapes: numeric IDs, pagination (`Link` header, `per_page`), rate limit headers
+- CORS enabled, `X-GitHub-Media-Type: github.v3` header
+- Start with `dwn-git github-api [--port <port>]` (default: 8181, configurable via `DWN_GIT_GITHUB_API_PORT`)
 
 ## Architecture
 
@@ -200,6 +214,12 @@ import { createGitServer, createBundleSyncer, restoreFromBundles } from '@enbox/
 
 // Git remote helper utilities
 import { parseDidUrl, resolveGitEndpoint } from '@enbox/dwn-git/git-remote';
+
+// Indexer service
+import { IndexerStore, IndexerCrawler, handleApiRequest } from '@enbox/dwn-git/indexer';
+
+// GitHub API compatibility shim
+import { handleShimRequest, startShimServer } from '@enbox/dwn-git/github-shim';
 ```
 
 ## Development
@@ -214,7 +234,7 @@ bun test               # Run all tests
 
 ## Status
 
-**Phase 5 in progress** — working MVP with CLI commands for all 11 protocols, git transport, DID-signed push auth, ref mirroring, bundle storage, package registry, GitHub migration tool, read-only web UI, and indexer service. 610+ tests across 16 test files. See PLAN.md Section 12 for the full roadmap.
+**Phase 5 complete** — working MVP with CLI commands for all 11 protocols, git transport, DID-signed push auth, ref mirroring, bundle storage, package registry, GitHub migration tool, read-only web UI, indexer service, and GitHub API compatibility shim. 666+ tests across 17 test files. See PLAN.md Section 12 for the full roadmap.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,10 @@
     "./indexer": {
       "types": "./dist/types/indexer/index.d.ts",
       "import": "./dist/esm/indexer/index.js"
+    },
+    "./github-shim": {
+      "types": "./dist/types/github-shim/index.d.ts",
+      "import": "./dist/esm/github-shim/index.js"
     }
   },
   "keywords": [

--- a/src/cli/commands/github-api.ts
+++ b/src/cli/commands/github-api.ts
@@ -1,0 +1,30 @@
+/**
+ * `dwn-git github-api` — start the GitHub API compatibility shim.
+ *
+ * Usage:
+ *   dwn-git github-api [--port <port>]
+ *
+ * Starts a read-only HTTP server that translates GitHub REST API v3
+ * requests into DWN queries.  Default port: 8181.
+ *
+ * @module
+ */
+
+import type { AgentContext } from '../agent.js';
+
+import { flagValue } from '../flags.js';
+import { startShimServer } from '../../github-shim/server.js';
+
+// ---------------------------------------------------------------------------
+// Command
+// ---------------------------------------------------------------------------
+
+export async function githubApiCommand(ctx: AgentContext, args: string[]): Promise<void> {
+  const port = parseInt(flagValue(args, '--port') ?? process.env.DWN_GIT_GITHUB_API_PORT ?? '8181', 10);
+
+  console.log('Starting GitHub API compatibility shim...');
+  startShimServer({ ctx, port });
+
+  // Keep the process alive — the server runs until Ctrl+C.
+  await new Promise(() => {});
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -44,6 +44,7 @@
  *   dwn-git migrate releases <owner/repo>       Import releases
  *   dwn-git web [--port <port>]                Start the read-only web UI
  *   dwn-git indexer [--port] [--interval] [--seed]  Start the indexer service
+ *   dwn-git github-api [--port <port>]         Start GitHub API compatibility shim
  *   dwn-git log                                Show recent activity
  *   dwn-git serve [--port <port>]              Start the git transport server
  *   dwn-git whoami                             Show connected DID
@@ -59,6 +60,7 @@
 import { ciCommand } from './commands/ci.js';
 import { cloneCommand } from './commands/clone.js';
 import { connectAgent } from './agent.js';
+import { githubApiCommand } from './commands/github-api.js';
 import { indexerCommand } from '../indexer/main.js';
 import { initCommand } from './commands/init.js';
 import { issueCommand } from './commands/issue.js';
@@ -163,6 +165,8 @@ function printUsage(): void {
   console.log('  indexer [--port <port>] [--interval <sec>]  Start the indexer service');
   console.log('  indexer --seed <did>                        Discover DIDs from a seed');
   console.log('');
+  console.log('  github-api [--port <port>]                  Start GitHub API shim (default: 8181)');
+  console.log('');
   console.log('  log                                         Show recent activity');
   console.log('  whoami                                      Show connected DID');
   console.log('  help                                        Show this message\n');
@@ -173,6 +177,7 @@ function printUsage(): void {
   console.log('  DWN_GIT_REPOS     base path for bare repos (default: ./repos)');
   console.log('  DWN_GIT_INDEXER_PORT      indexer API port (default: 8090)');
   console.log('  DWN_GIT_INDEXER_INTERVAL  crawl interval in seconds (default: 60)');
+  console.log('  DWN_GIT_GITHUB_API_PORT   GitHub API shim port (default: 8181)');
   console.log('  GITHUB_TOKEN      GitHub API token for migration (optional, higher rate limits)');
 }
 
@@ -284,6 +289,10 @@ async function main(): Promise<void> {
 
     case 'indexer':
       await indexerCommand(ctx, rest);
+      break;
+
+    case 'github-api':
+      await githubApiCommand(ctx, rest);
       break;
 
     case 'log':

--- a/src/github-shim/helpers.ts
+++ b/src/github-shim/helpers.ts
@@ -1,0 +1,220 @@
+/**
+ * Shared helpers for the GitHub API compatibility shim.
+ *
+ * Provides DID-to-numeric-ID hashing, `from` option building, repo
+ * record lookup, GitHub-style owner objects, pagination, and standard
+ * response headers.
+ *
+ * @module
+ */
+
+import type { AgentContext } from '../cli/agent.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** GitHub-style owner sub-object synthesized from a DID. */
+export type GitHubOwner = {
+  login : string;
+  id : number;
+  type : string;
+  avatar_url : string;
+  html_url : string;
+  url : string;
+};
+
+/** Repo metadata extracted from a DWN repo record. */
+export type RepoInfo = {
+  name : string;
+  description : string;
+  defaultBranch : string;
+  contextId : string;
+  visibility : string;
+  dateCreated : string;
+  timestamp : string;
+};
+
+/** Pagination parameters parsed from query string. */
+export type PaginationParams = {
+  page : number;
+  perPage : number;
+};
+
+/** Standard JSON API response shape. */
+export type JsonResponse = {
+  status : number;
+  headers : Record<string, string>;
+  body : string;
+};
+
+// ---------------------------------------------------------------------------
+// Numeric ID from DWN identifiers
+// ---------------------------------------------------------------------------
+
+/**
+ * Deterministic numeric ID from a DWN string identifier.
+ *
+ * Uses a simple FNV-1a-inspired hash to produce a positive 32-bit
+ * integer — sufficient for GitHub API compatibility where consumers
+ * expect numeric IDs.
+ */
+export function numericId(id: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < id.length; i++) {
+    hash ^= id.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0); // ensure unsigned 32-bit
+}
+
+// ---------------------------------------------------------------------------
+// DWN query helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the `from` option for a DWN query.  When the target is the
+ * local agent's own DID we omit `from`; otherwise set it so the SDK
+ * routes the message to the remote DWN.
+ */
+export function fromOpt(ctx: AgentContext, targetDid: string): string | undefined {
+  return targetDid === ctx.did ? undefined : targetDid;
+}
+
+/**
+ * Look up the singleton repo record for a target DID.  Returns `null`
+ * if no repo record exists.
+ */
+export async function getRepoRecord(ctx: AgentContext, targetDid: string): Promise<RepoInfo | null> {
+  const from = fromOpt(ctx, targetDid);
+  const { records } = await ctx.repo.records.query('repo', { from });
+  if (records.length === 0) { return null; }
+
+  const rec = records[0];
+  const data = await rec.data.json();
+  const tags = rec.tags as Record<string, string> | undefined;
+
+  return {
+    name          : data.name ?? 'unnamed',
+    description   : data.description ?? '',
+    defaultBranch : data.defaultBranch ?? 'main',
+    contextId     : rec.contextId ?? '',
+    visibility    : tags?.visibility ?? 'public',
+    dateCreated   : rec.dateCreated,
+    timestamp     : rec.timestamp,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// GitHub-style owner object
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a GitHub-style owner sub-object from a DID.  The DID itself is
+ * used as the `login` field since DIDs are globally unique identifiers
+ * (just like GitHub usernames).
+ */
+export function buildOwner(did: string, baseUrl: string): GitHubOwner {
+  return {
+    login      : did,
+    id         : numericId(did),
+    type       : 'User',
+    avatar_url : '',
+    html_url   : `${baseUrl}/users/${did}`,
+    url        : `${baseUrl}/users/${did}`,
+  };
+}
+
+/**
+ * Build the base API URL from request context.  Defaults to
+ * `http://localhost:<port>` for local development.
+ */
+export function buildApiUrl(url: URL): string {
+  return `${url.protocol}//${url.host}`;
+}
+
+// ---------------------------------------------------------------------------
+// Pagination
+// ---------------------------------------------------------------------------
+
+/** Parse `page` and `per_page` from the URL query string. */
+export function parsePagination(url: URL): PaginationParams {
+  const page = Math.max(1, parseInt(url.searchParams.get('page') ?? '1', 10));
+  const perPage = Math.min(100, Math.max(1, parseInt(url.searchParams.get('per_page') ?? '30', 10)));
+  return { page, perPage };
+}
+
+/** Apply pagination to an array and return the slice. */
+export function paginate<T>(items: T[], params: PaginationParams): T[] {
+  const start = (params.page - 1) * params.perPage;
+  return items.slice(start, start + params.perPage);
+}
+
+/** Build Link header value for pagination. */
+export function buildLinkHeader(baseUrl: string, path: string, page: number, perPage: number, totalItems: number): string | null {
+  const lastPage = Math.max(1, Math.ceil(totalItems / perPage));
+  if (lastPage <= 1) { return null; }
+
+  const links: string[] = [];
+  if (page < lastPage) {
+    links.push(`<${baseUrl}${path}?page=${page + 1}&per_page=${perPage}>; rel="next"`);
+    links.push(`<${baseUrl}${path}?page=${lastPage}&per_page=${perPage}>; rel="last"`);
+  }
+  if (page > 1) {
+    links.push(`<${baseUrl}${path}?page=1&per_page=${perPage}>; rel="first"`);
+    links.push(`<${baseUrl}${path}?page=${page - 1}&per_page=${perPage}>; rel="prev"`);
+  }
+
+  return links.length > 0 ? links.join(', ') : null;
+}
+
+// ---------------------------------------------------------------------------
+// Response builders
+// ---------------------------------------------------------------------------
+
+/** Standard headers for all GitHub API shim responses. */
+export function baseHeaders(): Record<string, string> {
+  return {
+    'Content-Type'                 : 'application/json; charset=utf-8',
+    'X-GitHub-Media-Type'          : 'github.v3',
+    'Access-Control-Allow-Origin'  : '*',
+    'Access-Control-Allow-Headers' : 'Authorization, Accept, Content-Type',
+    'X-RateLimit-Limit'            : '5000',
+    'X-RateLimit-Remaining'        : '4999',
+    'X-RateLimit-Reset'            : String(Math.floor(Date.now() / 1000) + 3600),
+  };
+}
+
+/** Build a successful JSON response. */
+export function jsonOk(data: unknown, extraHeaders?: Record<string, string>): JsonResponse {
+  return {
+    status  : 200,
+    headers : { ...baseHeaders(), ...extraHeaders },
+    body    : JSON.stringify(data),
+  };
+}
+
+/** Build a 404 JSON response. */
+export function jsonNotFound(message: string): JsonResponse {
+  return {
+    status  : 404,
+    headers : baseHeaders(),
+    body    : JSON.stringify({ message, documentation_url: 'https://docs.github.com/rest' }),
+  };
+}
+
+/** Build a 422 JSON response (validation error). */
+export function jsonValidationError(message: string): JsonResponse {
+  return {
+    status  : 422,
+    headers : baseHeaders(),
+    body    : JSON.stringify({ message, documentation_url: 'https://docs.github.com/rest' }),
+  };
+}
+
+/** Convert an ISO date string to GitHub's ISO 8601 format. */
+export function toISODate(dateStr: string | undefined): string {
+  if (!dateStr) { return new Date(0).toISOString(); }
+  // DWN dates may already be ISO 8601; normalize to ensure consistency.
+  return new Date(dateStr).toISOString();
+}

--- a/src/github-shim/index.ts
+++ b/src/github-shim/index.ts
@@ -1,0 +1,33 @@
+/**
+ * GitHub API compatibility shim — barrel exports.
+ *
+ * @module
+ */
+
+export { handleShimRequest, startShimServer } from './server.js';
+export type { ShimServerOptions } from './server.js';
+
+export { handleGetRepo, buildRepoResponse } from './repos.js';
+export { handleGetIssue, handleListIssueComments, handleListIssues } from './issues.js';
+export { handleGetPull, handleListPullReviews, handleListPulls } from './pulls.js';
+export { handleGetReleaseByTag, handleListReleases } from './releases.js';
+export { handleGetUser } from './users.js';
+
+export {
+  buildApiUrl,
+  buildLinkHeader,
+  buildOwner,
+  fromOpt,
+  getRepoRecord,
+  numericId,
+  paginate,
+  parsePagination,
+  toISODate,
+} from './helpers.js';
+
+export type {
+  GitHubOwner,
+  JsonResponse,
+  PaginationParams,
+  RepoInfo,
+} from './helpers.js';

--- a/src/github-shim/issues.ts
+++ b/src/github-shim/issues.ts
@@ -1,0 +1,235 @@
+/**
+ * GitHub API shim — `/repos/:did/:repo/issues` endpoints.
+ *
+ * Maps DWN issue records to GitHub REST API v3 issue responses.
+ *
+ * Endpoints:
+ *   GET /repos/:did/:repo/issues              List issues
+ *   GET /repos/:did/:repo/issues/:number      Issue detail
+ *   GET /repos/:did/:repo/issues/:number/comments  Issue comments
+ *
+ * @module
+ */
+
+import type { AgentContext } from '../cli/agent.js';
+import type { JsonResponse } from './helpers.js';
+
+import { DateSort } from '@enbox/dwn-sdk-js';
+
+import {
+  buildApiUrl,
+  buildLinkHeader,
+  buildOwner,
+  fromOpt,
+  getRepoRecord,
+  jsonNotFound,
+  jsonOk,
+  numericId,
+  paginate,
+  parsePagination,
+  toISODate,
+} from './helpers.js';
+
+// ---------------------------------------------------------------------------
+// Issue object builder
+// ---------------------------------------------------------------------------
+
+function buildIssueResponse(
+  rec: any, data: any, tags: Record<string, string>,
+  targetDid: string, repoName: string, baseUrl: string,
+): Record<string, unknown> {
+  const owner = buildOwner(targetDid, baseUrl);
+  const number = parseInt(tags.number ?? data.number ?? '0', 10);
+  const state = tags.status === 'closed' ? 'closed' : 'open';
+
+  return {
+    id                 : numericId(rec.id ?? ''),
+    node_id            : rec.id ?? '',
+    url                : `${baseUrl}/repos/${targetDid}/${repoName}/issues/${number}`,
+    html_url           : `${baseUrl}/repos/${targetDid}/${repoName}/issues/${number}`,
+    repository_url     : `${baseUrl}/repos/${targetDid}/${repoName}`,
+    comments_url       : `${baseUrl}/repos/${targetDid}/${repoName}/issues/${number}/comments`,
+    number,
+    title              : data.title ?? '',
+    body               : data.body ?? null,
+    state,
+    locked             : false,
+    comments           : 0,
+    created_at         : toISODate(rec.dateCreated),
+    updated_at         : toISODate(rec.timestamp),
+    closed_at          : state === 'closed' ? toISODate(rec.timestamp) : null,
+    user               : owner,
+    author_association : 'OWNER',
+    labels             : [],
+    assignees          : [],
+    milestone          : null,
+    reactions          : { url: '', total_count: 0 },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// GET /repos/:did/:repo/issues
+// ---------------------------------------------------------------------------
+
+export async function handleListIssues(
+  ctx: AgentContext, targetDid: string, repoName: string, url: URL,
+): Promise<JsonResponse> {
+  const repo = await getRepoRecord(ctx, targetDid);
+  if (!repo) {
+    return jsonNotFound(`Repository '${repoName}' not found for DID '${targetDid}'.`);
+  }
+
+  const from = fromOpt(ctx, targetDid);
+  const baseUrl = buildApiUrl(url);
+
+  // Query params.
+  const stateFilter = url.searchParams.get('state') ?? 'open';
+  const direction = url.searchParams.get('direction') ?? 'desc';
+  const pagination = parsePagination(url);
+
+  const dateSort = direction === 'asc'
+    ? DateSort.CreatedAscending
+    : DateSort.CreatedDescending;
+
+  const { records } = await ctx.issues.records.query('repo/issue', {
+    from,
+    filter: { contextId: repo.contextId },
+    dateSort,
+  });
+
+  // Filter by state.
+  let filtered = records;
+  if (stateFilter !== 'all') {
+    filtered = records.filter((r) => {
+      const t = r.tags as Record<string, string> | undefined;
+      const s = t?.status ?? 'open';
+      return stateFilter === 'closed' ? s === 'closed' : s === 'open';
+    });
+  }
+
+  // Paginate.
+  const page = paginate(filtered, pagination);
+
+  // Build response.
+  const items: Record<string, unknown>[] = [];
+  for (const rec of page) {
+    const data = await rec.data.json();
+    const tags = (rec.tags as Record<string, string> | undefined) ?? {};
+    items.push(buildIssueResponse(rec, data, tags, targetDid, repoName, baseUrl));
+  }
+
+  const linkHeader = buildLinkHeader(
+    baseUrl, `/repos/${targetDid}/${repoName}/issues`,
+    pagination.page, pagination.perPage, filtered.length,
+  );
+  const extraHeaders: Record<string, string> = {};
+  if (linkHeader) { extraHeaders['Link'] = linkHeader; }
+
+  return jsonOk(items, extraHeaders);
+}
+
+// ---------------------------------------------------------------------------
+// GET /repos/:did/:repo/issues/:number
+// ---------------------------------------------------------------------------
+
+export async function handleGetIssue(
+  ctx: AgentContext, targetDid: string, repoName: string, number: string, url: URL,
+): Promise<JsonResponse> {
+  const repo = await getRepoRecord(ctx, targetDid);
+  if (!repo) {
+    return jsonNotFound(`Repository '${repoName}' not found for DID '${targetDid}'.`);
+  }
+
+  const from = fromOpt(ctx, targetDid);
+  const baseUrl = buildApiUrl(url);
+
+  const { records } = await ctx.issues.records.query('repo/issue', {
+    from,
+    filter: { contextId: repo.contextId, tags: { number } },
+  });
+
+  if (records.length === 0) {
+    return jsonNotFound(`Issue #${number} not found.`);
+  }
+
+  const rec = records[0];
+  const data = await rec.data.json();
+  const tags = (rec.tags as Record<string, string> | undefined) ?? {};
+
+  // Fetch comment count.
+  const { records: comments } = await ctx.issues.records.query('repo/issue/comment' as any, {
+    from,
+    filter: { contextId: rec.contextId },
+  });
+
+  const issue = buildIssueResponse(rec, data, tags, targetDid, repoName, baseUrl);
+  issue.comments = comments.length;
+
+  return jsonOk(issue);
+}
+
+// ---------------------------------------------------------------------------
+// GET /repos/:did/:repo/issues/:number/comments
+// ---------------------------------------------------------------------------
+
+export async function handleListIssueComments(
+  ctx: AgentContext, targetDid: string, repoName: string, number: string, url: URL,
+): Promise<JsonResponse> {
+  const repo = await getRepoRecord(ctx, targetDid);
+  if (!repo) {
+    return jsonNotFound(`Repository '${repoName}' not found for DID '${targetDid}'.`);
+  }
+
+  const from = fromOpt(ctx, targetDid);
+  const baseUrl = buildApiUrl(url);
+  const pagination = parsePagination(url);
+
+  // Find the issue first.
+  const { records: issues } = await ctx.issues.records.query('repo/issue', {
+    from,
+    filter: { contextId: repo.contextId, tags: { number } },
+  });
+
+  if (issues.length === 0) {
+    return jsonNotFound(`Issue #${number} not found.`);
+  }
+
+  const issueRec = issues[0];
+  const owner = buildOwner(targetDid, baseUrl);
+
+  // Fetch comments.
+  const { records: comments } = await ctx.issues.records.query('repo/issue/comment' as any, {
+    from,
+    filter   : { contextId: issueRec.contextId },
+    dateSort : DateSort.CreatedAscending,
+  });
+
+  const paged = paginate(comments, pagination);
+
+  const items: Record<string, unknown>[] = [];
+  for (const comment of paged) {
+    const cData = await comment.data.json();
+    items.push({
+      id                 : numericId(comment.id ?? ''),
+      node_id            : comment.id ?? '',
+      url                : `${baseUrl}/repos/${targetDid}/${repoName}/issues/comments/${numericId(comment.id ?? '')}`,
+      html_url           : `${baseUrl}/repos/${targetDid}/${repoName}/issues/${number}#issuecomment-${numericId(comment.id ?? '')}`,
+      issue_url          : `${baseUrl}/repos/${targetDid}/${repoName}/issues/${number}`,
+      body               : cData.body ?? '',
+      created_at         : toISODate(comment.dateCreated),
+      updated_at         : toISODate(comment.timestamp),
+      user               : owner,
+      author_association : 'OWNER',
+      reactions          : { url: '', total_count: 0 },
+    });
+  }
+
+  const linkHeader = buildLinkHeader(
+    baseUrl, `/repos/${targetDid}/${repoName}/issues/${number}/comments`,
+    pagination.page, pagination.perPage, comments.length,
+  );
+  const extraHeaders: Record<string, string> = {};
+  if (linkHeader) { extraHeaders['Link'] = linkHeader; }
+
+  return jsonOk(items, extraHeaders);
+}

--- a/src/github-shim/pulls.ts
+++ b/src/github-shim/pulls.ts
@@ -1,0 +1,269 @@
+/**
+ * GitHub API shim — `/repos/:did/:repo/pulls` endpoints.
+ *
+ * Maps DWN patch records to GitHub REST API v3 pull request responses.
+ *
+ * Endpoints:
+ *   GET /repos/:did/:repo/pulls               List pull requests
+ *   GET /repos/:did/:repo/pulls/:number       Pull request detail
+ *   GET /repos/:did/:repo/pulls/:number/reviews  Pull request reviews
+ *
+ * Status mapping:
+ *   - `open`   -> state: "open"
+ *   - `closed` -> state: "closed", merged: false
+ *   - `merged` -> state: "closed", merged: true
+ *
+ * @module
+ */
+
+import type { AgentContext } from '../cli/agent.js';
+import type { JsonResponse } from './helpers.js';
+
+import { DateSort } from '@enbox/dwn-sdk-js';
+
+import {
+  buildApiUrl,
+  buildLinkHeader,
+  buildOwner,
+  fromOpt,
+  getRepoRecord,
+  jsonNotFound,
+  jsonOk,
+  numericId,
+  paginate,
+  parsePagination,
+  toISODate,
+} from './helpers.js';
+
+// ---------------------------------------------------------------------------
+// Verdict -> GitHub review state mapping
+// ---------------------------------------------------------------------------
+
+const VERDICT_MAP: Record<string, string> = {
+  approve : 'APPROVED',
+  reject  : 'CHANGES_REQUESTED',
+  comment : 'COMMENTED',
+};
+
+// ---------------------------------------------------------------------------
+// Pull request object builder
+// ---------------------------------------------------------------------------
+
+function buildPullResponse(
+  rec: any, data: any, tags: Record<string, string>,
+  targetDid: string, repoName: string, baseUrl: string,
+): Record<string, unknown> {
+  const owner = buildOwner(targetDid, baseUrl);
+  const number = parseInt(tags.number ?? data.number ?? '0', 10);
+  const dwnStatus = tags.status ?? 'open';
+  const merged = dwnStatus === 'merged';
+  const state = dwnStatus === 'open' ? 'open' : 'closed';
+  const baseBranch = tags.baseBranch ?? 'main';
+  const headBranch = tags.headBranch ?? '';
+
+  return {
+    id                  : numericId(rec.id ?? ''),
+    node_id             : rec.id ?? '',
+    url                 : `${baseUrl}/repos/${targetDid}/${repoName}/pulls/${number}`,
+    html_url            : `${baseUrl}/repos/${targetDid}/${repoName}/pulls/${number}`,
+    diff_url            : `${baseUrl}/repos/${targetDid}/${repoName}/pulls/${number}.diff`,
+    patch_url           : `${baseUrl}/repos/${targetDid}/${repoName}/pulls/${number}.patch`,
+    issue_url           : `${baseUrl}/repos/${targetDid}/${repoName}/issues/${number}`,
+    commits_url         : `${baseUrl}/repos/${targetDid}/${repoName}/pulls/${number}/commits`,
+    review_comments_url : `${baseUrl}/repos/${targetDid}/${repoName}/pulls/${number}/comments`,
+    comments_url        : `${baseUrl}/repos/${targetDid}/${repoName}/issues/${number}/comments`,
+    number,
+    title               : data.title ?? '',
+    body                : data.body ?? null,
+    state,
+    locked              : false,
+    merged,
+    mergeable           : state === 'open' ? true : null,
+    merge_commit_sha    : merged ? '0000000000000000000000000000000000000000' : null,
+    merged_at           : merged ? toISODate(rec.timestamp) : null,
+    merged_by           : merged ? owner : null,
+    created_at          : toISODate(rec.dateCreated),
+    updated_at          : toISODate(rec.timestamp),
+    closed_at           : state === 'closed' ? toISODate(rec.timestamp) : null,
+    user                : owner,
+    author_association  : 'OWNER',
+    draft               : false,
+    head                : {
+      label : `${targetDid}:${headBranch}`,
+      ref   : headBranch,
+      sha   : '',
+    },
+    base: {
+      label : `${targetDid}:${baseBranch}`,
+      ref   : baseBranch,
+      sha   : '',
+    },
+    labels              : [],
+    assignees           : [],
+    milestone           : null,
+    requested_reviewers : [],
+    commits             : 0,
+    additions           : 0,
+    deletions           : 0,
+    changed_files       : 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// GET /repos/:did/:repo/pulls
+// ---------------------------------------------------------------------------
+
+export async function handleListPulls(
+  ctx: AgentContext, targetDid: string, repoName: string, url: URL,
+): Promise<JsonResponse> {
+  const repo = await getRepoRecord(ctx, targetDid);
+  if (!repo) {
+    return jsonNotFound(`Repository '${repoName}' not found for DID '${targetDid}'.`);
+  }
+
+  const from = fromOpt(ctx, targetDid);
+  const baseUrl = buildApiUrl(url);
+
+  const stateFilter = url.searchParams.get('state') ?? 'open';
+  const direction = url.searchParams.get('direction') ?? 'desc';
+  const pagination = parsePagination(url);
+
+  const dateSort = direction === 'asc'
+    ? DateSort.CreatedAscending
+    : DateSort.CreatedDescending;
+
+  const { records } = await ctx.patches.records.query('repo/patch', {
+    from,
+    filter: { contextId: repo.contextId },
+    dateSort,
+  });
+
+  // Filter by state — GitHub treats `closed` as "closed or merged".
+  let filtered = records;
+  if (stateFilter !== 'all') {
+    filtered = records.filter((r) => {
+      const t = r.tags as Record<string, string> | undefined;
+      const s = t?.status ?? 'open';
+      if (stateFilter === 'open') { return s === 'open'; }
+      // 'closed' includes both closed and merged.
+      return s === 'closed' || s === 'merged';
+    });
+  }
+
+  const page = paginate(filtered, pagination);
+
+  const items: Record<string, unknown>[] = [];
+  for (const rec of page) {
+    const data = await rec.data.json();
+    const tags = (rec.tags as Record<string, string> | undefined) ?? {};
+    items.push(buildPullResponse(rec, data, tags, targetDid, repoName, baseUrl));
+  }
+
+  const linkHeader = buildLinkHeader(
+    baseUrl, `/repos/${targetDid}/${repoName}/pulls`,
+    pagination.page, pagination.perPage, filtered.length,
+  );
+  const extraHeaders: Record<string, string> = {};
+  if (linkHeader) { extraHeaders['Link'] = linkHeader; }
+
+  return jsonOk(items, extraHeaders);
+}
+
+// ---------------------------------------------------------------------------
+// GET /repos/:did/:repo/pulls/:number
+// ---------------------------------------------------------------------------
+
+export async function handleGetPull(
+  ctx: AgentContext, targetDid: string, repoName: string, number: string, url: URL,
+): Promise<JsonResponse> {
+  const repo = await getRepoRecord(ctx, targetDid);
+  if (!repo) {
+    return jsonNotFound(`Repository '${repoName}' not found for DID '${targetDid}'.`);
+  }
+
+  const from = fromOpt(ctx, targetDid);
+  const baseUrl = buildApiUrl(url);
+
+  const { records } = await ctx.patches.records.query('repo/patch', {
+    from,
+    filter: { contextId: repo.contextId, tags: { number } },
+  });
+
+  if (records.length === 0) {
+    return jsonNotFound(`Pull request #${number} not found.`);
+  }
+
+  const rec = records[0];
+  const data = await rec.data.json();
+  const tags = (rec.tags as Record<string, string> | undefined) ?? {};
+
+  return jsonOk(buildPullResponse(rec, data, tags, targetDid, repoName, baseUrl));
+}
+
+// ---------------------------------------------------------------------------
+// GET /repos/:did/:repo/pulls/:number/reviews
+// ---------------------------------------------------------------------------
+
+export async function handleListPullReviews(
+  ctx: AgentContext, targetDid: string, repoName: string, number: string, url: URL,
+): Promise<JsonResponse> {
+  const repo = await getRepoRecord(ctx, targetDid);
+  if (!repo) {
+    return jsonNotFound(`Repository '${repoName}' not found for DID '${targetDid}'.`);
+  }
+
+  const from = fromOpt(ctx, targetDid);
+  const baseUrl = buildApiUrl(url);
+  const pagination = parsePagination(url);
+
+  // Find the patch first.
+  const { records: patches } = await ctx.patches.records.query('repo/patch', {
+    from,
+    filter: { contextId: repo.contextId, tags: { number } },
+  });
+
+  if (patches.length === 0) {
+    return jsonNotFound(`Pull request #${number} not found.`);
+  }
+
+  const patchRec = patches[0];
+  const owner = buildOwner(targetDid, baseUrl);
+
+  // Fetch reviews.
+  const { records: reviews } = await ctx.patches.records.query('repo/patch/review' as any, {
+    from,
+    filter   : { contextId: patchRec.contextId },
+    dateSort : DateSort.CreatedAscending,
+  });
+
+  const paged = paginate(reviews, pagination);
+
+  const items: Record<string, unknown>[] = [];
+  for (const review of paged) {
+    const rData = await review.data.json();
+    const rTags = (review.tags as Record<string, string> | undefined) ?? {};
+    const verdict = rTags.verdict ?? 'comment';
+
+    items.push({
+      id                 : numericId(review.id ?? ''),
+      node_id            : review.id ?? '',
+      user               : owner,
+      body               : rData.body ?? '',
+      state              : VERDICT_MAP[verdict] ?? 'COMMENTED',
+      html_url           : `${baseUrl}/repos/${targetDid}/${repoName}/pulls/${number}#pullrequestreview-${numericId(review.id ?? '')}`,
+      pull_request_url   : `${baseUrl}/repos/${targetDid}/${repoName}/pulls/${number}`,
+      submitted_at       : toISODate(review.dateCreated),
+      commit_id          : '',
+      author_association : 'OWNER',
+    });
+  }
+
+  const linkHeader = buildLinkHeader(
+    baseUrl, `/repos/${targetDid}/${repoName}/pulls/${number}/reviews`,
+    pagination.page, pagination.perPage, reviews.length,
+  );
+  const extraHeaders: Record<string, string> = {};
+  if (linkHeader) { extraHeaders['Link'] = linkHeader; }
+
+  return jsonOk(items, extraHeaders);
+}

--- a/src/github-shim/releases.ts
+++ b/src/github-shim/releases.ts
@@ -1,0 +1,138 @@
+/**
+ * GitHub API shim — `/repos/:did/:repo/releases` endpoints.
+ *
+ * Maps DWN release records to GitHub REST API v3 release responses.
+ *
+ * Endpoints:
+ *   GET /repos/:did/:repo/releases            List releases
+ *   GET /repos/:did/:repo/releases/tags/:tag  Release by tag name
+ *
+ * @module
+ */
+
+import type { AgentContext } from '../cli/agent.js';
+import type { JsonResponse } from './helpers.js';
+
+import { DateSort } from '@enbox/dwn-sdk-js';
+
+import {
+  buildApiUrl,
+  buildLinkHeader,
+  buildOwner,
+  fromOpt,
+  getRepoRecord,
+  jsonNotFound,
+  jsonOk,
+  numericId,
+  paginate,
+  parsePagination,
+  toISODate,
+} from './helpers.js';
+
+// ---------------------------------------------------------------------------
+// Release object builder
+// ---------------------------------------------------------------------------
+
+function buildReleaseResponse(
+  rec: any, data: any, tags: Record<string, unknown>,
+  targetDid: string, repoName: string, baseUrl: string,
+): Record<string, unknown> {
+  const owner = buildOwner(targetDid, baseUrl);
+  const tagName = (tags.tagName as string) ?? '';
+  const prerelease = tags.prerelease === true;
+  const draft = tags.draft === true;
+  const id = numericId(rec.id ?? '');
+
+  return {
+    id,
+    node_id          : rec.id ?? '',
+    url              : `${baseUrl}/repos/${targetDid}/${repoName}/releases/${id}`,
+    html_url         : `${baseUrl}/repos/${targetDid}/${repoName}/releases/tags/${tagName}`,
+    assets_url       : `${baseUrl}/repos/${targetDid}/${repoName}/releases/${id}/assets`,
+    upload_url       : `${baseUrl}/repos/${targetDid}/${repoName}/releases/${id}/assets{?name,label}`,
+    tarball_url      : `${baseUrl}/repos/${targetDid}/${repoName}/tarball/${tagName}`,
+    zipball_url      : `${baseUrl}/repos/${targetDid}/${repoName}/zipball/${tagName}`,
+    tag_name         : tagName,
+    target_commitish : 'main',
+    name             : data.name ?? tagName,
+    body             : data.body ?? '',
+    draft,
+    prerelease,
+    created_at       : toISODate(rec.dateCreated),
+    published_at     : toISODate(rec.dateCreated),
+    author           : owner,
+    assets           : [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// GET /repos/:did/:repo/releases
+// ---------------------------------------------------------------------------
+
+export async function handleListReleases(
+  ctx: AgentContext, targetDid: string, repoName: string, url: URL,
+): Promise<JsonResponse> {
+  const repo = await getRepoRecord(ctx, targetDid);
+  if (!repo) {
+    return jsonNotFound(`Repository '${repoName}' not found for DID '${targetDid}'.`);
+  }
+
+  const from = fromOpt(ctx, targetDid);
+  const baseUrl = buildApiUrl(url);
+  const pagination = parsePagination(url);
+
+  const { records } = await ctx.releases.records.query('repo/release' as any, {
+    from,
+    filter   : { contextId: repo.contextId },
+    dateSort : DateSort.CreatedDescending,
+  });
+
+  const paged = paginate(records, pagination);
+
+  const items: Record<string, unknown>[] = [];
+  for (const rec of paged) {
+    const data = await rec.data.json();
+    const tags = (rec.tags as Record<string, unknown> | undefined) ?? {};
+    items.push(buildReleaseResponse(rec, data, tags, targetDid, repoName, baseUrl));
+  }
+
+  const linkHeader = buildLinkHeader(
+    baseUrl, `/repos/${targetDid}/${repoName}/releases`,
+    pagination.page, pagination.perPage, records.length,
+  );
+  const extraHeaders: Record<string, string> = {};
+  if (linkHeader) { extraHeaders['Link'] = linkHeader; }
+
+  return jsonOk(items, extraHeaders);
+}
+
+// ---------------------------------------------------------------------------
+// GET /repos/:did/:repo/releases/tags/:tag
+// ---------------------------------------------------------------------------
+
+export async function handleGetReleaseByTag(
+  ctx: AgentContext, targetDid: string, repoName: string, tag: string, url: URL,
+): Promise<JsonResponse> {
+  const repo = await getRepoRecord(ctx, targetDid);
+  if (!repo) {
+    return jsonNotFound(`Repository '${repoName}' not found for DID '${targetDid}'.`);
+  }
+
+  const from = fromOpt(ctx, targetDid);
+  const baseUrl = buildApiUrl(url);
+
+  const { records } = await ctx.releases.records.query('repo/release' as any, {
+    from,
+    filter: { contextId: repo.contextId, tags: { tagName: tag } },
+  });
+
+  if (records.length === 0) {
+    return jsonNotFound(`Release with tag '${tag}' not found.`);
+  }
+
+  const rec = records[0];
+  const data = await rec.data.json();
+  const tags = (rec.tags as Record<string, unknown> | undefined) ?? {};
+
+  return jsonOk(buildReleaseResponse(rec, data, tags, targetDid, repoName, baseUrl));
+}

--- a/src/github-shim/repos.ts
+++ b/src/github-shim/repos.ts
@@ -1,0 +1,95 @@
+/**
+ * GitHub API shim — `/repos/:did/:repo` endpoint.
+ *
+ * Maps the DWN singleton repo record to a GitHub REST API v3
+ * repository response.  The `:repo` segment is validated against the
+ * stored repo name but is otherwise informational — repos are singletons
+ * per DID in dwn-git.
+ *
+ * @module
+ */
+
+import type { AgentContext } from '../cli/agent.js';
+import type { JsonResponse, RepoInfo } from './helpers.js';
+
+import {
+  buildApiUrl,
+  buildOwner,
+  getRepoRecord,
+  jsonNotFound,
+  jsonOk,
+  numericId,
+  toISODate,
+} from './helpers.js';
+
+// ---------------------------------------------------------------------------
+// GET /repos/:did/:repo
+// ---------------------------------------------------------------------------
+
+/** Build a GitHub-style repository object from DWN data. */
+export function buildRepoResponse(
+  repo: RepoInfo, targetDid: string, repoName: string, baseUrl: string,
+): Record<string, unknown> {
+  const owner = buildOwner(targetDid, baseUrl);
+  const fullName = `${targetDid}/${repoName}`;
+
+  return {
+    id                : numericId(repo.contextId || `${targetDid}/repo`),
+    node_id           : repo.contextId || '',
+    name              : repoName,
+    full_name         : fullName,
+    private           : repo.visibility !== 'public',
+    owner,
+    html_url          : `${baseUrl}/repos/${fullName}`,
+    description       : repo.description || null,
+    fork              : false,
+    url               : `${baseUrl}/repos/${fullName}`,
+    archive_url       : `${baseUrl}/repos/${fullName}/{archive_format}{/ref}`,
+    issues_url        : `${baseUrl}/repos/${fullName}/issues{/number}`,
+    pulls_url         : `${baseUrl}/repos/${fullName}/pulls{/number}`,
+    releases_url      : `${baseUrl}/repos/${fullName}/releases{/id}`,
+    created_at        : toISODate(repo.dateCreated),
+    updated_at        : toISODate(repo.timestamp),
+    pushed_at         : toISODate(repo.timestamp),
+    git_url           : `did://${targetDid}/${repoName}.git`,
+    clone_url         : `did://${targetDid}/${repoName}.git`,
+    default_branch    : repo.defaultBranch,
+    visibility        : repo.visibility,
+    // Counts — zero unless enriched by an indexer.
+    stargazers_count  : 0,
+    watchers_count    : 0,
+    forks_count       : 0,
+    open_issues_count : 0,
+    // Standard GitHub fields with sensible defaults.
+    language          : null,
+    has_issues        : true,
+    has_projects      : false,
+    has_wiki          : true,
+    has_pages         : false,
+    has_downloads     : true,
+    archived          : false,
+    disabled          : false,
+    license           : null,
+    topics            : [],
+    forks             : 0,
+    watchers          : 0,
+    size              : 0,
+  };
+}
+
+/**
+ * Handle `GET /repos/:did/:repo`.
+ *
+ * Returns a GitHub-style repository JSON response.
+ */
+export async function handleGetRepo(
+  ctx: AgentContext, targetDid: string, repoName: string, url: URL,
+): Promise<JsonResponse> {
+  const repo = await getRepoRecord(ctx, targetDid);
+  if (!repo) {
+    return jsonNotFound(`Repository '${repoName}' not found for DID '${targetDid}'.`);
+  }
+
+  const baseUrl = buildApiUrl(url);
+  return jsonOk(buildRepoResponse(repo, targetDid, repo.name, baseUrl));
+}

--- a/src/github-shim/server.ts
+++ b/src/github-shim/server.ts
@@ -1,0 +1,229 @@
+/**
+ * GitHub API compatibility shim — HTTP server and router.
+ *
+ * Translates GitHub REST API v3 requests into DWN queries and returns
+ * GitHub-compatible JSON responses.  This allows existing tools that
+ * speak the GitHub API (VS Code extensions, `gh` CLI, CI/CD systems)
+ * to read data from any DWN-enabled git forge.
+ *
+ * Phase 1 is read-only — only GET endpoints are supported.
+ *
+ * URL scheme:
+ *   GET /repos/:did/:repo                          Repository info
+ *   GET /repos/:did/:repo/issues                   List issues
+ *   GET /repos/:did/:repo/issues/:number           Issue detail
+ *   GET /repos/:did/:repo/issues/:number/comments  Issue comments
+ *   GET /repos/:did/:repo/pulls                    List pull requests
+ *   GET /repos/:did/:repo/pulls/:number            Pull request detail
+ *   GET /repos/:did/:repo/pulls/:number/reviews    Pull request reviews
+ *   GET /repos/:did/:repo/releases                 List releases
+ *   GET /repos/:did/:repo/releases/tags/:tag       Release by tag
+ *   GET /users/:did                                User profile
+ *
+ * @module
+ */
+
+import type { AgentContext } from '../cli/agent.js';
+import type { JsonResponse } from './helpers.js';
+
+import type { Server } from 'node:http';
+
+import { createServer } from 'node:http';
+
+import { handleGetRepo } from './repos.js';
+import { handleGetUser } from './users.js';
+
+import { baseHeaders, jsonNotFound } from './helpers.js';
+import { handleGetIssue, handleListIssueComments, handleListIssues } from './issues.js';
+import { handleGetPull, handleListPullReviews, handleListPulls } from './pulls.js';
+import { handleGetReleaseByTag, handleListReleases } from './releases.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ShimServerOptions = {
+  ctx : AgentContext;
+  port : number;
+};
+
+// ---------------------------------------------------------------------------
+// DID extraction regex
+// ---------------------------------------------------------------------------
+
+/**
+ * DID methods use the pattern `did:<method>:<id>`.  We capture the full
+ * DID and the remaining path segments.
+ */
+const REPOS_RE = /^\/repos\/(did:[a-z0-9]+:[a-zA-Z0-9._:%-]+)\/([^/]+)(\/.*)?$/;
+const USERS_RE = /^\/users\/(did:[a-z0-9]+:[a-zA-Z0-9._:%-]+)$/;
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+/**
+ * Route an incoming request to the appropriate handler.
+ *
+ * This function is exported for testing — tests can call it directly
+ * with a constructed URL without starting an HTTP server.
+ */
+export async function handleShimRequest(
+  ctx: AgentContext,
+  url: URL,
+): Promise<JsonResponse> {
+  const path = url.pathname;
+
+  // -------------------------------------------------------------------------
+  // GET /users/:did
+  // -------------------------------------------------------------------------
+  const userMatch = path.match(USERS_RE);
+  if (userMatch) {
+    return handleGetUser(userMatch[1], url);
+  }
+
+  // -------------------------------------------------------------------------
+  // GET /repos/:did/:repo/...
+  // -------------------------------------------------------------------------
+  const repoMatch = path.match(REPOS_RE);
+  if (!repoMatch) {
+    return jsonNotFound('Not found');
+  }
+
+  const targetDid = repoMatch[1];
+  const repoName = repoMatch[2];
+  const rest = repoMatch[3] ?? '';
+
+  // Try/catch — DID resolution failures should return 502.
+  try {
+    return await dispatchRepoRoute(ctx, targetDid, repoName, rest, url);
+  } catch (err) {
+    const msg = (err as Error).message ?? 'Unknown error';
+    return {
+      status  : 502,
+      headers : baseHeaders(),
+      body    : JSON.stringify({ message: `DWN error: ${msg}` }),
+    };
+  }
+}
+
+/**
+ * Dispatch to the correct handler within the `/repos/:did/:repo/...`
+ * namespace.
+ */
+async function dispatchRepoRoute(
+  ctx: AgentContext, targetDid: string, repoName: string, rest: string, url: URL,
+): Promise<JsonResponse> {
+  // GET /repos/:did/:repo
+  if (rest === '' || rest === '/') {
+    return handleGetRepo(ctx, targetDid, repoName, url);
+  }
+
+  // GET /repos/:did/:repo/issues
+  if (rest === '/issues') {
+    return handleListIssues(ctx, targetDid, repoName, url);
+  }
+
+  // GET /repos/:did/:repo/pulls
+  if (rest === '/pulls') {
+    return handleListPulls(ctx, targetDid, repoName, url);
+  }
+
+  // GET /repos/:did/:repo/releases
+  if (rest === '/releases') {
+    return handleListReleases(ctx, targetDid, repoName, url);
+  }
+
+  // GET /repos/:did/:repo/releases/tags/:tag
+  const releaseTagMatch = rest.match(/^\/releases\/tags\/(.+)$/);
+  if (releaseTagMatch) {
+    return handleGetReleaseByTag(ctx, targetDid, repoName, releaseTagMatch[1], url);
+  }
+
+  // GET /repos/:did/:repo/issues/:number/comments
+  const issueCommentsMatch = rest.match(/^\/issues\/(\d+)\/comments$/);
+  if (issueCommentsMatch) {
+    return handleListIssueComments(ctx, targetDid, repoName, issueCommentsMatch[1], url);
+  }
+
+  // GET /repos/:did/:repo/issues/:number
+  const issueMatch = rest.match(/^\/issues\/(\d+)$/);
+  if (issueMatch) {
+    return handleGetIssue(ctx, targetDid, repoName, issueMatch[1], url);
+  }
+
+  // GET /repos/:did/:repo/pulls/:number/reviews
+  const pullReviewsMatch = rest.match(/^\/pulls\/(\d+)\/reviews$/);
+  if (pullReviewsMatch) {
+    return handleListPullReviews(ctx, targetDid, repoName, pullReviewsMatch[1], url);
+  }
+
+  // GET /repos/:did/:repo/pulls/:number
+  const pullMatch = rest.match(/^\/pulls\/(\d+)$/);
+  if (pullMatch) {
+    return handleGetPull(ctx, targetDid, repoName, pullMatch[1], url);
+  }
+
+  return jsonNotFound('Not found');
+}
+
+// ---------------------------------------------------------------------------
+// Server
+// ---------------------------------------------------------------------------
+
+/** Start the GitHub API shim server. Returns the server instance. */
+export function startShimServer(options: ShimServerOptions): Server {
+  const { ctx, port } = options;
+
+  const server = createServer(async (req, res) => {
+    // Handle CORS preflight.
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204, {
+        'Access-Control-Allow-Origin'  : '*',
+        'Access-Control-Allow-Methods' : 'GET, OPTIONS',
+        'Access-Control-Allow-Headers' : 'Authorization, Accept, Content-Type',
+        'Access-Control-Max-Age'       : '86400',
+      });
+      res.end();
+      return;
+    }
+
+    // Only support GET.
+    if (req.method !== 'GET') {
+      res.writeHead(405, baseHeaders());
+      res.end(JSON.stringify({ message: 'Method not allowed. This shim is read-only (Phase 1).' }));
+      return;
+    }
+
+    try {
+      const url = new URL(req.url ?? '/', `http://localhost:${port}`);
+      const result = await handleShimRequest(ctx, url);
+
+      res.writeHead(result.status, result.headers);
+      res.end(result.body);
+    } catch (err) {
+      console.error(`[github-shim] Error: ${(err as Error).message}`);
+      res.writeHead(500, baseHeaders());
+      res.end(JSON.stringify({ message: 'Internal server error' }));
+    }
+  });
+
+  server.listen(port, () => {
+    console.log(`[github-shim] GitHub API compatibility shim running at http://localhost:${port}`);
+    console.log('[github-shim] Phase 1: read-only endpoints');
+    console.log('[github-shim] Endpoints:');
+    console.log('  GET /repos/:did/:repo                  Repository info');
+    console.log('  GET /repos/:did/:repo/issues           List issues');
+    console.log('  GET /repos/:did/:repo/issues/:number   Issue detail');
+    console.log('  GET /repos/:did/:repo/issues/:n/comments  Issue comments');
+    console.log('  GET /repos/:did/:repo/pulls            List pull requests');
+    console.log('  GET /repos/:did/:repo/pulls/:number    Pull request detail');
+    console.log('  GET /repos/:did/:repo/pulls/:n/reviews Pull request reviews');
+    console.log('  GET /repos/:did/:repo/releases         List releases');
+    console.log('  GET /repos/:did/:repo/releases/tags/:t Release by tag');
+    console.log('  GET /users/:did                        User profile');
+    console.log('');
+  });
+
+  return server;
+}

--- a/src/github-shim/users.ts
+++ b/src/github-shim/users.ts
@@ -1,0 +1,63 @@
+/**
+ * GitHub API shim — `/users/:did` endpoint.
+ *
+ * Synthesizes a GitHub-style user object from a DID.  Since DIDs are
+ * self-sovereign identifiers, we don't have profile data beyond the
+ * DID itself — fields like `name`, `bio`, etc. are left empty.
+ *
+ * @module
+ */
+
+import type { JsonResponse } from './helpers.js';
+
+import {
+  buildApiUrl,
+  jsonOk,
+  numericId,
+  toISODate,
+} from './helpers.js';
+
+// ---------------------------------------------------------------------------
+// GET /users/:did
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle `GET /users/:did`.
+ *
+ * Returns a GitHub-style user profile JSON response.
+ */
+export async function handleGetUser(
+  targetDid: string, url: URL,
+): Promise<JsonResponse> {
+  const baseUrl = buildApiUrl(url);
+  const id = numericId(targetDid);
+
+  const user = {
+    login            : targetDid,
+    id,
+    node_id          : targetDid,
+    avatar_url       : '',
+    gravatar_id      : '',
+    url              : `${baseUrl}/users/${targetDid}`,
+    html_url         : `${baseUrl}/users/${targetDid}`,
+    repos_url        : `${baseUrl}/users/${targetDid}/repos`,
+    type             : 'User',
+    site_admin       : false,
+    name             : null,
+    company          : null,
+    blog             : '',
+    location         : null,
+    email            : null,
+    hireable         : null,
+    bio              : null,
+    twitter_username : null,
+    public_repos     : 0,
+    public_gists     : 0,
+    followers        : 0,
+    following        : 0,
+    created_at       : toISODate(undefined),
+    updated_at       : toISODate(undefined),
+  };
+
+  return jsonOk(user);
+}


### PR DESCRIPTION
## Summary

- Adds a read-only HTTP server that translates GitHub REST API v3 requests into DWN queries, enabling existing GitHub-compatible tools (VS Code extensions, `gh` CLI, CI systems) to read data from any DWN-enabled forge
- Implements 10 Phase 1 GET endpoints: repo info, issues (list/detail/comments), pulls (list/detail/reviews), releases (list/by-tag), and user profile
- Includes 56 new tests (163 assertions); full suite: **666 pass, 0 fail** across 17 test files

## Endpoints

| Endpoint | Description |
|---|---|
| `GET /repos/:did/:repo` | Repository info |
| `GET /repos/:did/:repo/issues` | List issues (`?state=`, `?per_page=`, `?page=`) |
| `GET /repos/:did/:repo/issues/:number` | Issue detail with comment count |
| `GET /repos/:did/:repo/issues/:number/comments` | Issue comments |
| `GET /repos/:did/:repo/pulls` | List pull requests |
| `GET /repos/:did/:repo/pulls/:number` | Pull request detail (merged state) |
| `GET /repos/:did/:repo/pulls/:number/reviews` | Pull request reviews |
| `GET /repos/:did/:repo/releases` | List releases |
| `GET /repos/:did/:repo/releases/tags/:tag` | Release by tag |
| `GET /users/:did` | User profile |

## Design

- **DID as owner**: DIDs are used as GitHub "owner" in URLs — globally unique like usernames
- **Deterministic numeric IDs**: FNV-1a hash of DWN record IDs for GitHub's expected `id` fields
- **Pagination**: GitHub-compatible `Link` header, `per_page`/`page` query params
- **Status mapping**: Patch `merged` → `state: "closed"` + `merged: true`; review `approve` → `APPROVED`, `reject` → `CHANGES_REQUESTED`
- **Headers**: `Content-Type: application/json`, `X-GitHub-Media-Type: github.v3`, CORS, rate limit headers
- **Remote DWN queries**: Same `from:` parameter pattern as the web UI and indexer

## New files

```
src/github-shim/helpers.ts     — numericId(), fromOpt(), pagination, response builders
src/github-shim/server.ts      — HTTP server, router, handleShimRequest()
src/github-shim/repos.ts       — GET /repos/:did/:repo
src/github-shim/issues.ts      — Issues list, detail, comments
src/github-shim/pulls.ts       — Pulls list, detail, reviews
src/github-shim/releases.ts    — Releases list, by-tag
src/github-shim/users.ts       — GET /users/:did
src/github-shim/index.ts       — Barrel exports
src/cli/commands/github-api.ts  — CLI command
tests/github-shim.spec.ts      — 56 tests
```

## Usage

```bash
dwn-git github-api                # Start shim on port 8181
dwn-git github-api --port 9000    # Custom port

# Then use any GitHub-compatible tool:
curl http://localhost:8181/repos/did:dht:abc123/my-repo/issues
```