### PR TITLE
feat: package manager shims — npm, Go, OCI/Docker

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,22 @@
     "./resolver": {
       "types": "./dist/types/resolver/index.d.ts",
       "import": "./dist/esm/resolver/index.js"
+    },
+    "./shims": {
+      "types": "./dist/types/shims/index.d.ts",
+      "import": "./dist/esm/shims/index.js"
+    },
+    "./shims/npm": {
+      "types": "./dist/types/shims/npm/index.d.ts",
+      "import": "./dist/esm/shims/npm/index.js"
+    },
+    "./shims/go": {
+      "types": "./dist/types/shims/go/index.d.ts",
+      "import": "./dist/esm/shims/go/index.js"
+    },
+    "./shims/oci": {
+      "types": "./dist/types/shims/oci/index.d.ts",
+      "import": "./dist/esm/shims/oci/index.js"
     }
   },
   "keywords": [

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -50,6 +50,9 @@
  *   dwn-git web [--port <port>]                Start the read-only web UI
  *   dwn-git indexer [--port] [--interval] [--seed]  Start the indexer service
  *   dwn-git github-api [--port <port>]         Start GitHub API compatibility shim
+ *   dwn-git shim npm [--port 4873]             Start npm registry proxy
+ *   dwn-git shim go  [--port 4874]             Start Go module proxy (GOPROXY)
+ *   dwn-git shim oci [--port 5555]             Start OCI/Docker registry proxy
  *   dwn-git log                                Show recent activity
  *   dwn-git serve [--port <port>]              Start the git transport server
  *   dwn-git whoami                             Show connected DID
@@ -79,6 +82,7 @@ import { releaseCommand } from './commands/release.js';
 import { repoCommand } from './commands/repo.js';
 import { serveCommand } from './commands/serve.js';
 import { setupCommand } from './commands/setup.js';
+import { shimCommand } from './commands/shim.js';
 import { socialCommand } from './commands/social.js';
 import { webCommand } from './commands/web.js';
 import { wikiCommand } from './commands/wiki.js';
@@ -177,6 +181,10 @@ function printUsage(): void {
   console.log('');
   console.log('  github-api [--port <port>]                  Start GitHub API shim (default: 8181)');
   console.log('');
+  console.log('  shim npm [--port 4873]                      Start npm registry proxy');
+  console.log('  shim go  [--port 4874]                      Start Go module proxy (GOPROXY)');
+  console.log('  shim oci [--port 5555]                      Start OCI/Docker registry proxy');
+  console.log('');
   console.log('  log                                         Show recent activity');
   console.log('  whoami                                      Show connected DID');
   console.log('  help                                        Show this message\n');
@@ -188,6 +196,9 @@ function printUsage(): void {
   console.log('  DWN_GIT_INDEXER_PORT      indexer API port (default: 8090)');
   console.log('  DWN_GIT_INDEXER_INTERVAL  crawl interval in seconds (default: 60)');
   console.log('  DWN_GIT_GITHUB_API_PORT   GitHub API shim port (default: 8181)');
+  console.log('  DWN_GIT_NPM_SHIM_PORT    npm shim port (default: 4873)');
+  console.log('  DWN_GIT_GO_SHIM_PORT     Go proxy shim port (default: 4874)');
+  console.log('  DWN_GIT_OCI_SHIM_PORT    OCI registry shim port (default: 5555)');
   console.log('  GITHUB_TOKEN      GitHub API token for migration (optional, higher rate limits)');
 }
 
@@ -303,6 +314,10 @@ async function main(): Promise<void> {
 
     case 'github-api':
       await githubApiCommand(ctx, rest);
+      break;
+
+    case 'shim':
+      await shimCommand(ctx, rest);
       break;
 
     case 'log':

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -83,7 +83,7 @@ export const ForgeRegistryDefinition = {
         $requiredTags       : ['name', 'ecosystem'],
         $allowUndefinedTags : false,
         name                : { type: 'string', maxLength: 214 },
-        ecosystem           : { type: 'string', enum: ['npm', 'cargo', 'pip', 'go'] },
+        ecosystem           : { type: 'string', enum: ['npm', 'cargo', 'pip', 'go', 'oci'] },
         description         : { type: 'string' },
       },
 

--- a/src/shims/go/index.ts
+++ b/src/shims/go/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Go module proxy shim module — DID-scoped module resolution via the
+ * GOPROXY HTTP protocol.
+ *
+ * @module
+ */
+
+export { handleGoProxyRequest, parseGoModulePath } from './proxy.js';
+
+export type { GoProxyResponse } from './proxy.js';
+
+export { startGoShim } from './server.js';
+
+export type { GoShimOptions } from './server.js';

--- a/src/shims/go/proxy.ts
+++ b/src/shims/go/proxy.ts
@@ -1,0 +1,336 @@
+/**
+ * Go module proxy shim — translates GOPROXY protocol requests into
+ * DWN queries via the resolver module.
+ *
+ * Implements the GOPROXY protocol (https://go.dev/ref/mod#goproxy-protocol)
+ * for DID-scoped Go modules.  Module paths use the format:
+ *   `did.enbox.org/did:<method>:<id>/<module>`
+ *
+ * The `did.enbox.org` prefix is a virtual domain that the shim
+ * intercepts.  The DID and module name are extracted from the path.
+ *
+ * Endpoints:
+ *   GET /{module}/@v/list          List available versions
+ *   GET /{module}/@v/{ver}.info    Version info (JSON: version + time)
+ *   GET /{module}/@v/{ver}.mod     go.mod file
+ *   GET /{module}/@v/{ver}.zip     Module zip archive
+ *   GET /{module}/@latest          Latest version info
+ *
+ * @module
+ */
+
+import type { AgentContext } from '../../cli/agent.js';
+
+import {
+  fetchTarball,
+  listVersions,
+  resolvePackage,
+  resolveVersion,
+} from '../../resolver/resolve.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Go proxy HTTP response. */
+export type GoProxyResponse = {
+  status : number;
+  headers : Record<string, string>;
+  body : string | Uint8Array;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Standard JSON headers. */
+function jsonHeaders(): Record<string, string> {
+  return {
+    'Content-Type'                : 'application/json',
+    'Access-Control-Allow-Origin' : '*',
+  };
+}
+
+/** Build a 404 response. */
+function notFound(message: string): GoProxyResponse {
+  return {
+    status  : 404,
+    headers : { 'Content-Type': 'text/plain', 'Access-Control-Allow-Origin': '*' },
+    body    : message,
+  };
+}
+
+/** Build a 410 Gone response (GOPROXY convention for not available). */
+function gone(message: string): GoProxyResponse {
+  return {
+    status  : 410,
+    headers : { 'Content-Type': 'text/plain', 'Access-Control-Allow-Origin': '*' },
+    body    : message,
+  };
+}
+
+/**
+ * Parse a Go module path into DID + module name.
+ *
+ * Go module paths are URL-encoded in the GOPROXY protocol — uppercase
+ * letters become `!` + lowercase (Go module proxy encoding).
+ *
+ * Format: `did.enbox.org/did:<method>:<id>/<module>`
+ *
+ * The `did.enbox.org/` prefix is stripped by the time it reaches us
+ * (it's part of the GOPROXY URL, not the request path).  The path
+ * starts with `did:<method>:<id>/<module>`.
+ */
+export function parseGoModulePath(
+  modulePath: string,
+): { did: string; name: string } | null {
+  // Decode Go module proxy encoding: !x → X
+  const decoded = modulePath.replace(/!([a-z])/g, (_, c: string) => c.toUpperCase());
+
+  // Match: did:<method>:<id>/<module-name>
+  const match = decoded.match(
+    /^(did:[a-z0-9]+:[a-zA-Z0-9._:%-]+)\/([a-zA-Z0-9._/-]+)/,
+  );
+
+  if (!match) { return null; }
+
+  return { did: match[1], name: match[2] };
+}
+
+/**
+ * Go version info JSON: `{ "Version": "v1.0.0", "Time": "2024-01-01T…" }`
+ */
+function versionInfo(semver: string, dateCreated: string): string {
+  // Go expects `v`-prefixed semver.
+  const goVer = semver.startsWith('v') ? semver : `v${semver}`;
+  return JSON.stringify({
+    Version : goVer,
+    Time    : new Date(dateCreated).toISOString(),
+  });
+}
+
+/**
+ * Strip `v` prefix from a Go version string for DWN semver queries.
+ */
+function stripV(version: string): string {
+  return version.startsWith('v') ? version.slice(1) : version;
+}
+
+/**
+ * Generate a minimal `go.mod` file for a DID-scoped module.
+ */
+function generateGoMod(did: string, name: string, deps: Record<string, string>): string {
+  const modulePath = `did.enbox.org/${did}/${name}`;
+  const lines = [`module ${modulePath}`, '', 'go 1.21', ''];
+
+  const depEntries = Object.entries(deps);
+  if (depEntries.length > 0) {
+    lines.push('require (');
+    for (const [dep, ver] of depEntries) {
+      // DID-scoped deps: did:dht:abc/utils → did.enbox.org/did:dht:abc/utils
+      const goPath = dep.startsWith('did:') ? `did.enbox.org/${dep}` : dep;
+      const goVer = ver.startsWith('v') ? ver : `v${ver}`;
+      lines.push(`\t${goPath} ${goVer}`);
+    }
+    lines.push(')');
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/** GET /{module}/@v/list — list available versions. */
+async function handleVersionList(
+  ctx: AgentContext,
+  did: string,
+  name: string,
+): Promise<GoProxyResponse> {
+  const pkg = await resolvePackage(ctx, did, name, 'go');
+  if (!pkg) {
+    return gone(`module not found: did.enbox.org/${did}/${name}`);
+  }
+
+  const versions = await listVersions(ctx, did, pkg.contextId);
+  const versionLines = versions
+    .filter((v) => !v.deprecated)
+    .map((v) => v.semver.startsWith('v') ? v.semver : `v${v.semver}`)
+    .join('\n');
+
+  return {
+    status  : 200,
+    headers : { 'Content-Type': 'text/plain', 'Access-Control-Allow-Origin': '*' },
+    body    : versionLines,
+  };
+}
+
+/** GET /{module}/@v/{ver}.info — version metadata JSON. */
+async function handleVersionInfo(
+  ctx: AgentContext,
+  did: string,
+  name: string,
+  version: string,
+): Promise<GoProxyResponse> {
+  const pkg = await resolvePackage(ctx, did, name, 'go');
+  if (!pkg) {
+    return gone(`module not found: did.enbox.org/${did}/${name}`);
+  }
+
+  const ver = await resolveVersion(ctx, did, pkg.contextId, stripV(version));
+  if (!ver) {
+    return gone(`version not found: ${version}`);
+  }
+
+  return {
+    status  : 200,
+    headers : jsonHeaders(),
+    body    : versionInfo(ver.semver, ver.dateCreated),
+  };
+}
+
+/** GET /{module}/@v/{ver}.mod — go.mod content. */
+async function handleGoMod(
+  ctx: AgentContext,
+  did: string,
+  name: string,
+  version: string,
+): Promise<GoProxyResponse> {
+  const pkg = await resolvePackage(ctx, did, name, 'go');
+  if (!pkg) {
+    return gone(`module not found: did.enbox.org/${did}/${name}`);
+  }
+
+  const ver = await resolveVersion(ctx, did, pkg.contextId, stripV(version));
+  if (!ver) {
+    return gone(`version not found: ${version}`);
+  }
+
+  return {
+    status  : 200,
+    headers : { 'Content-Type': 'text/plain', 'Access-Control-Allow-Origin': '*' },
+    body    : generateGoMod(did, name, ver.dependencies),
+  };
+}
+
+/** GET /{module}/@v/{ver}.zip — module zip archive (tarball from DWN). */
+async function handleModuleZip(
+  ctx: AgentContext,
+  did: string,
+  name: string,
+  version: string,
+): Promise<GoProxyResponse> {
+  const pkg = await resolvePackage(ctx, did, name, 'go');
+  if (!pkg) {
+    return gone(`module not found: did.enbox.org/${did}/${name}`);
+  }
+
+  const ver = await resolveVersion(ctx, did, pkg.contextId, stripV(version));
+  if (!ver) {
+    return gone(`version not found: ${version}`);
+  }
+
+  const tarball = await fetchTarball(ctx, did, ver.contextId);
+  if (!tarball) {
+    return gone(`archive not found for ${version}`);
+  }
+
+  return {
+    status  : 200,
+    headers : {
+      'Content-Type'                : 'application/zip',
+      'Content-Length'              : String(tarball.byteLength),
+      'Access-Control-Allow-Origin' : '*',
+    },
+    body: tarball,
+  };
+}
+
+/** GET /{module}/@latest — latest version info. */
+async function handleLatest(
+  ctx: AgentContext,
+  did: string,
+  name: string,
+): Promise<GoProxyResponse> {
+  const pkg = await resolvePackage(ctx, did, name, 'go');
+  if (!pkg) {
+    return gone(`module not found: did.enbox.org/${did}/${name}`);
+  }
+
+  const versions = await listVersions(ctx, did, pkg.contextId);
+  const latest = versions.find((v) => !v.deprecated) ?? versions[0];
+  if (!latest) {
+    return gone('no versions available');
+  }
+
+  return {
+    status  : 200,
+    headers : jsonHeaders(),
+    body    : versionInfo(latest.semver, latest.dateCreated),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+/**
+ * Route a Go proxy request to the appropriate handler.
+ *
+ * Exported for testing — tests can call this directly without starting
+ * an HTTP server.
+ */
+export async function handleGoProxyRequest(
+  ctx: AgentContext,
+  url: URL,
+): Promise<GoProxyResponse> {
+  const path = url.pathname.replace(/^\/+/, '');
+
+  // Split the path to find /@v/ or /@latest.
+  const atVIdx = path.indexOf('/@v/');
+  const atLatestIdx = path.indexOf('/@latest');
+
+  // --- /@latest --------------------------------------------------------
+  if (atLatestIdx !== -1) {
+    const modulePath = path.slice(0, atLatestIdx);
+    const parsed = parseGoModulePath(modulePath);
+    if (!parsed) { return notFound('Invalid module path'); }
+    return handleLatest(ctx, parsed.did, parsed.name);
+  }
+
+  // --- /@v/list --------------------------------------------------------
+  if (atVIdx !== -1) {
+    const modulePath = path.slice(0, atVIdx);
+    const rest = path.slice(atVIdx + 4); // after "/@v/"
+    const parsed = parseGoModulePath(modulePath);
+    if (!parsed) { return notFound('Invalid module path'); }
+
+    if (rest === 'list') {
+      return handleVersionList(ctx, parsed.did, parsed.name);
+    }
+
+    // --- /@v/{ver}.info ------------------------------------------------
+    if (rest.endsWith('.info')) {
+      const version = rest.slice(0, -5);
+      return handleVersionInfo(ctx, parsed.did, parsed.name, version);
+    }
+
+    // --- /@v/{ver}.mod -------------------------------------------------
+    if (rest.endsWith('.mod')) {
+      const version = rest.slice(0, -4);
+      return handleGoMod(ctx, parsed.did, parsed.name, version);
+    }
+
+    // --- /@v/{ver}.zip -------------------------------------------------
+    if (rest.endsWith('.zip')) {
+      const version = rest.slice(0, -4);
+      return handleModuleZip(ctx, parsed.did, parsed.name, version);
+    }
+
+    return notFound(`Unknown @v endpoint: ${rest}`);
+  }
+
+  return notFound('Not a Go module proxy request. Expected /@v/ or /@latest in path.');
+}

--- a/src/shims/go/server.ts
+++ b/src/shims/go/server.ts
@@ -1,0 +1,82 @@
+/**
+ * Go module proxy shim — HTTP server.
+ *
+ * Starts a local GOPROXY-compatible server that resolves DID-scoped
+ * Go modules from DWN records.
+ *
+ * Usage:
+ *   dwn-git shim go [--port 4874]
+ *
+ * Then:
+ *   GOPROXY=http://localhost:4874 go get did.enbox.org/did:dht:abc123/my-mod@v1.0.0
+ *
+ * @module
+ */
+
+import type { Server } from 'node:http';
+
+import { createServer } from 'node:http';
+
+import type { AgentContext } from '../../cli/agent.js';
+import type { GoProxyResponse } from './proxy.js';
+
+import { handleGoProxyRequest } from './proxy.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type GoShimOptions = {
+  ctx : AgentContext;
+  port : number;
+};
+
+// ---------------------------------------------------------------------------
+// Server
+// ---------------------------------------------------------------------------
+
+/** Start the Go module proxy shim server. Returns the server instance. */
+export function startGoShim(options: GoShimOptions): Server {
+  const { ctx, port } = options;
+
+  const server = createServer(async (req, res) => {
+    // CORS preflight.
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204, {
+        'Access-Control-Allow-Origin'  : '*',
+        'Access-Control-Allow-Methods' : 'GET, OPTIONS',
+        'Access-Control-Allow-Headers' : 'Authorization, Accept',
+        'Access-Control-Max-Age'       : '86400',
+      });
+      res.end();
+      return;
+    }
+
+    if (req.method !== 'GET') {
+      res.writeHead(405, { 'Content-Type': 'text/plain' });
+      res.end('Method not allowed. This is a read-only Go module proxy.');
+      return;
+    }
+
+    try {
+      const url = new URL(req.url ?? '/', `http://localhost:${port}`);
+      const result: GoProxyResponse = await handleGoProxyRequest(ctx, url);
+
+      res.writeHead(result.status, result.headers);
+      res.end(result.body);
+    } catch (err) {
+      console.error(`[go-shim] Error: ${(err as Error).message}`);
+      res.writeHead(500, { 'Content-Type': 'text/plain' });
+      res.end('Internal server error');
+    }
+  });
+
+  server.listen(port, () => {
+    console.log(`[go-shim] Go module proxy running at http://localhost:${port}`);
+    console.log('[go-shim] Usage:');
+    console.log(`  GOPROXY=http://localhost:${port} go get did.enbox.org/did:dht:<id>/<module>@v1.0.0`);
+    console.log('');
+  });
+
+  return server;
+}

--- a/src/shims/index.ts
+++ b/src/shims/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Package manager and container registry shims — local proxy servers
+ * that translate native tool protocols into DWN queries.
+ *
+ * Each shim serves the native HTTP API of its ecosystem tool:
+ *   - npm: npm registry API (for npm, bun, yarn, pnpm)
+ *   - go:  GOPROXY protocol (for go get)
+ *   - oci: OCI Distribution Spec v2 (for docker, podman)
+ *
+ * @module
+ */
+
+export { handleNpmRequest, parseNpmScope, startNpmShim } from './npm/index.js';
+export type { NpmResponse, NpmShimOptions } from './npm/index.js';
+
+export { handleGoProxyRequest, parseGoModulePath, startGoShim } from './go/index.js';
+export type { GoProxyResponse, GoShimOptions } from './go/index.js';
+
+export { handleOciRequest, parseOciName, startOciShim } from './oci/index.js';
+export type { OciResponse, OciShimOptions } from './oci/index.js';

--- a/src/shims/npm/index.ts
+++ b/src/shims/npm/index.ts
@@ -1,0 +1,14 @@
+/**
+ * npm registry shim module — DID-scoped package resolution via the
+ * standard npm registry HTTP API.
+ *
+ * @module
+ */
+
+export { handleNpmRequest, parseNpmScope } from './registry.js';
+
+export type { NpmResponse } from './registry.js';
+
+export { startNpmShim } from './server.js';
+
+export type { NpmShimOptions } from './server.js';

--- a/src/shims/npm/registry.ts
+++ b/src/shims/npm/registry.ts
@@ -1,0 +1,288 @@
+/**
+ * npm registry shim — translates npm registry HTTP API requests into
+ * DWN queries via the resolver module.
+ *
+ * Serves the subset of the npm registry API needed by `npm install`,
+ * `bun install`, `yarn add`, and `pnpm add`.  Packages are addressed
+ * using DID-scoped npm scopes: `@did:dht:abc123/my-pkg`.
+ *
+ * URL mapping:
+ *   GET /@did:*{@/:name}/:name               Package metadata (all versions)
+ *   GET /@did:*{@/:name}/:name/:version      Specific version metadata
+ *   GET /@did:*{@/:name}/:name/-/:file.tgz   Tarball download
+ *
+ * The DID is extracted from the npm scope.  For example:
+ *   `@did:dht:abc123/my-pkg` → DID `did:dht:abc123`, package `my-pkg`
+ *
+ * @module
+ */
+
+import type { AgentContext } from '../../cli/agent.js';
+
+import {
+  fetchTarball,
+  listVersions,
+  resolvePackage,
+  resolveVersion,
+} from '../../resolver/resolve.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** npm registry HTTP response. */
+export type NpmResponse = {
+  status : number;
+  headers : Record<string, string>;
+  body : string | Uint8Array;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Standard JSON headers for npm registry responses. */
+function jsonHeaders(): Record<string, string> {
+  return {
+    'Content-Type'                : 'application/json',
+    'Access-Control-Allow-Origin' : '*',
+  };
+}
+
+/** Build a 404 response. */
+function notFound(message: string): NpmResponse {
+  return {
+    status  : 404,
+    headers : jsonHeaders(),
+    body    : JSON.stringify({ error: message }),
+  };
+}
+
+/**
+ * Parse an npm-scoped package name into DID + package name.
+ *
+ * Supports two scope formats for DID methods with colons:
+ *   - URL-encoded: `@did%3Adht%3Aabc123/pkg`   (npm's default encoding)
+ *   - Slash-separated: `@did:dht:abc123/pkg`    (direct browser access)
+ *
+ * Returns `null` if the scope doesn't contain a valid DID.
+ */
+export function parseNpmScope(
+  path: string,
+): { did: string; name: string } | null {
+  // Decode percent-encoding first (%3A → :, %2F → /)
+  const decoded = decodeURIComponent(path);
+
+  // Match: /@did:<method>:<id>/<package-name>
+  const match = decoded.match(
+    /^\/@(did:[a-z0-9]+:[a-zA-Z0-9._:%-]+)\/([a-zA-Z0-9._-]+)/,
+  );
+
+  if (!match) { return null; }
+
+  return { did: match[1], name: match[2] };
+}
+
+/**
+ * Build a Packument (npm package document) for a DID-scoped package.
+ *
+ * This is the standard npm registry response for `GET /:package`.
+ * Contains metadata for all published versions.
+ */
+async function buildPackument(
+  ctx: AgentContext,
+  did: string,
+  name: string,
+): Promise<NpmResponse> {
+  const pkg = await resolvePackage(ctx, did, name, 'npm');
+  if (!pkg) {
+    return notFound(`Package not found: @${did}/${name}`);
+  }
+
+  const versions = await listVersions(ctx, did, pkg.contextId);
+  if (versions.length === 0) {
+    return notFound(`No versions found for @${did}/${name}`);
+  }
+
+  // Build versions map.
+  const versionsMap: Record<string, unknown> = {};
+  const distTags: Record<string, string> = {};
+  const times: Record<string, string> = { created: versions[versions.length - 1].dateCreated };
+
+  for (const v of versions) {
+    const scopedName = `@${did}/${name}`;
+    const tarballUrl = `/-/${scopedName}/-/${name}-${v.semver}.tgz`;
+
+    versionsMap[v.semver] = {
+      name    : scopedName,
+      version : v.semver,
+      dist    : {
+        tarball: tarballUrl,
+      },
+      dependencies : v.dependencies,
+      deprecated   : v.deprecated ? `Version ${v.semver} is deprecated` : undefined,
+      _dwn         : {
+        publisherDid : did,
+        contextId    : v.contextId,
+        author       : v.author,
+      },
+    };
+
+    times[v.semver] = v.dateCreated;
+  }
+
+  // Latest = first non-deprecated, or just first.
+  const latest = versions.find((v) => !v.deprecated) ?? versions[0];
+  distTags.latest = latest.semver;
+
+  const packument = {
+    _id         : `@${did}/${name}`,
+    name        : `@${did}/${name}`,
+    description : pkg.description,
+    'dist-tags' : distTags,
+    versions    : versionsMap,
+    time        : times,
+    _dwn        : {
+      publisherDid : did,
+      ecosystem    : pkg.ecosystem,
+      contextId    : pkg.contextId,
+    },
+  };
+
+  return {
+    status  : 200,
+    headers : jsonHeaders(),
+    body    : JSON.stringify(packument),
+  };
+}
+
+/**
+ * Build a version-specific metadata response.
+ *
+ * This is the npm registry response for `GET /:package/:version`.
+ */
+async function buildVersionMeta(
+  ctx: AgentContext,
+  did: string,
+  name: string,
+  semver: string,
+): Promise<NpmResponse> {
+  const pkg = await resolvePackage(ctx, did, name, 'npm');
+  if (!pkg) {
+    return notFound(`Package not found: @${did}/${name}`);
+  }
+
+  const ver = await resolveVersion(ctx, did, pkg.contextId, semver);
+  if (!ver) {
+    return notFound(`Version not found: @${did}/${name}@${semver}`);
+  }
+
+  const scopedName = `@${did}/${name}`;
+  const tarballUrl = `/-/${scopedName}/-/${name}-${ver.semver}.tgz`;
+
+  const body = {
+    name         : scopedName,
+    version      : ver.semver,
+    dist         : { tarball: tarballUrl },
+    dependencies : ver.dependencies,
+    deprecated   : ver.deprecated ? `Version ${ver.semver} is deprecated` : undefined,
+    _dwn         : {
+      publisherDid : did,
+      contextId    : ver.contextId,
+      author       : ver.author,
+    },
+  };
+
+  return {
+    status  : 200,
+    headers : jsonHeaders(),
+    body    : JSON.stringify(body),
+  };
+}
+
+/**
+ * Serve a tarball download.
+ *
+ * npm fetches tarballs from the `dist.tarball` URL returned in the
+ * packument.  We resolve the version and fetch the tarball from the DWN.
+ */
+async function serveTarball(
+  ctx: AgentContext,
+  did: string,
+  name: string,
+  filename: string,
+): Promise<NpmResponse> {
+  // Parse version from filename: "name-1.0.0.tgz" → "1.0.0"
+  const prefix = `${name}-`;
+  if (!filename.startsWith(prefix) || !filename.endsWith('.tgz')) {
+    return notFound(`Invalid tarball filename: ${filename}`);
+  }
+  const semver = filename.slice(prefix.length, -4);
+
+  const pkg = await resolvePackage(ctx, did, name, 'npm');
+  if (!pkg) {
+    return notFound(`Package not found: @${did}/${name}`);
+  }
+
+  const ver = await resolveVersion(ctx, did, pkg.contextId, semver);
+  if (!ver) {
+    return notFound(`Version not found: @${did}/${name}@${semver}`);
+  }
+
+  const tarball = await fetchTarball(ctx, did, ver.contextId);
+  if (!tarball) {
+    return notFound(`Tarball not found for @${did}/${name}@${semver}`);
+  }
+
+  return {
+    status  : 200,
+    headers : {
+      'Content-Type'                : 'application/octet-stream',
+      'Content-Length'              : String(tarball.byteLength),
+      'Access-Control-Allow-Origin' : '*',
+    },
+    body: tarball,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+/**
+ * Route an npm registry request to the appropriate handler.
+ *
+ * Exported for testing — tests can call this directly without starting
+ * an HTTP server.
+ */
+export async function handleNpmRequest(
+  ctx: AgentContext,
+  url: URL,
+): Promise<NpmResponse> {
+  const path = url.pathname;
+
+  // --- Tarball download: /-/@did:…/name/-/name-ver.tgz -----------------
+  const tarballMatch = path.match(
+    /^\/-\/@(did:[a-z0-9]+:[a-zA-Z0-9._:%-]+)\/([a-zA-Z0-9._-]+)\/-\/(.+\.tgz)$/,
+  );
+  if (tarballMatch) {
+    return serveTarball(ctx, tarballMatch[1], tarballMatch[2], tarballMatch[3]);
+  }
+
+  // --- Scoped package with version: /@did:…/name/version ---------------
+  const scope = parseNpmScope(path);
+  if (!scope) {
+    return notFound('Not a DID-scoped package. Use @did:<method>:<id>/<name>');
+  }
+
+  // Check for trailing version segment: /@did:…/name/1.0.0
+  const afterScope = path.slice(path.indexOf(scope.name) + scope.name.length);
+  const versionMatch = afterScope.match(/^\/([^/]+)$/);
+
+  if (versionMatch) {
+    return buildVersionMeta(ctx, scope.did, scope.name, versionMatch[1]);
+  }
+
+  // --- Scoped package metadata (all versions): /@did:…/name ------------
+  return buildPackument(ctx, scope.did, scope.name);
+}

--- a/src/shims/npm/server.ts
+++ b/src/shims/npm/server.ts
@@ -1,0 +1,84 @@
+/**
+ * npm registry shim — HTTP server.
+ *
+ * Starts a local npm-compatible registry that resolves DID-scoped
+ * packages from DWN records.
+ *
+ * Usage:
+ *   dwn-git shim npm [--port 4873]
+ *
+ * Then:
+ *   npm install --registry=http://localhost:4873 @did:dht:abc123/my-pkg
+ *
+ * @module
+ */
+
+import type { Server } from 'node:http';
+
+import { createServer } from 'node:http';
+
+import type { AgentContext } from '../../cli/agent.js';
+import type { NpmResponse } from './registry.js';
+
+import { handleNpmRequest } from './registry.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type NpmShimOptions = {
+  ctx : AgentContext;
+  port : number;
+};
+
+// ---------------------------------------------------------------------------
+// Server
+// ---------------------------------------------------------------------------
+
+/** Start the npm registry shim server. Returns the server instance. */
+export function startNpmShim(options: NpmShimOptions): Server {
+  const { ctx, port } = options;
+
+  const server = createServer(async (req, res) => {
+    // CORS preflight.
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204, {
+        'Access-Control-Allow-Origin'  : '*',
+        'Access-Control-Allow-Methods' : 'GET, OPTIONS',
+        'Access-Control-Allow-Headers' : 'Authorization, Accept',
+        'Access-Control-Max-Age'       : '86400',
+      });
+      res.end();
+      return;
+    }
+
+    // Only support GET — this is a read-only registry proxy.
+    if (req.method !== 'GET') {
+      res.writeHead(405, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Method not allowed. This is a read-only registry shim.' }));
+      return;
+    }
+
+    try {
+      const url = new URL(req.url ?? '/', `http://localhost:${port}`);
+      const result: NpmResponse = await handleNpmRequest(ctx, url);
+
+      res.writeHead(result.status, result.headers);
+      res.end(result.body);
+    } catch (err) {
+      console.error(`[npm-shim] Error: ${(err as Error).message}`);
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Internal server error' }));
+    }
+  });
+
+  server.listen(port, () => {
+    console.log(`[npm-shim] npm registry shim running at http://localhost:${port}`);
+    console.log('[npm-shim] Usage:');
+    console.log(`  npm install --registry=http://localhost:${port} @did:dht:<id>/<package>`);
+    console.log(`  bun install --registry http://localhost:${port} @did:dht:<id>/<package>`);
+    console.log('');
+  });
+
+  return server;
+}

--- a/src/shims/oci/index.ts
+++ b/src/shims/oci/index.ts
@@ -1,0 +1,14 @@
+/**
+ * OCI Distribution registry shim module — DID-scoped container image
+ * resolution via the OCI Distribution Spec HTTP API.
+ *
+ * @module
+ */
+
+export { handleOciRequest, parseOciName } from './registry.js';
+
+export type { OciResponse } from './registry.js';
+
+export { startOciShim } from './server.js';
+
+export type { OciShimOptions } from './server.js';

--- a/src/shims/oci/registry.ts
+++ b/src/shims/oci/registry.ts
@@ -1,0 +1,334 @@
+/**
+ * OCI Distribution registry shim — translates Docker/Podman pull
+ * requests into DWN queries.
+ *
+ * Implements the read-only subset of the OCI Distribution Spec v2
+ * needed by `docker pull` and `podman pull`.
+ *
+ * Container images are stored in the DWN using the forge-registry
+ * protocol with the `oci` ecosystem.  The mapping is:
+ *
+ *   OCI concept       → DWN record
+ *   ──────────────────────────────────────
+ *   Repository         → `package` (ecosystem: 'oci')
+ *   Tag / version      → `package/version` (semver = tag)
+ *   Manifest           → `package/version/tarball` (application/vnd.oci.image.manifest.v1+json)
+ *   Blob / layer       → queried by digest from version data
+ *
+ * Image naming:
+ *   `localhost:5555/did:dht:abc123/my-image:v1.0.0`
+ *
+ * The DID and image name are extracted from the Docker repository name.
+ *
+ * Endpoints (OCI Distribution Spec v2):
+ *   GET /v2/                                      API version check
+ *   GET /v2/{name}/manifests/{reference}           Pull manifest (by tag or digest)
+ *   HEAD /v2/{name}/manifests/{reference}          Check manifest existence
+ *   GET /v2/{name}/blobs/{digest}                  Pull blob
+ *   GET /v2/{name}/tags/list                       List tags
+ *
+ * @module
+ */
+
+import type { AgentContext } from '../../cli/agent.js';
+
+import {
+  fetchTarball,
+  listVersions,
+  resolvePackage,
+  resolveVersion,
+} from '../../resolver/resolve.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** OCI registry HTTP response. */
+export type OciResponse = {
+  status : number;
+  headers : Record<string, string>;
+  body : string | Uint8Array;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** OCI-required headers for all responses. */
+function ociHeaders(extra?: Record<string, string>): Record<string, string> {
+  return {
+    'Docker-Distribution-Api-Version' : 'registry/2.0',
+    'Access-Control-Allow-Origin'     : '*',
+    ...extra,
+  };
+}
+
+/** Build a 404 response with OCI error envelope. */
+function notFound(code: string, message: string): OciResponse {
+  return {
+    status  : 404,
+    headers : ociHeaders({ 'Content-Type': 'application/json' }),
+    body    : JSON.stringify({
+      errors: [{ code, message, detail: null }],
+    }),
+  };
+}
+
+/**
+ * Parse an OCI repository name into DID + image name.
+ *
+ * OCI repositories use the format: `did:<method>:<id>/<image-name>`
+ * Docker CLI sends this as the `name` portion of the v2 API path.
+ */
+export function parseOciName(
+  name: string,
+): { did: string; imageName: string } | null {
+  const match = name.match(
+    /^(did:[a-z0-9]+:[a-zA-Z0-9._:%-]+)\/([a-zA-Z0-9._/-]+)$/,
+  );
+
+  if (!match) { return null; }
+
+  return { did: match[1], imageName: match[2] };
+}
+
+/**
+ * Compute a SHA-256 digest of the given data.
+ *
+ * Returns the digest in OCI format: `sha256:<hex>`.
+ */
+async function sha256Digest(data: Uint8Array | string): Promise<string> {
+  const bytes = typeof data === 'string' ? new TextEncoder().encode(data) : data;
+  const hash = new Uint8Array(
+    await crypto.subtle.digest('SHA-256', bytes),
+  );
+  const hex = Array.from(hash).map((b) => b.toString(16).padStart(2, '0')).join('');
+  return `sha256:${hex}`;
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/** GET /v2/ — API version check. */
+function handleApiVersionCheck(): OciResponse {
+  return {
+    status  : 200,
+    headers : ociHeaders({ 'Content-Type': 'application/json' }),
+    body    : JSON.stringify({}),
+  };
+}
+
+/** GET /v2/{name}/tags/list — list tags for a repository. */
+async function handleTagsList(
+  ctx: AgentContext,
+  did: string,
+  imageName: string,
+): Promise<OciResponse> {
+  const pkg = await resolvePackage(ctx, did, imageName, 'oci');
+  if (!pkg) {
+    return notFound('NAME_UNKNOWN', `repository not found: ${did}/${imageName}`);
+  }
+
+  const versions = await listVersions(ctx, did, pkg.contextId);
+  const tags = versions.map((v) => v.semver);
+
+  return {
+    status  : 200,
+    headers : ociHeaders({ 'Content-Type': 'application/json' }),
+    body    : JSON.stringify({
+      name: `${did}/${imageName}`,
+      tags,
+    }),
+  };
+}
+
+/**
+ * GET /v2/{name}/manifests/{reference} — pull manifest.
+ *
+ * The manifest is stored as the tarball record's data.  The `reference`
+ * can be a tag (semver string) or a digest (`sha256:…`).
+ */
+async function handleGetManifest(
+  ctx: AgentContext,
+  did: string,
+  imageName: string,
+  reference: string,
+  headOnly: boolean,
+): Promise<OciResponse> {
+  const pkg = await resolvePackage(ctx, did, imageName, 'oci');
+  if (!pkg) {
+    return notFound('NAME_UNKNOWN', `repository not found: ${did}/${imageName}`);
+  }
+
+  // Resolve by tag or digest.
+  let manifestBytes: Uint8Array | null = null;
+
+  if (reference.startsWith('sha256:')) {
+    // Digest-based lookup: iterate versions and match by content digest.
+    const versions = await listVersions(ctx, did, pkg.contextId);
+    for (const ver of versions) {
+      const data = await fetchTarball(ctx, did, ver.contextId);
+      if (data) {
+        const digest = await sha256Digest(data);
+        if (digest === reference) {
+          manifestBytes = data;
+          break;
+        }
+      }
+    }
+  } else {
+    // Tag-based lookup.
+    const ver = await resolveVersion(ctx, did, pkg.contextId, reference);
+    if (ver) {
+      manifestBytes = await fetchTarball(ctx, did, ver.contextId);
+    }
+  }
+
+  if (!manifestBytes) {
+    return notFound('MANIFEST_UNKNOWN', `manifest unknown: ${reference}`);
+  }
+
+  const digest = await sha256Digest(manifestBytes);
+
+  // Determine content type from manifest content.
+  let contentType = 'application/vnd.oci.image.manifest.v1+json';
+  try {
+    const parsed = JSON.parse(new TextDecoder().decode(manifestBytes));
+    if (parsed.mediaType) {
+      contentType = parsed.mediaType as string;
+    }
+  } catch {
+    // Not valid JSON — treat as raw manifest.
+  }
+
+  if (headOnly) {
+    return {
+      status  : 200,
+      headers : ociHeaders({
+        'Content-Type'          : contentType,
+        'Content-Length'        : String(manifestBytes.byteLength),
+        'Docker-Content-Digest' : digest,
+      }),
+      body: '',
+    };
+  }
+
+  return {
+    status  : 200,
+    headers : ociHeaders({
+      'Content-Type'          : contentType,
+      'Content-Length'        : String(manifestBytes.byteLength),
+      'Docker-Content-Digest' : digest,
+    }),
+    body: manifestBytes,
+  };
+}
+
+/**
+ * GET /v2/{name}/blobs/{digest} — pull a blob.
+ *
+ * In this shim, blobs are also stored as version tarballs.  The digest
+ * is matched against all version tarballs for the repository.
+ *
+ * For a production implementation, blobs would be stored as separate
+ * DWN records keyed by content digest.
+ */
+async function handleGetBlob(
+  ctx: AgentContext,
+  did: string,
+  imageName: string,
+  digest: string,
+): Promise<OciResponse> {
+  const pkg = await resolvePackage(ctx, did, imageName, 'oci');
+  if (!pkg) {
+    return notFound('NAME_UNKNOWN', `repository not found: ${did}/${imageName}`);
+  }
+
+  // Search all versions for a tarball matching the digest.
+  const versions = await listVersions(ctx, did, pkg.contextId);
+  for (const ver of versions) {
+    const data = await fetchTarball(ctx, did, ver.contextId);
+    if (data) {
+      const d = await sha256Digest(data);
+      if (d === digest) {
+        return {
+          status  : 200,
+          headers : ociHeaders({
+            'Content-Type'          : 'application/octet-stream',
+            'Content-Length'        : String(data.byteLength),
+            'Docker-Content-Digest' : digest,
+          }),
+          body: data,
+        };
+      }
+    }
+  }
+
+  return notFound('BLOB_UNKNOWN', `blob unknown: ${digest}`);
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+/**
+ * Route an OCI registry request to the appropriate handler.
+ *
+ * Exported for testing — tests can call this directly without starting
+ * an HTTP server.
+ */
+export async function handleOciRequest(
+  ctx: AgentContext,
+  url: URL,
+  method: string = 'GET',
+): Promise<OciResponse> {
+  const path = url.pathname;
+
+  // --- /v2/ — API version check ----------------------------------------
+  if (path === '/v2/' || path === '/v2') {
+    return handleApiVersionCheck();
+  }
+
+  // All other endpoints are under /v2/{name}/…
+  const v2Match = path.match(/^\/v2\/(.+)\/(manifests|blobs|tags)\/(.+)$/);
+  if (!v2Match) {
+    // Check for tags/list format: /v2/{name}/tags/list
+    const tagsMatch = path.match(/^\/v2\/(.+)\/tags\/list$/);
+    if (tagsMatch) {
+      const parsed = parseOciName(tagsMatch[1]);
+      if (!parsed) {
+        return notFound('NAME_INVALID', 'Invalid repository name. Expected did:<method>:<id>/<name>');
+      }
+      return handleTagsList(ctx, parsed.did, parsed.imageName);
+    }
+
+    return notFound('NAME_INVALID', 'Invalid v2 API path');
+  }
+
+  const repoName = v2Match[1];
+  const endpoint = v2Match[2];
+  const reference = v2Match[3];
+
+  const parsed = parseOciName(repoName);
+  if (!parsed) {
+    return notFound('NAME_INVALID', 'Invalid repository name. Expected did:<method>:<id>/<name>');
+  }
+
+  switch (endpoint) {
+    case 'manifests':
+      return handleGetManifest(ctx, parsed.did, parsed.imageName, reference, method === 'HEAD');
+
+    case 'blobs':
+      return handleGetBlob(ctx, parsed.did, parsed.imageName, reference);
+
+    case 'tags':
+      if (reference === 'list') {
+        return handleTagsList(ctx, parsed.did, parsed.imageName);
+      }
+      return notFound('NAME_INVALID', `Unknown tags endpoint: ${reference}`);
+
+    default:
+      return notFound('NAME_INVALID', `Unknown endpoint: ${endpoint}`);
+  }
+}

--- a/src/shims/oci/server.ts
+++ b/src/shims/oci/server.ts
@@ -1,0 +1,94 @@
+/**
+ * OCI Distribution registry shim — HTTP server.
+ *
+ * Starts a local OCI-compatible registry that resolves DID-scoped
+ * container images from DWN records.
+ *
+ * Usage:
+ *   dwn-git shim oci [--port 5555]
+ *
+ * Then:
+ *   docker pull localhost:5555/did:dht:abc123/my-image:v1.0.0
+ *
+ * @module
+ */
+
+import type { Server } from 'node:http';
+
+import { createServer } from 'node:http';
+
+import type { AgentContext } from '../../cli/agent.js';
+import type { OciResponse } from './registry.js';
+
+import { handleOciRequest } from './registry.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type OciShimOptions = {
+  ctx : AgentContext;
+  port : number;
+};
+
+// ---------------------------------------------------------------------------
+// Server
+// ---------------------------------------------------------------------------
+
+/** Start the OCI registry shim server. Returns the server instance. */
+export function startOciShim(options: OciShimOptions): Server {
+  const { ctx, port } = options;
+
+  const server = createServer(async (req, res) => {
+    // CORS preflight.
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204, {
+        'Access-Control-Allow-Origin'  : '*',
+        'Access-Control-Allow-Methods' : 'GET, HEAD, OPTIONS',
+        'Access-Control-Allow-Headers' : 'Authorization, Accept, Docker-Distribution-Api-Version',
+        'Access-Control-Max-Age'       : '86400',
+      });
+      res.end();
+      return;
+    }
+
+    // Only support GET and HEAD — this is a pull-only registry.
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      res.writeHead(405, {
+        'Content-Type'                    : 'application/json',
+        'Docker-Distribution-Api-Version' : 'registry/2.0',
+      });
+      res.end(JSON.stringify({
+        errors: [{ code: 'UNSUPPORTED', message: 'This is a read-only registry shim.', detail: null }],
+      }));
+      return;
+    }
+
+    try {
+      const url = new URL(req.url ?? '/', `http://localhost:${port}`);
+      const result: OciResponse = await handleOciRequest(ctx, url, req.method);
+
+      res.writeHead(result.status, result.headers);
+      res.end(result.body);
+    } catch (err) {
+      console.error(`[oci-shim] Error: ${(err as Error).message}`);
+      res.writeHead(500, {
+        'Content-Type'                    : 'application/json',
+        'Docker-Distribution-Api-Version' : 'registry/2.0',
+      });
+      res.end(JSON.stringify({
+        errors: [{ code: 'UNKNOWN', message: 'Internal server error', detail: null }],
+      }));
+    }
+  });
+
+  server.listen(port, () => {
+    console.log(`[oci-shim] OCI registry shim running at http://localhost:${port}`);
+    console.log('[oci-shim] Usage:');
+    console.log(`  docker pull localhost:${port}/did:dht:<id>/<image>:<tag>`);
+    console.log(`  podman pull localhost:${port}/did:dht:<id>/<image>:<tag>`);
+    console.log('');
+  });
+
+  return server;
+}

--- a/tests/protocols.spec.ts
+++ b/tests/protocols.spec.ts
@@ -554,9 +554,9 @@ describe('@enbox/dwn-git', () => {
       expect(tags?.$requiredTags).toContain('ecosystem');
     });
 
-    it('should restrict ecosystem to npm, cargo, pip, go', () => {
+    it('should restrict ecosystem to npm, cargo, pip, go, oci', () => {
       const ecosystem = ForgeRegistryDefinition.structure.package.$tags?.ecosystem as { enum: string[] };
-      expect(ecosystem.enum).toEqual(['npm', 'cargo', 'pip', 'go']);
+      expect(ecosystem.enum).toEqual(['npm', 'cargo', 'pip', 'go', 'oci']);
     });
 
     it('should nest version under package and tarball/attestation under version (3-level)', () => {

--- a/tests/shims.spec.ts
+++ b/tests/shims.spec.ts
@@ -1,0 +1,831 @@
+/**
+ * Package manager and container registry shim tests — exercises the
+ * npm, Go, and OCI shim request handlers against a real Web5 agent
+ * populated with DWN records.
+ *
+ * The test agent is created once in `beforeAll`, packages are seeded
+ * for each ecosystem (npm, go, oci), and then each test calls the
+ * handler functions directly with constructed URLs.  No HTTP server
+ * is started.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+
+import { rmSync } from 'node:fs';
+
+import { Web5 } from '@enbox/api';
+import { Web5UserAgent } from '@enbox/agent';
+
+import type { AgentContext } from '../src/cli/agent.js';
+
+import { ForgeCiProtocol } from '../src/ci.js';
+import { ForgeIssuesProtocol } from '../src/issues.js';
+import { ForgeNotificationsProtocol } from '../src/notifications.js';
+import { ForgeOrgProtocol } from '../src/org.js';
+import { ForgePatchesProtocol } from '../src/patches.js';
+import { ForgeRefsProtocol } from '../src/refs.js';
+import { ForgeRegistryProtocol } from '../src/registry.js';
+import { ForgeReleasesProtocol } from '../src/releases.js';
+import { ForgeRepoProtocol } from '../src/repo.js';
+import { ForgeSocialProtocol } from '../src/social.js';
+import { ForgeWikiProtocol } from '../src/wiki.js';
+
+import { handleGoProxyRequest, parseGoModulePath } from '../src/shims/go/proxy.js';
+import { handleNpmRequest, parseNpmScope } from '../src/shims/npm/registry.js';
+import { handleOciRequest, parseOciName } from '../src/shims/oci/registry.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DATA_PATH = '__TESTDATA__/shims-agent';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let testDid: string;
+let ctx: AgentContext;
+
+/** Create a URL for the npm shim. */
+function npmUrl(path: string): URL {
+  return new URL(path, 'http://localhost:4873');
+}
+
+/** Create a URL for the Go proxy shim. */
+function goUrl(path: string): URL {
+  return new URL(path, 'http://localhost:4874');
+}
+
+/** Create a URL for the OCI shim. */
+function ociUrl(path: string): URL {
+  return new URL(path, 'http://localhost:5555');
+}
+
+/** Parse JSON from a string or Uint8Array body. */
+function parseBody(body: string | Uint8Array): any {
+  if (typeof body === 'string') { return JSON.parse(body); }
+  return JSON.parse(new TextDecoder().decode(body));
+}
+
+// Tarball: 8-byte gzip magic number (same as resolver tests).
+const TARBALL_BYTES = new Uint8Array([0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00]);
+
+// OCI manifest JSON.
+const OCI_MANIFEST = JSON.stringify({
+  schemaVersion : 2,
+  mediaType     : 'application/vnd.oci.image.manifest.v1+json',
+  config        : {
+    mediaType : 'application/vnd.oci.image.config.v1+json',
+    digest    : 'sha256:abcdef0123456789',
+    size      : 1024,
+  },
+  layers: [{
+    mediaType : 'application/vnd.oci.image.layer.v1.tar+gzip',
+    digest    : 'sha256:layer0123456789',
+    size      : 2048,
+  }],
+});
+const OCI_MANIFEST_BYTES = new TextEncoder().encode(OCI_MANIFEST);
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('Package manager shims', () => {
+
+  beforeAll(async () => {
+    rmSync(DATA_PATH, { recursive: true, force: true });
+
+    const agent = await Web5UserAgent.create({ dataPath: DATA_PATH });
+    await agent.initialize({ password: 'test-password' });
+    await agent.start({ password: 'test-password' });
+
+    const identities = await agent.identity.list();
+    let identity = identities[0];
+    if (!identity) {
+      identity = await agent.identity.create({
+        didMethod : 'jwk',
+        metadata  : { name: 'Shim Test' },
+      });
+    }
+
+    const result = await Web5.connect({
+      agent,
+      connectedDid : identity.did.uri,
+      sync         : 'off',
+    });
+    const { web5, did } = result;
+    testDid = did;
+
+    const repo = web5.using(ForgeRepoProtocol);
+    const refs = web5.using(ForgeRefsProtocol);
+    const issues = web5.using(ForgeIssuesProtocol);
+    const patches = web5.using(ForgePatchesProtocol);
+    const ci = web5.using(ForgeCiProtocol);
+    const releases = web5.using(ForgeReleasesProtocol);
+    const registry = web5.using(ForgeRegistryProtocol);
+    const social = web5.using(ForgeSocialProtocol);
+    const notifications = web5.using(ForgeNotificationsProtocol);
+    const wiki = web5.using(ForgeWikiProtocol);
+    const org = web5.using(ForgeOrgProtocol);
+
+    await repo.configure();
+    await refs.configure();
+    await issues.configure();
+    await patches.configure();
+    await ci.configure();
+    await releases.configure();
+    await registry.configure();
+    await social.configure();
+    await notifications.configure();
+    await wiki.configure();
+    await org.configure();
+
+    ctx = {
+      did, repo, refs, issues, patches, ci, releases,
+      registry, social, notifications, wiki, org, web5,
+    };
+
+    // -----------------------------------------------------------------------
+    // Seed npm package: "my-utils" with v1.0.0 and v2.0.0
+    // -----------------------------------------------------------------------
+    const { record: npmPkgRec } = await registry.records.create('package', {
+      data : { name: 'my-utils', description: 'Utility functions' },
+      tags : { name: 'my-utils', ecosystem: 'npm', description: 'Utility functions' },
+    });
+    const npmPkgCtx = npmPkgRec!.contextId ?? '';
+
+    // v1.0.0 — no deps
+    const { record: npmV1Rec } = await registry.records.create('package/version' as any, {
+      data            : { semver: '1.0.0', dependencies: {} },
+      tags            : { semver: '1.0.0' },
+      parentContextId : npmPkgCtx,
+    } as any);
+    const npmV1Ctx = npmV1Rec!.contextId ?? '';
+
+    await registry.records.create('package/version/tarball' as any, {
+      data            : TARBALL_BYTES,
+      dataFormat      : 'application/gzip',
+      tags            : { filename: 'my-utils-1.0.0.tgz', contentType: 'application/gzip', size: 8 },
+      parentContextId : npmV1Ctx,
+    } as any);
+
+    // v2.0.0 — has dependency
+    const { record: npmV2Rec } = await registry.records.create('package/version' as any, {
+      data            : { semver: '2.0.0', dependencies: { [`${testDid}/my-utils`]: '1.0.0' } },
+      tags            : { semver: '2.0.0' },
+      parentContextId : npmPkgCtx,
+    } as any);
+    const npmV2Ctx = npmV2Rec!.contextId ?? '';
+
+    await registry.records.create('package/version/tarball' as any, {
+      data            : TARBALL_BYTES,
+      dataFormat      : 'application/gzip',
+      tags            : { filename: 'my-utils-2.0.0.tgz', contentType: 'application/gzip', size: 8 },
+      parentContextId : npmV2Ctx,
+    } as any);
+
+    // -----------------------------------------------------------------------
+    // Seed Go module: "my-mod" with v1.0.0 and v2.0.0
+    // -----------------------------------------------------------------------
+    const { record: goPkgRec } = await registry.records.create('package', {
+      data : { name: 'my-mod', description: 'Go module' },
+      tags : { name: 'my-mod', ecosystem: 'go', description: 'Go module' },
+    });
+    const goPkgCtx = goPkgRec!.contextId ?? '';
+
+    const { record: goV1Rec } = await registry.records.create('package/version' as any, {
+      data            : { semver: '1.0.0', dependencies: {} },
+      tags            : { semver: '1.0.0' },
+      parentContextId : goPkgCtx,
+    } as any);
+    const goV1Ctx = goV1Rec!.contextId ?? '';
+
+    await registry.records.create('package/version/tarball' as any, {
+      data            : TARBALL_BYTES,
+      dataFormat      : 'application/gzip',
+      tags            : { filename: 'my-mod-1.0.0.tar.gz', contentType: 'application/gzip', size: 8 },
+      parentContextId : goV1Ctx,
+    } as any);
+
+    // v2.0.0 with a dependency
+    const { record: goV2Rec } = await registry.records.create('package/version' as any, {
+      data            : { semver: '2.0.0', dependencies: { [`${testDid}/my-mod`]: '1.0.0' } },
+      tags            : { semver: '2.0.0' },
+      parentContextId : goPkgCtx,
+    } as any);
+    const goV2Ctx = goV2Rec!.contextId ?? '';
+
+    await registry.records.create('package/version/tarball' as any, {
+      data            : TARBALL_BYTES,
+      dataFormat      : 'application/gzip',
+      tags            : { filename: 'my-mod-2.0.0.tar.gz', contentType: 'application/gzip', size: 8 },
+      parentContextId : goV2Ctx,
+    } as any);
+
+    // -----------------------------------------------------------------------
+    // Seed OCI image: "my-image" with v1.0.0
+    // -----------------------------------------------------------------------
+    const { record: ociPkgRec } = await registry.records.create('package', {
+      data : { name: 'my-image', description: 'Container image' },
+      tags : { name: 'my-image', ecosystem: 'oci', description: 'Container image' },
+    });
+    const ociPkgCtx = ociPkgRec!.contextId ?? '';
+
+    const { record: ociV1Rec } = await registry.records.create('package/version' as any, {
+      data            : { semver: 'v1.0.0', dependencies: {} },
+      tags            : { semver: 'v1.0.0' },
+      parentContextId : ociPkgCtx,
+    } as any);
+    const ociV1Ctx = ociV1Rec!.contextId ?? '';
+
+    await registry.records.create('package/version/tarball' as any, {
+      data            : OCI_MANIFEST_BYTES,
+      dataFormat      : 'application/octet-stream',
+      tags            : { filename: 'manifest.json', contentType: 'application/octet-stream', size: OCI_MANIFEST_BYTES.byteLength },
+      parentContextId : ociV1Ctx,
+    } as any);
+  });
+
+  afterAll(() => {
+    rmSync(DATA_PATH, { recursive: true, force: true });
+  });
+
+  // =========================================================================
+  // parseNpmScope
+  // =========================================================================
+
+  describe('parseNpmScope()', () => {
+    it('should parse a DID-scoped npm path', () => {
+      const result = parseNpmScope('/@did:dht:abc123/my-pkg');
+      expect(result).not.toBeNull();
+      expect(result!.did).toBe('did:dht:abc123');
+      expect(result!.name).toBe('my-pkg');
+    });
+
+    it('should parse a URL-encoded DID scope', () => {
+      const result = parseNpmScope('/@did%3Adht%3Aabc123/my-pkg');
+      expect(result).not.toBeNull();
+      expect(result!.did).toBe('did:dht:abc123');
+      expect(result!.name).toBe('my-pkg');
+    });
+
+    it('should return null for non-DID scopes', () => {
+      expect(parseNpmScope('/@myorg/my-pkg')).toBeNull();
+    });
+
+    it('should return null for unscoped packages', () => {
+      expect(parseNpmScope('/lodash')).toBeNull();
+    });
+  });
+
+  // =========================================================================
+  // parseGoModulePath
+  // =========================================================================
+
+  describe('parseGoModulePath()', () => {
+    it('should parse a DID-scoped Go module path', () => {
+      const result = parseGoModulePath('did:dht:abc123/my-mod');
+      expect(result).not.toBeNull();
+      expect(result!.did).toBe('did:dht:abc123');
+      expect(result!.name).toBe('my-mod');
+    });
+
+    it('should decode Go module proxy encoding', () => {
+      // In Go proxy encoding, uppercase → !lowercase
+      const result = parseGoModulePath('did:dht:abc123/my!module');
+      expect(result).not.toBeNull();
+      expect(result!.name).toBe('myModule');
+    });
+
+    it('should handle nested module paths', () => {
+      const result = parseGoModulePath('did:dht:abc123/org/sub-mod');
+      expect(result).not.toBeNull();
+      expect(result!.name).toBe('org/sub-mod');
+    });
+
+    it('should return null for invalid paths', () => {
+      expect(parseGoModulePath('not-a-did/mod')).toBeNull();
+    });
+  });
+
+  // =========================================================================
+  // parseOciName
+  // =========================================================================
+
+  describe('parseOciName()', () => {
+    it('should parse a DID-scoped OCI repository name', () => {
+      const result = parseOciName('did:dht:abc123/my-image');
+      expect(result).not.toBeNull();
+      expect(result!.did).toBe('did:dht:abc123');
+      expect(result!.imageName).toBe('my-image');
+    });
+
+    it('should handle nested image names', () => {
+      const result = parseOciName('did:dht:abc123/org/sub-image');
+      expect(result).not.toBeNull();
+      expect(result!.imageName).toBe('org/sub-image');
+    });
+
+    it('should return null for invalid names', () => {
+      expect(parseOciName('not-a-did')).toBeNull();
+    });
+
+    it('should return null for plain image names without DID', () => {
+      expect(parseOciName('library/nginx')).toBeNull();
+    });
+  });
+
+  // =========================================================================
+  // npm registry shim
+  // =========================================================================
+
+  describe('npm registry shim', () => {
+    describe('GET /@did/name — packument', () => {
+      it('should return a packument with all versions', async () => {
+        const res = await handleNpmRequest(ctx, npmUrl(`/@${testDid}/my-utils`));
+        expect(res.status).toBe(200);
+
+        const body = parseBody(res.body);
+        expect(body.name).toBe(`@${testDid}/my-utils`);
+        expect(body.description).toBe('Utility functions');
+        expect(body['dist-tags'].latest).toBeDefined();
+        expect(body.versions['1.0.0']).toBeDefined();
+        expect(body.versions['2.0.0']).toBeDefined();
+      });
+
+      it('should include tarball URLs in each version', async () => {
+        const res = await handleNpmRequest(ctx, npmUrl(`/@${testDid}/my-utils`));
+        const body = parseBody(res.body);
+        const v1 = body.versions['1.0.0'];
+        expect(v1.dist.tarball).toContain('my-utils-1.0.0.tgz');
+      });
+
+      it('should include dependencies in version metadata', async () => {
+        const res = await handleNpmRequest(ctx, npmUrl(`/@${testDid}/my-utils`));
+        const body = parseBody(res.body);
+        const v2 = body.versions['2.0.0'];
+        expect(v2.dependencies).toBeDefined();
+        expect(v2.dependencies[`${testDid}/my-utils`]).toBe('1.0.0');
+      });
+
+      it('should include DWN metadata in _dwn field', async () => {
+        const res = await handleNpmRequest(ctx, npmUrl(`/@${testDid}/my-utils`));
+        const body = parseBody(res.body);
+        expect(body._dwn.publisherDid).toBe(testDid);
+        expect(body._dwn.ecosystem).toBe('npm');
+      });
+
+      it('should return 404 for nonexistent packages', async () => {
+        const res = await handleNpmRequest(ctx, npmUrl(`/@${testDid}/nonexistent`));
+        expect(res.status).toBe(404);
+      });
+    });
+
+    describe('GET /@did/name/version — version metadata', () => {
+      it('should return version-specific metadata', async () => {
+        const res = await handleNpmRequest(ctx, npmUrl(`/@${testDid}/my-utils/1.0.0`));
+        expect(res.status).toBe(200);
+
+        const body = parseBody(res.body);
+        expect(body.name).toBe(`@${testDid}/my-utils`);
+        expect(body.version).toBe('1.0.0');
+        expect(body.dist.tarball).toContain('my-utils-1.0.0.tgz');
+      });
+
+      it('should return 404 for nonexistent version', async () => {
+        const res = await handleNpmRequest(ctx, npmUrl(`/@${testDid}/my-utils/9.9.9`));
+        expect(res.status).toBe(404);
+      });
+    });
+
+    describe('GET tarball — download', () => {
+      it('should return the tarball bytes', async () => {
+        const res = await handleNpmRequest(
+          ctx,
+          npmUrl(`/-/@${testDid}/my-utils/-/my-utils-1.0.0.tgz`),
+        );
+        expect(res.status).toBe(200);
+        expect(res.headers['Content-Type']).toBe('application/octet-stream');
+
+        const bytes = res.body as Uint8Array;
+        expect(bytes.byteLength).toBe(TARBALL_BYTES.byteLength);
+        expect(bytes[0]).toBe(0x1f);
+        expect(bytes[1]).toBe(0x8b);
+      });
+
+      it('should return 404 for nonexistent tarball', async () => {
+        const res = await handleNpmRequest(
+          ctx,
+          npmUrl(`/-/@${testDid}/my-utils/-/my-utils-9.9.9.tgz`),
+        );
+        expect(res.status).toBe(404);
+      });
+
+      it('should return 404 for malformed tarball filename', async () => {
+        const res = await handleNpmRequest(
+          ctx,
+          npmUrl(`/-/@${testDid}/my-utils/-/bad-file.tar`),
+        );
+        expect(res.status).toBe(404);
+      });
+    });
+
+    describe('error cases', () => {
+      it('should return 404 for non-DID-scoped requests', async () => {
+        const res = await handleNpmRequest(ctx, npmUrl('/lodash'));
+        expect(res.status).toBe(404);
+        const body = parseBody(res.body);
+        expect(body.error).toContain('DID-scoped');
+      });
+    });
+  });
+
+  // =========================================================================
+  // Go module proxy shim
+  // =========================================================================
+
+  describe('Go module proxy shim', () => {
+    describe('GET /@v/list — version list', () => {
+      it('should list available versions with v prefix', async () => {
+        const res = await handleGoProxyRequest(
+          ctx,
+          goUrl(`/${testDid}/my-mod/@v/list`),
+        );
+        expect(res.status).toBe(200);
+        expect(res.headers['Content-Type']).toBe('text/plain');
+
+        const body = res.body as string;
+        expect(body).toContain('v1.0.0');
+        expect(body).toContain('v2.0.0');
+      });
+
+      it('should return 410 for nonexistent module', async () => {
+        const res = await handleGoProxyRequest(
+          ctx,
+          goUrl(`/${testDid}/nonexistent/@v/list`),
+        );
+        expect(res.status).toBe(410);
+      });
+    });
+
+    describe('GET /@v/{ver}.info — version info', () => {
+      it('should return version info JSON', async () => {
+        const res = await handleGoProxyRequest(
+          ctx,
+          goUrl(`/${testDid}/my-mod/@v/v1.0.0.info`),
+        );
+        expect(res.status).toBe(200);
+
+        const body = parseBody(res.body);
+        expect(body.Version).toBe('v1.0.0');
+        expect(body.Time).toBeDefined();
+      });
+
+      it('should handle versions without v prefix', async () => {
+        const res = await handleGoProxyRequest(
+          ctx,
+          goUrl(`/${testDid}/my-mod/@v/1.0.0.info`),
+        );
+        expect(res.status).toBe(200);
+
+        const body = parseBody(res.body);
+        expect(body.Version).toBe('v1.0.0');
+      });
+
+      it('should return 410 for nonexistent version', async () => {
+        const res = await handleGoProxyRequest(
+          ctx,
+          goUrl(`/${testDid}/my-mod/@v/v9.9.9.info`),
+        );
+        expect(res.status).toBe(410);
+      });
+    });
+
+    describe('GET /@v/{ver}.mod — go.mod file', () => {
+      it('should return a valid go.mod file', async () => {
+        const res = await handleGoProxyRequest(
+          ctx,
+          goUrl(`/${testDid}/my-mod/@v/v1.0.0.mod`),
+        );
+        expect(res.status).toBe(200);
+
+        const body = res.body as string;
+        expect(body).toContain(`module did.enbox.org/${testDid}/my-mod`);
+        expect(body).toContain('go 1.21');
+      });
+
+      it('should include dependencies in go.mod', async () => {
+        const res = await handleGoProxyRequest(
+          ctx,
+          goUrl(`/${testDid}/my-mod/@v/v2.0.0.mod`),
+        );
+        expect(res.status).toBe(200);
+
+        const body = res.body as string;
+        expect(body).toContain('require (');
+        expect(body).toContain(`did.enbox.org/${testDid}/my-mod`);
+      });
+    });
+
+    describe('GET /@v/{ver}.zip — module archive', () => {
+      it('should return the module archive bytes', async () => {
+        const res = await handleGoProxyRequest(
+          ctx,
+          goUrl(`/${testDid}/my-mod/@v/v1.0.0.zip`),
+        );
+        expect(res.status).toBe(200);
+        expect(res.headers['Content-Type']).toBe('application/zip');
+
+        const bytes = res.body as Uint8Array;
+        expect(bytes.byteLength).toBe(TARBALL_BYTES.byteLength);
+      });
+
+      it('should return 410 for nonexistent version', async () => {
+        const res = await handleGoProxyRequest(
+          ctx,
+          goUrl(`/${testDid}/my-mod/@v/v9.9.9.zip`),
+        );
+        expect(res.status).toBe(410);
+      });
+    });
+
+    describe('GET /@latest — latest version', () => {
+      it('should return the latest version info', async () => {
+        const res = await handleGoProxyRequest(
+          ctx,
+          goUrl(`/${testDid}/my-mod/@latest`),
+        );
+        expect(res.status).toBe(200);
+
+        const body = parseBody(res.body);
+        expect(body.Version).toBeDefined();
+        expect(body.Time).toBeDefined();
+      });
+
+      it('should return 410 for nonexistent module', async () => {
+        const res = await handleGoProxyRequest(
+          ctx,
+          goUrl(`/${testDid}/nonexistent/@latest`),
+        );
+        expect(res.status).toBe(410);
+      });
+    });
+
+    describe('error cases', () => {
+      it('should return 404 for non-module paths', async () => {
+        const res = await handleGoProxyRequest(ctx, goUrl('/random/path'));
+        expect(res.status).toBe(404);
+      });
+
+      it('should return 404 for invalid module paths', async () => {
+        const res = await handleGoProxyRequest(ctx, goUrl('/not-a-did/@v/list'));
+        expect(res.status).toBe(404);
+      });
+    });
+  });
+
+  // =========================================================================
+  // OCI/Docker registry shim
+  // =========================================================================
+
+  describe('OCI/Docker registry shim', () => {
+    describe('GET /v2/ — API version check', () => {
+      it('should return 200 with registry API version header', async () => {
+        const res = await handleOciRequest(ctx, ociUrl('/v2/'));
+        expect(res.status).toBe(200);
+        expect(res.headers['Docker-Distribution-Api-Version']).toBe('registry/2.0');
+      });
+
+      it('should work without trailing slash', async () => {
+        const res = await handleOciRequest(ctx, ociUrl('/v2'));
+        expect(res.status).toBe(200);
+      });
+    });
+
+    describe('GET /v2/{name}/tags/list — list tags', () => {
+      it('should list available tags', async () => {
+        const res = await handleOciRequest(
+          ctx,
+          ociUrl(`/v2/${testDid}/my-image/tags/list`),
+        );
+        expect(res.status).toBe(200);
+
+        const body = parseBody(res.body);
+        expect(body.name).toBe(`${testDid}/my-image`);
+        expect(body.tags).toBeArray();
+        expect(body.tags).toContain('v1.0.0');
+      });
+
+      it('should return 404 for nonexistent repository', async () => {
+        const res = await handleOciRequest(
+          ctx,
+          ociUrl(`/v2/${testDid}/nonexistent/tags/list`),
+        );
+        expect(res.status).toBe(404);
+        const body = parseBody(res.body);
+        expect(body.errors[0].code).toBe('NAME_UNKNOWN');
+      });
+
+      it('should return 404 for invalid repository names', async () => {
+        const res = await handleOciRequest(
+          ctx,
+          ociUrl('/v2/not-a-did/tags/list'),
+        );
+        expect(res.status).toBe(404);
+        const body = parseBody(res.body);
+        expect(body.errors[0].code).toBe('NAME_INVALID');
+      });
+    });
+
+    describe('GET /v2/{name}/manifests/{reference} — pull manifest', () => {
+      it('should return the manifest by tag', async () => {
+        const res = await handleOciRequest(
+          ctx,
+          ociUrl(`/v2/${testDid}/my-image/manifests/v1.0.0`),
+        );
+        expect(res.status).toBe(200);
+        expect(res.headers['Content-Type']).toBe('application/vnd.oci.image.manifest.v1+json');
+        expect(res.headers['Docker-Content-Digest']).toMatch(/^sha256:/);
+
+        const body = parseBody(res.body);
+        expect(body.schemaVersion).toBe(2);
+        expect(body.config).toBeDefined();
+        expect(body.layers).toBeArray();
+      });
+
+      it('should return the manifest by digest', async () => {
+        // First get the digest from a tag-based request.
+        const tagRes = await handleOciRequest(
+          ctx,
+          ociUrl(`/v2/${testDid}/my-image/manifests/v1.0.0`),
+        );
+        const digest = tagRes.headers['Docker-Content-Digest'];
+
+        // Now fetch by digest.
+        const digestRes = await handleOciRequest(
+          ctx,
+          ociUrl(`/v2/${testDid}/my-image/manifests/${digest}`),
+        );
+        expect(digestRes.status).toBe(200);
+        expect(digestRes.headers['Docker-Content-Digest']).toBe(digest);
+      });
+
+      it('should handle HEAD requests (manifest existence check)', async () => {
+        const res = await handleOciRequest(
+          ctx,
+          ociUrl(`/v2/${testDid}/my-image/manifests/v1.0.0`),
+          'HEAD',
+        );
+        expect(res.status).toBe(200);
+        expect(res.headers['Docker-Content-Digest']).toMatch(/^sha256:/);
+        expect(res.headers['Content-Length']).toBeDefined();
+        // HEAD response body should be empty.
+        expect(res.body).toBe('');
+      });
+
+      it('should return 404 for nonexistent tag', async () => {
+        const res = await handleOciRequest(
+          ctx,
+          ociUrl(`/v2/${testDid}/my-image/manifests/v9.9.9`),
+        );
+        expect(res.status).toBe(404);
+        const body = parseBody(res.body);
+        expect(body.errors[0].code).toBe('MANIFEST_UNKNOWN');
+      });
+
+      it('should return 404 for nonexistent digest', async () => {
+        const res = await handleOciRequest(
+          ctx,
+          ociUrl(`/v2/${testDid}/my-image/manifests/sha256:0000000000000000`),
+        );
+        expect(res.status).toBe(404);
+      });
+    });
+
+    describe('GET /v2/{name}/blobs/{digest} — pull blob', () => {
+      it('should return a blob matching the manifest content digest', async () => {
+        // Get the digest of the manifest (which is our "blob" in this test).
+        const tagRes = await handleOciRequest(
+          ctx,
+          ociUrl(`/v2/${testDid}/my-image/manifests/v1.0.0`),
+        );
+        const digest = tagRes.headers['Docker-Content-Digest'];
+
+        const blobRes = await handleOciRequest(
+          ctx,
+          ociUrl(`/v2/${testDid}/my-image/blobs/${digest}`),
+        );
+        expect(blobRes.status).toBe(200);
+        expect(blobRes.headers['Content-Type']).toBe('application/octet-stream');
+        expect(blobRes.headers['Docker-Content-Digest']).toBe(digest);
+      });
+
+      it('should return 404 for nonexistent blob digest', async () => {
+        const res = await handleOciRequest(
+          ctx,
+          ociUrl(`/v2/${testDid}/my-image/blobs/sha256:0000000000000000`),
+        );
+        expect(res.status).toBe(404);
+        const body = parseBody(res.body);
+        expect(body.errors[0].code).toBe('BLOB_UNKNOWN');
+      });
+
+      it('should return 404 for nonexistent repository', async () => {
+        const res = await handleOciRequest(
+          ctx,
+          ociUrl(`/v2/${testDid}/nonexistent/blobs/sha256:0000`),
+        );
+        expect(res.status).toBe(404);
+      });
+    });
+
+    describe('error cases', () => {
+      it('should return 404 for invalid v2 paths', async () => {
+        const res = await handleOciRequest(ctx, ociUrl('/v2/invalid'));
+        expect(res.status).toBe(404);
+      });
+
+      it('should return OCI error envelope with code and message', async () => {
+        const res = await handleOciRequest(
+          ctx,
+          ociUrl(`/v2/${testDid}/nonexistent/manifests/latest`),
+        );
+        expect(res.status).toBe(404);
+        const body = parseBody(res.body);
+        expect(body.errors).toBeArray();
+        expect(body.errors[0].code).toBeDefined();
+        expect(body.errors[0].message).toBeDefined();
+      });
+
+      it('should include Docker-Distribution-Api-Version header in errors', async () => {
+        const res = await handleOciRequest(
+          ctx,
+          ociUrl(`/v2/${testDid}/nonexistent/manifests/latest`),
+        );
+        expect(res.headers['Docker-Distribution-Api-Version']).toBe('registry/2.0');
+      });
+    });
+  });
+
+  // =========================================================================
+  // Cross-cutting concerns
+  // =========================================================================
+
+  describe('cross-cutting', () => {
+    it('npm packument dist-tags.latest should point to a real version', async () => {
+      const res = await handleNpmRequest(ctx, npmUrl(`/@${testDid}/my-utils`));
+      const body = parseBody(res.body);
+      const latest = body['dist-tags'].latest;
+      expect(body.versions[latest]).toBeDefined();
+    });
+
+    it('Go proxy list and .info should be consistent', async () => {
+      const listRes = await handleGoProxyRequest(
+        ctx,
+        goUrl(`/${testDid}/my-mod/@v/list`),
+      );
+      const versions = (listRes.body as string).split('\n').filter(Boolean);
+      expect(versions.length).toBeGreaterThan(0);
+
+      // Each listed version should have valid .info
+      for (const ver of versions) {
+        const infoRes = await handleGoProxyRequest(
+          ctx,
+          goUrl(`/${testDid}/my-mod/@v/${ver}.info`),
+        );
+        expect(infoRes.status).toBe(200);
+      }
+    });
+
+    it('OCI tags/list and manifests should be consistent', async () => {
+      const tagsRes = await handleOciRequest(
+        ctx,
+        ociUrl(`/v2/${testDid}/my-image/tags/list`),
+      );
+      const body = parseBody(tagsRes.body);
+
+      for (const tag of body.tags) {
+        const manifestRes = await handleOciRequest(
+          ctx,
+          ociUrl(`/v2/${testDid}/my-image/manifests/${tag}`),
+        );
+        expect(manifestRes.status).toBe(200);
+      }
+    });
+
+    it('all shims return CORS headers', async () => {
+      const npmRes = await handleNpmRequest(ctx, npmUrl(`/@${testDid}/my-utils`));
+      expect(npmRes.headers['Access-Control-Allow-Origin']).toBe('*');
+
+      const goRes = await handleGoProxyRequest(
+        ctx,
+        goUrl(`/${testDid}/my-mod/@v/list`),
+      );
+      expect(goRes.headers['Access-Control-Allow-Origin']).toBe('*');
+
+      const ociRes = await handleOciRequest(ctx, ociUrl('/v2/'));
+      expect(ociRes.headers['Access-Control-Allow-Origin']).toBe('*');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **npm registry shim** — local proxy that serves the npm registry HTTP API, enabling `npm install --registry=http://localhost:4873 @did:dht:abc123/my-pkg`
- **Go module proxy shim** — GOPROXY-compatible server for `GOPROXY=http://localhost:4874 go get did.enbox.org/did:dht:abc123/my-mod@v1.0.0`
- **OCI/Docker registry shim** — OCI Distribution Spec v2 server for `docker pull localhost:5555/did:dht:abc123/my-image:v1.0.0`
- **CLI integration** — `dwn-git shim npm|go|oci [--port]` with env var overrides
- **Registry protocol update** — added `oci` to the ecosystem enum for container image support

## Architecture

Each shim is a local HTTP proxy that speaks the native protocol of its ecosystem tool but resolves packages from DWN records via the existing resolver module. All shims are read-only and inherit DWN's cryptographic provenance guarantees.

### npm shim (`src/shims/npm/`)
| Endpoint | Maps to |
|---|---|
| `GET /@scope/name` | Packument (all versions, dist-tags, tarball URLs) |
| `GET /@scope/name/version` | Version-specific metadata |
| `GET /-/@scope/name/-/name-ver.tgz` | Tarball download from DWN |

### Go proxy shim (`src/shims/go/`)
| Endpoint | Maps to |
|---|---|
| `GET /{module}/@v/list` | Version listing |
| `GET /{module}/@v/{ver}.info` | Version JSON (Version + Time) |
| `GET /{module}/@v/{ver}.mod` | Generated go.mod |
| `GET /{module}/@v/{ver}.zip` | Module archive from DWN |
| `GET /{module}/@latest` | Latest version info |

### OCI shim (`src/shims/oci/`)
| Endpoint | Maps to |
|---|---|
| `GET /v2/` | API version check |
| `GET /v2/{name}/tags/list` | Tag listing |
| `GET /v2/{name}/manifests/{ref}` | Manifest by tag or SHA-256 digest |
| `HEAD /v2/{name}/manifests/{ref}` | Manifest existence check |
| `GET /v2/{name}/blobs/{digest}` | Blob download |

## Test results

56 new tests with 122 assertions. Full suite: **763 pass, 0 fail**, 9 skip, 1879 assertions across 19 test files.

## Files changed

- `src/shims/npm/` — npm registry shim (3 files)
- `src/shims/go/` — Go module proxy shim (3 files)
- `src/shims/oci/` — OCI registry shim (3 files)
- `src/shims/index.ts` — barrel exports
- `src/cli/commands/shim.ts` — CLI shim command
- `src/cli/main.ts` — wire in shim command + help text
- `src/registry.ts` — add `oci` to ecosystem enum
- `package.json` — 4 new sub-path exports
- `tests/shims.spec.ts` — 56 tests
- `tests/protocols.spec.ts` — update ecosystem enum test
- `PLAN.md` — document shims architecture + update roadmap
- `README.md` — document shims usage + update status