### PR TITLE
feat: GitHub API shim write endpoints — issues, PRs, reviews, releases

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1368,7 +1368,7 @@ Registry CLI with 5 subcommands and 20 CLI tests — 525 total tests, 1282 asser
 - [x] **Web UI**: read-only repo/issue/PR viewer
 - [ ] **VS Code extension**: native IDE integration (separate repo, post-stabilization)
 - [x] **GitHub migration tool**: import repos, issues, PRs from GitHub
-- [x] **GitHub API compatibility shim**: read-only Phase 1 (10 endpoints)
+- [x] **GitHub API compatibility shim**: read + write (18 endpoints — 10 GET, 8 POST/PATCH/PUT)
 - [x] **Package manager shims**: npm registry proxy, Go module proxy, OCI/Docker registry proxy — 56 tests, 122 assertions
 
 ---
@@ -1484,7 +1484,7 @@ dwn-git/
     ├── ref-sync.spec.ts        # Ref sync tests
     ├── verify.spec.ts          # Signature verification tests
     ├── credential-helper.spec.ts # Credential helper tests
-    ├── github-shim.spec.ts     # GitHub API shim tests (56 tests)
+    ├── github-shim.spec.ts     # GitHub API shim tests (92 tests)
     ├── resolver.spec.ts        # Resolver, attestation, trust chain tests (41 tests)
     └── shims.spec.ts           # Package manager shim tests (56 tests)
 ```

--- a/README.md
+++ b/README.md
@@ -173,10 +173,12 @@ dwn-git whoami                    # Show connected DID
 
 ### GitHub API Compatibility Shim
 
-- Read-only HTTP server that translates GitHub REST API v3 requests into DWN queries
-- Allows existing GitHub-compatible tools (VS Code extensions, `gh` CLI, CI systems) to read DWN data
+- HTTP server that translates GitHub REST API v3 requests into DWN queries and writes
+- Allows existing GitHub-compatible tools (VS Code extensions, `gh` CLI, CI systems) to interact with DWN data
 - DID is used as the GitHub "owner" in URLs: `GET /repos/:did/:repo/issues`
-- 10 Phase 1 endpoints: repo info, issues (list/detail/comments), pulls (list/detail/reviews), releases (list/by-tag), user profile
+- 18 endpoints (10 read, 8 write):
+  - **Read (GET)**: repo info, issues (list/detail/comments), pulls (list/detail/reviews), releases (list/by-tag), user profile
+  - **Write**: create/update issues, create issue comments, create/update/merge pull requests, create pull reviews, create releases
 - GitHub-compatible response shapes: numeric IDs, pagination (`Link` header, `per_page`), rate limit headers
 - CORS enabled, `X-GitHub-Media-Type: github.v3` header
 - Start with `dwn-git github-api [--port <port>]` (default: 8181, configurable via `DWN_GIT_GITHUB_API_PORT`)
@@ -301,7 +303,7 @@ bun test               # Run all tests
 
 ## Status
 
-**All phases complete** — working MVP with CLI commands for all 11 protocols, git transport, DID-signed push auth, ref mirroring, bundle storage, package registry with attestation system and dependency trust chain verification, GitHub migration tool, read-only web UI, indexer service, GitHub API compatibility shim, and package manager shims (npm, Go, OCI/Docker). 763+ tests across 19 test files. See PLAN.md Section 12 for the full roadmap.
+**All phases complete** — working MVP with CLI commands for all 11 protocols, git transport, DID-signed push auth, ref mirroring, bundle storage, package registry with attestation system and dependency trust chain verification, GitHub migration tool, read-only web UI, indexer service, GitHub API compatibility shim (read + write), and package manager shims (npm, Go, OCI/Docker). 799+ tests across 19 test files. See PLAN.md Section 12 for the full roadmap.
 
 ## License
 

--- a/src/github-shim/index.ts
+++ b/src/github-shim/index.ts
@@ -8,9 +8,9 @@ export { handleShimRequest, startShimServer } from './server.js';
 export type { ShimServerOptions } from './server.js';
 
 export { handleGetRepo, buildRepoResponse } from './repos.js';
-export { handleGetIssue, handleListIssueComments, handleListIssues } from './issues.js';
-export { handleGetPull, handleListPullReviews, handleListPulls } from './pulls.js';
-export { handleGetReleaseByTag, handleListReleases } from './releases.js';
+export { handleCreateIssue, handleCreateIssueComment, handleGetIssue, handleListIssueComments, handleListIssues, handleUpdateIssue } from './issues.js';
+export { handleCreatePull, handleCreatePullReview, handleGetPull, handleListPullReviews, handleListPulls, handleMergePull, handleUpdatePull } from './pulls.js';
+export { handleCreateRelease, handleGetReleaseByTag, handleListReleases } from './releases.js';
 export { handleGetUser } from './users.js';
 
 export {
@@ -18,6 +18,8 @@ export {
   buildLinkHeader,
   buildOwner,
   fromOpt,
+  getNextIssueNumber,
+  getNextPatchNumber,
   getRepoRecord,
   numericId,
   paginate,


### PR DESCRIPTION
## Summary

- Add 8 write endpoints to the GitHub API compatibility shim, bringing it from read-only (10 GET) to full read+write (18 endpoints)
- Update server router to dispatch by HTTP method with JSON body parsing and proper CORS for POST/PATCH/PUT/DELETE
- Add 36 new tests covering all write endpoints, validation errors, 404s, and 405 method-not-allowed cases

## Write Endpoints

| Method | Path | Description |
|--------|------|-------------|
| `POST` | `/repos/:did/:repo/issues` | Create issue |
| `PATCH` | `/repos/:did/:repo/issues/:number` | Update issue (title, body, state) |
| `POST` | `/repos/:did/:repo/issues/:number/comments` | Create issue comment |
| `POST` | `/repos/:did/:repo/pulls` | Create pull request |
| `PATCH` | `/repos/:did/:repo/pulls/:number` | Update pull request (title, body, state, base) |
| `PUT` | `/repos/:did/:repo/pulls/:number/merge` | Merge pull request |
| `POST` | `/repos/:did/:repo/pulls/:number/reviews` | Create pull review (APPROVE/REQUEST_CHANGES/COMMENT) |
| `POST` | `/repos/:did/:repo/releases` | Create release (with prerelease/draft flags) |

## Server Changes

- `handleShimRequest()` now accepts optional `method` and `reqBody` params (backward compatible — defaults to `GET`)
- `dispatchRepoRoute()` routes by both URL path and HTTP method
- `startShimServer()` parses JSON request bodies for POST/PATCH/PUT
- CORS preflight updated to allow `POST, PATCH, PUT, DELETE`
- Unsupported method+path combos return `405 Method Not Allowed`

## Test Results

- **github-shim.spec.ts**: 92 pass, 0 fail, 254 assertions (up from 56 tests)
- **Full suite**: 799 pass, 0 fail, 9 skip, 1970 assertions across 19 files
- Lint: clean, Build: clean

## Files Changed (9)

- `src/github-shim/pulls.ts` — 4 new handlers: create, update, merge, create review
- `src/github-shim/releases.ts` — 1 new handler: create release
- `src/github-shim/issues.ts` — 3 new handlers: create issue, update issue, create comment
- `src/github-shim/helpers.ts` — New helpers: `jsonCreated`, `jsonValidationError`, `jsonMethodNotAllowed`, `getNextIssueNumber`, `getNextPatchNumber`
- `src/github-shim/server.ts` — Rewritten router with method-based dispatch and body parsing
- `src/github-shim/index.ts` — Updated barrel exports
- `tests/github-shim.spec.ts` — 36 new test cases
- `PLAN.md` / `README.md` — Updated docs and test counts