### PR TITLE
feat: unified daemon with ShimAdapter plugin architecture

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1370,6 +1370,7 @@ Registry CLI with 5 subcommands and 20 CLI tests — 525 total tests, 1282 asser
 - [x] **GitHub migration tool**: import repos, issues, PRs from GitHub
 - [x] **GitHub API compatibility shim**: read + write (18 endpoints — 10 GET, 8 POST/PATCH/PUT)
 - [x] **Package manager shims**: npm registry proxy, Go module proxy, OCI/Docker registry proxy — 56 tests, 122 assertions
+- [x] **Unified daemon**: `ShimAdapter` interface, config-driven multi-shim process, `dwn-git daemon` command — 34 tests, 85 assertions
 
 ---
 
@@ -1457,6 +1458,16 @@ dwn-git/
 │           ├── index.ts
 │           ├── registry.ts     # OCI Distribution API handlers
 │           └── server.ts       # HTTP server
+│   └── daemon/                 # Unified shim daemon
+│       ├── index.ts            # Barrel re-export
+│       ├── adapter.ts          # ShimAdapter interface + config types
+│       ├── server.ts           # DaemonServer lifecycle (start, stop, health)
+│       └── adapters/           # Per-ecosystem adapter implementations
+│           ├── index.ts        # Adapter registry (builtinAdapters)
+│           ├── github.ts       # GitHub API adapter
+│           ├── npm.ts          # npm registry adapter
+│           ├── go.ts           # Go module proxy adapter
+│           └── oci.ts          # OCI/Docker registry adapter
 ├── schemas/                    # JSON Schema files (34 files)
 │   ├── repo/
 │   ├── refs/
@@ -1486,5 +1497,6 @@ dwn-git/
     ├── credential-helper.spec.ts # Credential helper tests
     ├── github-shim.spec.ts     # GitHub API shim tests (92 tests)
     ├── resolver.spec.ts        # Resolver, attestation, trust chain tests (41 tests)
-    └── shims.spec.ts           # Package manager shim tests (56 tests)
+    ├── shims.spec.ts           # Package manager shim tests (56 tests)
+    └── daemon.spec.ts          # Unified daemon tests (34 tests)
 ```

--- a/package.json
+++ b/package.json
@@ -65,6 +65,10 @@
     "./shims/oci": {
       "types": "./dist/types/shims/oci/index.d.ts",
       "import": "./dist/esm/shims/oci/index.js"
+    },
+    "./daemon": {
+      "types": "./dist/types/daemon/index.d.ts",
+      "import": "./dist/esm/daemon/index.js"
     }
   },
   "keywords": [

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -1,0 +1,129 @@
+/**
+ * `dwn-git daemon` — start the unified shim daemon.
+ *
+ * Starts all enabled ecosystem shims in a single process.  Each shim
+ * runs on its own port and speaks the native protocol of its ecosystem
+ * (GitHub REST API, npm registry, GOPROXY, OCI Distribution, etc.).
+ *
+ * Usage:
+ *   dwn-git daemon                                Start all shims with defaults
+ *   dwn-git daemon --config ./daemon.json         Use a config file
+ *   dwn-git daemon --only github,npm              Only start specific shims
+ *   dwn-git daemon --disable go,oci               Start all except specific shims
+ *   dwn-git daemon --list                         List available shims and exit
+ *
+ * Config file format (dwn-git.daemon.json):
+ *   {
+ *     "shims": {
+ *       "github": { "enabled": true, "port": 8181 },
+ *       "npm":    { "enabled": true, "port": 4873 },
+ *       "go":     { "enabled": true, "port": 4874 },
+ *       "oci":    { "enabled": true, "port": 5555 }
+ *     }
+ *   }
+ *
+ * @module
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+
+import type { AgentContext } from '../agent.js';
+import type { DaemonConfig } from '../../daemon/adapter.js';
+
+import { builtinAdapters } from '../../daemon/adapters/index.js';
+import { flagValue } from '../flags.js';
+import { startDaemon } from '../../daemon/server.js';
+
+// ---------------------------------------------------------------------------
+// Config loading
+// ---------------------------------------------------------------------------
+
+/** Default config file name searched in CWD. */
+const DEFAULT_CONFIG_FILES = [
+  'dwn-git.daemon.json',
+  '.dwn-git-daemon.json',
+];
+
+/**
+ * Load and merge config from file + CLI flags.
+ */
+function loadConfig(args: string[]): DaemonConfig {
+  // Start with empty config (all defaults).
+  let config: DaemonConfig = {};
+
+  // Load config file if specified or found in CWD.
+  const configPath = flagValue(args, '--config');
+  if (configPath) {
+    if (!existsSync(configPath)) {
+      console.error(`Config file not found: ${configPath}`);
+      process.exit(1);
+    }
+    config = JSON.parse(readFileSync(configPath, 'utf-8'));
+  } else {
+    // Auto-discover config in CWD.
+    for (const name of DEFAULT_CONFIG_FILES) {
+      if (existsSync(name)) {
+        config = JSON.parse(readFileSync(name, 'utf-8'));
+        console.log(`[daemon] Using config from ${name}`);
+        break;
+      }
+    }
+  }
+
+  // Apply --only filter (disables everything not listed).
+  const only = flagValue(args, '--only');
+  if (only) {
+    const ids = new Set(only.split(',').map((s) => s.trim()));
+    if (!config.shims) { config.shims = {}; }
+    for (const adapter of builtinAdapters) {
+      if (!config.shims[adapter.id]) { config.shims[adapter.id] = {}; }
+      config.shims[adapter.id].enabled = ids.has(adapter.id);
+    }
+  }
+
+  // Apply --disable filter.
+  const disable = flagValue(args, '--disable');
+  if (disable) {
+    const ids = new Set(disable.split(',').map((s) => s.trim()));
+    if (!config.shims) { config.shims = {}; }
+    for (const id of ids) {
+      if (!config.shims[id]) { config.shims[id] = {}; }
+      config.shims[id].enabled = false;
+    }
+  }
+
+  return config;
+}
+
+// ---------------------------------------------------------------------------
+// Command
+// ---------------------------------------------------------------------------
+
+export async function daemonCommand(ctx: AgentContext, args: string[]): Promise<void> {
+  // --list: show available shims and exit.
+  if (args.includes('--list')) {
+    console.log('Available shims:\n');
+    for (const adapter of builtinAdapters) {
+      console.log(`  ${adapter.id.padEnd(12)} ${adapter.name.padEnd(24)} default port: ${adapter.defaultPort}  env: ${adapter.portEnvVar}`);
+    }
+    console.log(`\nTotal: ${builtinAdapters.length} adapters`);
+    return;
+  }
+
+  const config = loadConfig(args);
+  const instance = await startDaemon({ ctx, config });
+
+  // Register signal handlers for graceful shutdown.
+  const shutdown = async (): Promise<void> => {
+    console.log('\n[daemon] Shutting down...');
+    await instance.stop();
+    console.log('[daemon] All shims stopped.');
+    process.exit(0);
+  };
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+
+  // Keep the process alive.
+  await new Promise(() => {});
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -49,6 +49,7 @@
  *   dwn-git migrate releases <owner/repo>       Import releases
  *   dwn-git web [--port <port>]                Start the read-only web UI
  *   dwn-git indexer [--port] [--interval] [--seed]  Start the indexer service
+ *   dwn-git daemon [--config <path>] [--only ...] Start unified shim daemon
  *   dwn-git github-api [--port <port>]         Start GitHub API compatibility shim
  *   dwn-git shim npm [--port 4873]             Start npm registry proxy
  *   dwn-git shim go  [--port 4874]             Start Go module proxy (GOPROXY)
@@ -68,6 +69,7 @@
 import { ciCommand } from './commands/ci.js';
 import { cloneCommand } from './commands/clone.js';
 import { connectAgent } from './agent.js';
+import { daemonCommand } from './commands/daemon.js';
 import { githubApiCommand } from './commands/github-api.js';
 import { indexerCommand } from '../indexer/main.js';
 import { initCommand } from './commands/init.js';
@@ -178,6 +180,9 @@ function printUsage(): void {
   console.log('');
   console.log('  indexer [--port <port>] [--interval <sec>]  Start the indexer service');
   console.log('  indexer --seed <did>                        Discover DIDs from a seed');
+  console.log('');
+  console.log('  daemon [--config <path>] [--only ...]        Start all shims in one process');
+  console.log('  daemon --list                               List available shim adapters');
   console.log('');
   console.log('  github-api [--port <port>]                  Start GitHub API shim (default: 8181)');
   console.log('');
@@ -310,6 +315,10 @@ async function main(): Promise<void> {
 
     case 'indexer':
       await indexerCommand(ctx, rest);
+      break;
+
+    case 'daemon':
+      await daemonCommand(ctx, rest);
       break;
 
     case 'github-api':

--- a/src/daemon/adapter.ts
+++ b/src/daemon/adapter.ts
@@ -1,0 +1,95 @@
+/**
+ * ShimAdapter — the interface every ecosystem shim implements to plug
+ * into the unified daemon.
+ *
+ * Each adapter wraps a specific protocol translation (GitHub REST API,
+ * npm registry, Go module proxy, OCI Distribution, etc.) behind a
+ * uniform contract.  The daemon starts one HTTP server per enabled
+ * adapter and delegates all request handling to the adapter.
+ *
+ * To add a new ecosystem (e.g. Maven Central, Rust crates.io):
+ *   1. Implement `ShimAdapter`
+ *   2. Register it in `adapters/index.ts`
+ *   3. The daemon picks it up automatically
+ *
+ * @module
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+import type { AgentContext } from '../cli/agent.js';
+
+// ---------------------------------------------------------------------------
+// Adapter interface
+// ---------------------------------------------------------------------------
+
+/** A shim adapter bridges between an ecosystem's native HTTP protocol and DWN. */
+export interface ShimAdapter {
+  /** Unique identifier — used in config and CLI flags (e.g. `'github'`, `'npm'`). */
+  readonly id: string;
+
+  /** Human-readable name for log output (e.g. `'GitHub API'`, `'npm registry'`). */
+  readonly name: string;
+
+  /** Default port when none is configured. */
+  readonly defaultPort: number;
+
+  /** Environment variable that overrides the default port (e.g. `'DWN_GIT_GITHUB_API_PORT'`). */
+  readonly portEnvVar: string;
+
+  /**
+   * Handle an incoming HTTP request.
+   *
+   * The daemon calls this for every non-OPTIONS request on the
+   * adapter's server.  The adapter is responsible for writing the
+   * full response (status, headers, body) to `res`.
+   *
+   * CORS preflight (OPTIONS) is handled by the daemon — adapters
+   * never see OPTIONS requests.
+   */
+  handle(ctx: AgentContext, req: IncomingMessage, res: ServerResponse): Promise<void>;
+
+  /**
+   * Additional CORS methods to advertise in the preflight response.
+   * Defaults to `'GET, OPTIONS'` if not provided.
+   */
+  readonly corsMethods?: string;
+
+  /**
+   * Additional CORS headers to advertise in the preflight response.
+   * Defaults to `'Authorization, Accept, Content-Type'` if not provided.
+   */
+  readonly corsHeaders?: string;
+
+  /**
+   * One-line usage hint printed when the adapter starts.
+   * Can reference `{port}` which will be replaced with the actual port.
+   */
+  readonly usageHint?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/** Per-shim configuration entry. */
+export type ShimConfig = {
+  /** Whether this shim is enabled. Defaults to `true`. */
+  enabled? : boolean;
+
+  /** Port override. Falls back to env var, then `defaultPort`. */
+  port? : number;
+};
+
+/** Full daemon configuration. */
+export type DaemonConfig = {
+  /** Per-shim overrides keyed by adapter `id`. */
+  shims? : Record<string, ShimConfig>;
+};
+
+/** Resolved runtime config for a single shim — all values concrete. */
+export type ResolvedShimConfig = {
+  adapter : ShimAdapter;
+  enabled : boolean;
+  port : number;
+};

--- a/src/daemon/adapters/github.ts
+++ b/src/daemon/adapters/github.ts
@@ -1,0 +1,72 @@
+/**
+ * GitHub API shim adapter for the unified daemon.
+ *
+ * Wraps `handleShimRequest()` behind the `ShimAdapter` interface.
+ *
+ * @module
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+import type { AgentContext } from '../../cli/agent.js';
+import type { ShimAdapter } from '../adapter.js';
+
+import { handleShimRequest } from '../../github-shim/server.js';
+import { baseHeaders, jsonMethodNotAllowed } from '../../github-shim/helpers.js';
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+export const githubAdapter: ShimAdapter = {
+  id          : 'github',
+  name        : 'GitHub API',
+  defaultPort : 8181,
+  portEnvVar  : 'DWN_GIT_GITHUB_API_PORT',
+  corsMethods : 'GET, POST, PATCH, PUT, DELETE, OPTIONS',
+  corsHeaders : 'Authorization, Accept, Content-Type',
+  usageHint   : 'GitHub REST API v3 compatible — point tools at http://localhost:{port}',
+
+  async handle(ctx: AgentContext, req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const method = req.method ?? 'GET';
+    const port = (req.socket.address() as { port?: number })?.port ?? 8181;
+    const url = new URL(req.url ?? '/', `http://localhost:${port}`);
+
+    // Reject truly unsupported methods.
+    const allowed = new Set(['GET', 'POST', 'PATCH', 'PUT', 'DELETE']);
+    if (!allowed.has(method)) {
+      const r = jsonMethodNotAllowed(`Method ${method} is not supported.`);
+      res.writeHead(r.status, r.headers);
+      res.end(r.body);
+      return;
+    }
+
+    // Parse body for mutating methods.
+    let reqBody: Record<string, unknown> = {};
+    if (method === 'POST' || method === 'PATCH' || method === 'PUT') {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) {
+        chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+      }
+      const raw = Buffer.concat(chunks).toString('utf-8');
+      if (raw.length > 0) {
+        try {
+          reqBody = JSON.parse(raw);
+        } catch {
+          res.writeHead(400, baseHeaders());
+          res.end(JSON.stringify({ message: 'Invalid JSON in request body.' }));
+          return;
+        }
+      }
+    }
+
+    try {
+      const result = await handleShimRequest(ctx, url, method, reqBody);
+      res.writeHead(result.status, result.headers);
+      res.end(result.body);
+    } catch {
+      res.writeHead(500, baseHeaders());
+      res.end(JSON.stringify({ message: 'Internal server error' }));
+    }
+  },
+};

--- a/src/daemon/adapters/go.ts
+++ b/src/daemon/adapters/go.ts
@@ -1,0 +1,47 @@
+/**
+ * Go module proxy shim adapter for the unified daemon.
+ *
+ * Wraps `handleGoProxyRequest()` behind the `ShimAdapter` interface.
+ *
+ * @module
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+import type { AgentContext } from '../../cli/agent.js';
+import type { ShimAdapter } from '../adapter.js';
+
+import { handleGoProxyRequest } from '../../shims/go/proxy.js';
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+export const goAdapter: ShimAdapter = {
+  id          : 'go',
+  name        : 'Go module proxy',
+  defaultPort : 4874,
+  portEnvVar  : 'DWN_GIT_GO_SHIM_PORT',
+  corsMethods : 'GET, OPTIONS',
+  corsHeaders : 'Authorization, Accept',
+  usageHint   : 'GOPROXY=http://localhost:{port} go get did.enbox.org/did:dht:<id>/<module>@v1.0.0',
+
+  async handle(ctx: AgentContext, req: IncomingMessage, res: ServerResponse): Promise<void> {
+    if (req.method !== 'GET') {
+      res.writeHead(405, { 'Content-Type': 'text/plain' });
+      res.end('Method not allowed. This is a read-only Go module proxy.');
+      return;
+    }
+
+    try {
+      const port = (req.socket.address() as { port?: number })?.port ?? 4874;
+      const url = new URL(req.url ?? '/', `http://localhost:${port}`);
+      const result = await handleGoProxyRequest(ctx, url);
+      res.writeHead(result.status, result.headers);
+      res.end(result.body);
+    } catch {
+      res.writeHead(500, { 'Content-Type': 'text/plain' });
+      res.end('Internal server error');
+    }
+  },
+};

--- a/src/daemon/adapters/index.ts
+++ b/src/daemon/adapters/index.ts
@@ -1,0 +1,36 @@
+/**
+ * Adapter registry — all available shim adapters.
+ *
+ * To add a new ecosystem shim:
+ *   1. Create `src/daemon/adapters/<name>.ts` implementing `ShimAdapter`
+ *   2. Import and add it to the `builtinAdapters` array below
+ *   3. The daemon picks it up automatically
+ *
+ * @module
+ */
+
+import type { ShimAdapter } from '../adapter.js';
+
+import { githubAdapter } from './github.js';
+import { goAdapter } from './go.js';
+import { npmAdapter } from './npm.js';
+import { ociAdapter } from './oci.js';
+
+/**
+ * All built-in shim adapters, in display order.
+ *
+ * Each adapter is registered once and referenced by its `id` in
+ * configuration.  The daemon iterates this list to resolve config
+ * entries to concrete adapters.
+ */
+export const builtinAdapters: readonly ShimAdapter[] = [
+  githubAdapter,
+  npmAdapter,
+  goAdapter,
+  ociAdapter,
+];
+
+/** Look up an adapter by its `id`. Returns `undefined` if not found. */
+export function findAdapter(id: string): ShimAdapter | undefined {
+  return builtinAdapters.find((a) => a.id === id);
+}

--- a/src/daemon/adapters/npm.ts
+++ b/src/daemon/adapters/npm.ts
@@ -1,0 +1,47 @@
+/**
+ * npm registry shim adapter for the unified daemon.
+ *
+ * Wraps `handleNpmRequest()` behind the `ShimAdapter` interface.
+ *
+ * @module
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+import type { AgentContext } from '../../cli/agent.js';
+import type { ShimAdapter } from '../adapter.js';
+
+import { handleNpmRequest } from '../../shims/npm/registry.js';
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+export const npmAdapter: ShimAdapter = {
+  id          : 'npm',
+  name        : 'npm registry',
+  defaultPort : 4873,
+  portEnvVar  : 'DWN_GIT_NPM_SHIM_PORT',
+  corsMethods : 'GET, OPTIONS',
+  corsHeaders : 'Authorization, Accept',
+  usageHint   : 'npm install --registry=http://localhost:{port} @did:dht:<id>/<package>',
+
+  async handle(ctx: AgentContext, req: IncomingMessage, res: ServerResponse): Promise<void> {
+    if (req.method !== 'GET') {
+      res.writeHead(405, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Method not allowed. This is a read-only registry shim.' }));
+      return;
+    }
+
+    try {
+      const port = (req.socket.address() as { port?: number })?.port ?? 4873;
+      const url = new URL(req.url ?? '/', `http://localhost:${port}`);
+      const result = await handleNpmRequest(ctx, url);
+      res.writeHead(result.status, result.headers);
+      res.end(result.body);
+    } catch {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Internal server error' }));
+    }
+  },
+};

--- a/src/daemon/adapters/oci.ts
+++ b/src/daemon/adapters/oci.ts
@@ -1,0 +1,59 @@
+/**
+ * OCI/Docker registry shim adapter for the unified daemon.
+ *
+ * Wraps `handleOciRequest()` behind the `ShimAdapter` interface.
+ *
+ * @module
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+import type { AgentContext } from '../../cli/agent.js';
+import type { ShimAdapter } from '../adapter.js';
+
+import { handleOciRequest } from '../../shims/oci/registry.js';
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+export const ociAdapter: ShimAdapter = {
+  id          : 'oci',
+  name        : 'OCI/Docker registry',
+  defaultPort : 5555,
+  portEnvVar  : 'DWN_GIT_OCI_SHIM_PORT',
+  corsMethods : 'GET, HEAD, OPTIONS',
+  corsHeaders : 'Authorization, Accept, Docker-Distribution-Api-Version',
+  usageHint   : 'docker pull localhost:{port}/did:dht:<id>/<image>:<tag>',
+
+  async handle(ctx: AgentContext, req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const method = req.method ?? 'GET';
+
+    if (method !== 'GET' && method !== 'HEAD') {
+      res.writeHead(405, {
+        'Content-Type'                    : 'application/json',
+        'Docker-Distribution-Api-Version' : 'registry/2.0',
+      });
+      res.end(JSON.stringify({
+        errors: [{ code: 'UNSUPPORTED', message: 'This is a read-only registry shim.', detail: null }],
+      }));
+      return;
+    }
+
+    try {
+      const port = (req.socket.address() as { port?: number })?.port ?? 5555;
+      const url = new URL(req.url ?? '/', `http://localhost:${port}`);
+      const result = await handleOciRequest(ctx, url, method);
+      res.writeHead(result.status, result.headers);
+      res.end(result.body);
+    } catch {
+      res.writeHead(500, {
+        'Content-Type'                    : 'application/json',
+        'Docker-Distribution-Api-Version' : 'registry/2.0',
+      });
+      res.end(JSON.stringify({
+        errors: [{ code: 'UNKNOWN', message: 'Internal server error', detail: null }],
+      }));
+    }
+  },
+};

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Unified daemon — barrel exports.
+ *
+ * @module
+ */
+
+export type { DaemonConfig, ResolvedShimConfig, ShimAdapter, ShimConfig } from './adapter.js';
+export type { DaemonInstance, DaemonOptions } from './server.js';
+
+export { createAdapterServer, resolveConfig, startDaemon } from './server.js';
+export { builtinAdapters, findAdapter } from './adapters/index.js';
+
+export { githubAdapter } from './adapters/github.js';
+export { goAdapter } from './adapters/go.js';
+export { npmAdapter } from './adapters/npm.js';
+export { ociAdapter } from './adapters/oci.js';

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -1,0 +1,203 @@
+/**
+ * Unified daemon server — starts one HTTP server per enabled shim adapter.
+ *
+ * The daemon manages the lifecycle of all shim servers from a single
+ * process.  It resolves configuration (JSON file, env vars, defaults),
+ * starts each enabled adapter on its assigned port, logs a status
+ * summary, and handles graceful shutdown on SIGINT/SIGTERM.
+ *
+ * Each adapter's server includes:
+ *   - CORS preflight handling (OPTIONS)
+ *   - A `/health` endpoint returning `{ status: 'ok', shim: '<id>' }`
+ *   - Delegation to the adapter's `handle()` method for all other requests
+ *   - Top-level error catching with 500 responses
+ *
+ * @module
+ */
+
+import type { Server } from 'node:http';
+
+import { createServer } from 'node:http';
+
+import type { AgentContext } from '../cli/agent.js';
+import type { DaemonConfig, ResolvedShimConfig, ShimAdapter } from './adapter.js';
+
+import { builtinAdapters } from './adapters/index.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type DaemonOptions = {
+  ctx : AgentContext;
+  config : DaemonConfig;
+};
+
+export type DaemonInstance = {
+  /** All running HTTP servers keyed by adapter id. */
+  servers : Map<string, Server>;
+
+  /** The resolved config for each adapter. */
+  resolved : ResolvedShimConfig[];
+
+  /** Gracefully shut down all servers. */
+  stop(): Promise<void>;
+};
+
+// ---------------------------------------------------------------------------
+// Config resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the effective configuration for every known adapter.
+ *
+ * Priority for port: config file > env var > adapter default.
+ * Priority for enabled: config file > `true` (all enabled by default).
+ */
+export function resolveConfig(
+  config: DaemonConfig,
+  adapters: readonly ShimAdapter[] = builtinAdapters,
+): ResolvedShimConfig[] {
+  return adapters.map((adapter) => {
+    const entry = config.shims?.[adapter.id];
+    const envPort = process.env[adapter.portEnvVar];
+
+    const port = entry?.port
+      ?? (envPort ? parseInt(envPort, 10) : undefined)
+      ?? adapter.defaultPort;
+
+    const enabled = entry?.enabled ?? true;
+
+    return { adapter, enabled, port };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Server factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an HTTP server for a single adapter.
+ *
+ * The server handles CORS preflight, `/health`, and delegates
+ * everything else to the adapter.  It does NOT call `server.listen()`
+ * — the caller is responsible for that.
+ */
+export function createAdapterServer(ctx: AgentContext, adapter: ShimAdapter): Server {
+  const corsMethods = adapter.corsMethods ?? 'GET, OPTIONS';
+  const corsHeaders = adapter.corsHeaders ?? 'Authorization, Accept, Content-Type';
+
+  return createServer(async (req, res) => {
+    const method = req.method ?? 'GET';
+
+    // CORS preflight.
+    if (method === 'OPTIONS') {
+      res.writeHead(204, {
+        'Access-Control-Allow-Origin'  : '*',
+        'Access-Control-Allow-Methods' : corsMethods,
+        'Access-Control-Allow-Headers' : corsHeaders,
+        'Access-Control-Max-Age'       : '86400',
+      });
+      res.end();
+      return;
+    }
+
+    // Health endpoint.
+    if (req.url === '/health') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'ok', shim: adapter.id }));
+      return;
+    }
+
+    // Delegate to adapter.
+    try {
+      await adapter.handle(ctx, req, res);
+    } catch (err) {
+      console.error(`[daemon:${adapter.id}] Error: ${(err as Error).message}`);
+      if (!res.headersSent) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Internal server error' }));
+      }
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Daemon lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Start the unified daemon.
+ *
+ * Resolves configuration, starts one HTTP server per enabled adapter,
+ * registers SIGINT/SIGTERM handlers, and returns the `DaemonInstance`
+ * for programmatic control and testing.
+ */
+export async function startDaemon(options: DaemonOptions): Promise<DaemonInstance> {
+  const { ctx, config } = options;
+  const resolved = resolveConfig(config);
+  const servers = new Map<string, Server>();
+
+  const enabledAdapters = resolved.filter((r) => r.enabled);
+
+  if (enabledAdapters.length === 0) {
+    console.log('[daemon] No shims enabled — nothing to start.');
+    return { servers, resolved, stop: async (): Promise<void> => {} };
+  }
+
+  // Start each enabled adapter.
+  const startPromises = enabledAdapters.map((r) => {
+    return new Promise<void>((resolve, reject) => {
+      const server = createAdapterServer(ctx, r.adapter);
+
+      server.on('error', (err: NodeJS.ErrnoException) => {
+        if (err.code === 'EADDRINUSE') {
+          console.error(`[daemon:${r.adapter.id}] Port ${r.port} is already in use — skipping.`);
+          resolve();
+        } else {
+          reject(err);
+        }
+      });
+
+      server.listen(r.port, () => {
+        servers.set(r.adapter.id, server);
+        resolve();
+      });
+    });
+  });
+
+  await Promise.all(startPromises);
+
+  // Print status summary.
+  console.log('[daemon] dwn-git daemon started');
+  console.log('');
+  for (const r of enabledAdapters) {
+    const running = servers.has(r.adapter.id);
+    const status = running ? `http://localhost:${r.port}` : 'FAILED';
+    console.log(`  ${r.adapter.name.padEnd(22)} ${status}`);
+    if (running && r.adapter.usageHint) {
+      console.log(`  ${''.padEnd(22)} ${r.adapter.usageHint.replace('{port}', String(r.port))}`);
+    }
+  }
+  console.log('');
+  console.log(`[daemon] ${servers.size}/${enabledAdapters.length} shims running. Health: GET /health on any port.`);
+  console.log('[daemon] Press Ctrl+C to stop.');
+  console.log('');
+
+  // Build the stop function.
+  const stop = async (): Promise<void> => {
+    const closePromises: Promise<void>[] = [];
+    for (const [id, server] of servers) {
+      closePromises.push(new Promise<void>((resolve) => {
+        server.close(() => {
+          console.log(`[daemon:${id}] stopped`);
+          resolve();
+        });
+      }));
+    }
+    await Promise.all(closePromises);
+    servers.clear();
+  };
+
+  return { servers, resolved, stop };
+}

--- a/tests/daemon.spec.ts
+++ b/tests/daemon.spec.ts
@@ -1,0 +1,615 @@
+/**
+ * Unified daemon tests — exercises the ShimAdapter interface, config
+ * resolution, adapter server creation, and daemon lifecycle.
+ *
+ * Tests the daemon infrastructure against a real Web5 agent — each
+ * adapter's HTTP server is started and receives real HTTP requests.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+
+import { rmSync } from 'node:fs';
+
+import { Web5 } from '@enbox/api';
+import { Web5UserAgent } from '@enbox/agent';
+
+import type { AgentContext } from '../src/cli/agent.js';
+import type { DaemonConfig, ShimAdapter } from '../src/daemon/adapter.js';
+
+import { ForgeCiProtocol } from '../src/ci.js';
+import { ForgeIssuesProtocol } from '../src/issues.js';
+import { ForgeNotificationsProtocol } from '../src/notifications.js';
+import { ForgeOrgProtocol } from '../src/org.js';
+import { ForgePatchesProtocol } from '../src/patches.js';
+import { ForgeRefsProtocol } from '../src/refs.js';
+import { ForgeRegistryProtocol } from '../src/registry.js';
+import { ForgeReleasesProtocol } from '../src/releases.js';
+import { ForgeRepoProtocol } from '../src/repo.js';
+import { ForgeSocialProtocol } from '../src/social.js';
+import { ForgeWikiProtocol } from '../src/wiki.js';
+import { githubAdapter } from '../src/daemon/adapters/github.js';
+import { goAdapter } from '../src/daemon/adapters/go.js';
+import { npmAdapter } from '../src/daemon/adapters/npm.js';
+import { ociAdapter } from '../src/daemon/adapters/oci.js';
+import { builtinAdapters, findAdapter } from '../src/daemon/adapters/index.js';
+import { createAdapterServer, resolveConfig, startDaemon } from '../src/daemon/server.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DATA_PATH = '__TESTDATA__/daemon-agent';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Make a simple HTTP GET request and return status + body. */
+async function httpGet(port: number, path: string): Promise<{ status: number; body: string }> {
+  const res = await fetch(`http://localhost:${port}${path}`);
+  const body = await res.text();
+  return { status: res.status, body };
+}
+
+/** Make an HTTP request with a specific method and optional JSON body. */
+async function httpRequest(
+  port: number, path: string, method: string, jsonBody?: Record<string, unknown>,
+): Promise<{ status: number; body: string; headers: Headers }> {
+  const opts: RequestInit = { method };
+  if (jsonBody) {
+    opts.headers = { 'Content-Type': 'application/json' };
+    opts.body = JSON.stringify(jsonBody);
+  }
+  const res = await fetch(`http://localhost:${port}${path}`, opts);
+  const body = await res.text();
+  return { status: res.status, body, headers: res.headers };
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('Unified daemon', () => {
+  let ctx: AgentContext;
+  let testDid: string;
+
+  beforeAll(async () => {
+    rmSync(DATA_PATH, { recursive: true, force: true });
+
+    const agent = await Web5UserAgent.create({ dataPath: DATA_PATH });
+    await agent.initialize({ password: 'test-password' });
+    await agent.start({ password: 'test-password' });
+
+    const identities = await agent.identity.list();
+    let identity = identities[0];
+    if (!identity) {
+      identity = await agent.identity.create({
+        didMethod : 'jwk',
+        metadata  : { name: 'Daemon Test' },
+      });
+    }
+
+    const result = await Web5.connect({
+      agent,
+      connectedDid : identity.did.uri,
+      sync         : 'off',
+    });
+    const { web5, did } = result;
+    testDid = did;
+
+    const repo = web5.using(ForgeRepoProtocol);
+    const refs = web5.using(ForgeRefsProtocol);
+    const issues = web5.using(ForgeIssuesProtocol);
+    const patches = web5.using(ForgePatchesProtocol);
+    const ci = web5.using(ForgeCiProtocol);
+    const releases = web5.using(ForgeReleasesProtocol);
+    const registry = web5.using(ForgeRegistryProtocol);
+    const social = web5.using(ForgeSocialProtocol);
+    const notifications = web5.using(ForgeNotificationsProtocol);
+    const wiki = web5.using(ForgeWikiProtocol);
+    const org = web5.using(ForgeOrgProtocol);
+
+    await repo.configure();
+    await refs.configure();
+    await issues.configure();
+    await patches.configure();
+    await ci.configure();
+    await releases.configure();
+    await registry.configure();
+    await social.configure();
+    await notifications.configure();
+    await wiki.configure();
+    await org.configure();
+
+    ctx = {
+      did, repo, refs, issues, patches, ci, releases,
+      registry, social, notifications, wiki, org, web5,
+    };
+
+    // Seed a repo for GitHub shim testing.
+    await ctx.repo.records.create('repo', {
+      data : { name: 'daemon-test', description: 'Test repo', defaultBranch: 'main', dwnEndpoints: [] },
+      tags : { name: 'daemon-test', visibility: 'public' },
+    });
+  });
+
+  afterAll(() => {
+    rmSync(DATA_PATH, { recursive: true, force: true });
+  });
+
+  // =========================================================================
+  // Adapter registry
+  // =========================================================================
+
+  describe('adapter registry', () => {
+    it('should have 4 built-in adapters', () => {
+      expect(builtinAdapters.length).toBe(4);
+    });
+
+    it('should have github, npm, go, oci adapters', () => {
+      const ids = builtinAdapters.map((a) => a.id);
+      expect(ids).toContain('github');
+      expect(ids).toContain('npm');
+      expect(ids).toContain('go');
+      expect(ids).toContain('oci');
+    });
+
+    it('should find adapters by id', () => {
+      expect(findAdapter('github')).toBe(githubAdapter);
+      expect(findAdapter('npm')).toBe(npmAdapter);
+      expect(findAdapter('go')).toBe(goAdapter);
+      expect(findAdapter('oci')).toBe(ociAdapter);
+    });
+
+    it('should return undefined for unknown adapter id', () => {
+      expect(findAdapter('maven')).toBeUndefined();
+    });
+  });
+
+  // =========================================================================
+  // Adapter properties
+  // =========================================================================
+
+  describe('adapter properties', () => {
+    it('should have correct ids', () => {
+      expect(githubAdapter.id).toBe('github');
+      expect(npmAdapter.id).toBe('npm');
+      expect(goAdapter.id).toBe('go');
+      expect(ociAdapter.id).toBe('oci');
+    });
+
+    it('should have unique default ports', () => {
+      const ports = builtinAdapters.map((a) => a.defaultPort);
+      expect(new Set(ports).size).toBe(ports.length);
+    });
+
+    it('should have unique port env vars', () => {
+      const envVars = builtinAdapters.map((a) => a.portEnvVar);
+      expect(new Set(envVars).size).toBe(envVars.length);
+    });
+
+    it('should have human-readable names', () => {
+      for (const adapter of builtinAdapters) {
+        expect(adapter.name.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('should have usage hints with port placeholder', () => {
+      for (const adapter of builtinAdapters) {
+        if (adapter.usageHint) {
+          expect(adapter.usageHint).toContain('{port}');
+        }
+      }
+    });
+  });
+
+  // =========================================================================
+  // Config resolution
+  // =========================================================================
+
+  describe('resolveConfig()', () => {
+    it('should use defaults when config is empty', () => {
+      const resolved = resolveConfig({});
+      expect(resolved.length).toBe(4);
+      for (const r of resolved) {
+        expect(r.enabled).toBe(true);
+        expect(r.port).toBe(r.adapter.defaultPort);
+      }
+    });
+
+    it('should apply port overrides from config', () => {
+      const config: DaemonConfig = {
+        shims: {
+          github : { port: 9999 },
+          npm    : { port: 7777 },
+        },
+      };
+      const resolved = resolveConfig(config);
+      const github = resolved.find((r) => r.adapter.id === 'github');
+      const npm = resolved.find((r) => r.adapter.id === 'npm');
+      expect(github?.port).toBe(9999);
+      expect(npm?.port).toBe(7777);
+    });
+
+    it('should disable adapters via config', () => {
+      const config: DaemonConfig = {
+        shims: {
+          go  : { enabled: false },
+          oci : { enabled: false },
+        },
+      };
+      const resolved = resolveConfig(config);
+      const go = resolved.find((r) => r.adapter.id === 'go');
+      const oci = resolved.find((r) => r.adapter.id === 'oci');
+      expect(go?.enabled).toBe(false);
+      expect(oci?.enabled).toBe(false);
+
+      const github = resolved.find((r) => r.adapter.id === 'github');
+      expect(github?.enabled).toBe(true);
+    });
+
+    it('should resolve config for custom adapter list', () => {
+      const custom: ShimAdapter = {
+        id          : 'maven',
+        name        : 'Maven Central',
+        defaultPort : 8082,
+        portEnvVar  : 'DWN_GIT_MAVEN_PORT',
+        async handle(): Promise<void> { /* noop */ },
+      };
+      const resolved = resolveConfig({}, [custom]);
+      expect(resolved.length).toBe(1);
+      expect(resolved[0].adapter.id).toBe('maven');
+      expect(resolved[0].port).toBe(8082);
+    });
+  });
+
+  // =========================================================================
+  // createAdapterServer() — health endpoint
+  // =========================================================================
+
+  describe('createAdapterServer()', () => {
+    let server: Server;
+    let port: number;
+
+    beforeAll(async () => {
+      server = createAdapterServer(ctx, githubAdapter);
+      await new Promise<void>((resolve) => {
+        server.listen(0, () => { resolve(); });
+      });
+      port = (server.address() as AddressInfo).port;
+    });
+
+    afterAll(async () => {
+      await new Promise<void>((resolve) => { server.close(() => { resolve(); }); });
+    });
+
+    it('should respond to /health with ok status', async () => {
+      const { status, body } = await httpGet(port, '/health');
+      expect(status).toBe(200);
+      const data = JSON.parse(body);
+      expect(data.status).toBe('ok');
+      expect(data.shim).toBe('github');
+    });
+
+    it('should handle CORS preflight', async () => {
+      const res = await fetch(`http://localhost:${port}/anything`, { method: 'OPTIONS' });
+      expect(res.status).toBe(204);
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*');
+      expect(res.headers.get('Access-Control-Allow-Methods')).toContain('GET');
+    });
+
+    it('should delegate to the adapter for real requests', async () => {
+      // GET /users/:did should be handled by the GitHub adapter.
+      const { status, body } = await httpGet(port, `/users/${testDid}`);
+      expect(status).toBe(200);
+      const data = JSON.parse(body);
+      expect(data.login).toBe(testDid);
+    });
+  });
+
+  // =========================================================================
+  // startDaemon() — full lifecycle
+  // =========================================================================
+
+  describe('startDaemon()', () => {
+    it('should start only enabled adapters', async () => {
+      const config: DaemonConfig = {
+        shims: {
+          github : { enabled: true, port: 0 },
+          npm    : { enabled: false },
+          go     : { enabled: false },
+          oci    : { enabled: false },
+        },
+      };
+
+      const instance = await startDaemon({ ctx, config });
+      try {
+        expect(instance.servers.size).toBe(1);
+        expect(instance.servers.has('github')).toBe(true);
+        expect(instance.servers.has('npm')).toBe(false);
+      } finally {
+        await instance.stop();
+      }
+    });
+
+    it('should return empty servers when nothing is enabled', async () => {
+      const config: DaemonConfig = {
+        shims: {
+          github : { enabled: false },
+          npm    : { enabled: false },
+          go     : { enabled: false },
+          oci    : { enabled: false },
+        },
+      };
+
+      const instance = await startDaemon({ ctx, config });
+      expect(instance.servers.size).toBe(0);
+    });
+
+    it('should start multiple adapters and serve health on each', async () => {
+      const config: DaemonConfig = {
+        shims: {
+          github : { port: 0 },
+          npm    : { port: 0 },
+          go     : { enabled: false },
+          oci    : { enabled: false },
+        },
+      };
+
+      const instance = await startDaemon({ ctx, config });
+      try {
+        expect(instance.servers.size).toBe(2);
+
+        const githubServer = instance.servers.get('github')!;
+        const npmServer = instance.servers.get('npm')!;
+        const githubPort = (githubServer.address() as AddressInfo).port;
+        const npmPort = (npmServer.address() as AddressInfo).port;
+
+        // Health on github port.
+        const gh = await httpGet(githubPort, '/health');
+        expect(JSON.parse(gh.body).shim).toBe('github');
+
+        // Health on npm port.
+        const npm = await httpGet(npmPort, '/health');
+        expect(JSON.parse(npm.body).shim).toBe('npm');
+      } finally {
+        await instance.stop();
+      }
+    });
+
+    it('should stop all servers on stop()', async () => {
+      const config: DaemonConfig = {
+        shims: {
+          github : { port: 0 },
+          npm    : { enabled: false },
+          go     : { enabled: false },
+          oci    : { enabled: false },
+        },
+      };
+
+      const instance = await startDaemon({ ctx, config });
+      const port = (instance.servers.get('github')!.address() as AddressInfo).port;
+
+      // Verify server is running.
+      const before = await httpGet(port, '/health');
+      expect(before.status).toBe(200);
+
+      await instance.stop();
+      expect(instance.servers.size).toBe(0);
+
+      // Verify server is stopped (fetch should fail).
+      try {
+        await fetch(`http://localhost:${port}/health`);
+        // If we get here without error, that's unexpected.
+        expect(true).toBe(false);
+      } catch {
+        // Expected — connection refused.
+        expect(true).toBe(true);
+      }
+    });
+  });
+
+  // =========================================================================
+  // GitHub adapter — via daemon
+  // =========================================================================
+
+  describe('GitHub adapter via daemon', () => {
+    let port: number;
+    let server: Server;
+
+    beforeAll(async () => {
+      server = createAdapterServer(ctx, githubAdapter);
+      await new Promise<void>((resolve) => { server.listen(0, () => { resolve(); }); });
+      port = (server.address() as AddressInfo).port;
+    });
+
+    afterAll(async () => {
+      await new Promise<void>((resolve) => { server.close(() => { resolve(); }); });
+    });
+
+    it('should serve repo info via GET', async () => {
+      const { status, body } = await httpGet(port, `/repos/${testDid}/daemon-test`);
+      expect(status).toBe(200);
+      const data = JSON.parse(body);
+      expect(data.name).toBe('daemon-test');
+    });
+
+    it('should create an issue via POST', async () => {
+      const { status, body } = await httpRequest(port, `/repos/${testDid}/daemon-test/issues`, 'POST', {
+        title : 'Daemon test issue',
+        body  : 'Created via daemon.',
+      });
+      expect(status).toBe(201);
+      const data = JSON.parse(body);
+      expect(data.title).toBe('Daemon test issue');
+      expect(data.state).toBe('open');
+    });
+
+    it('should return 404 for unknown routes', async () => {
+      const { status } = await httpGet(port, '/nonexistent');
+      expect(status).toBe(404);
+    });
+  });
+
+  // =========================================================================
+  // npm adapter — via daemon
+  // =========================================================================
+
+  describe('npm adapter via daemon', () => {
+    let port: number;
+    let server: Server;
+
+    beforeAll(async () => {
+      server = createAdapterServer(ctx, npmAdapter);
+      await new Promise<void>((resolve) => { server.listen(0, () => { resolve(); }); });
+      port = (server.address() as AddressInfo).port;
+    });
+
+    afterAll(async () => {
+      await new Promise<void>((resolve) => { server.close(() => { resolve(); }); });
+    });
+
+    it('should respond to health check', async () => {
+      const { status, body } = await httpGet(port, '/health');
+      expect(status).toBe(200);
+      expect(JSON.parse(body).shim).toBe('npm');
+    });
+
+    it('should reject POST with 405', async () => {
+      const { status } = await httpRequest(port, '/@did:jwk:test/pkg', 'POST');
+      expect(status).toBe(405);
+    });
+  });
+
+  // =========================================================================
+  // Go adapter — via daemon
+  // =========================================================================
+
+  describe('Go adapter via daemon', () => {
+    let port: number;
+    let server: Server;
+
+    beforeAll(async () => {
+      server = createAdapterServer(ctx, goAdapter);
+      await new Promise<void>((resolve) => { server.listen(0, () => { resolve(); }); });
+      port = (server.address() as AddressInfo).port;
+    });
+
+    afterAll(async () => {
+      await new Promise<void>((resolve) => { server.close(() => { resolve(); }); });
+    });
+
+    it('should respond to health check', async () => {
+      const { status, body } = await httpGet(port, '/health');
+      expect(status).toBe(200);
+      expect(JSON.parse(body).shim).toBe('go');
+    });
+
+    it('should reject POST with 405', async () => {
+      const { status } = await httpRequest(port, '/test/@latest', 'POST');
+      expect(status).toBe(405);
+    });
+  });
+
+  // =========================================================================
+  // OCI adapter — via daemon
+  // =========================================================================
+
+  describe('OCI adapter via daemon', () => {
+    let port: number;
+    let server: Server;
+
+    beforeAll(async () => {
+      server = createAdapterServer(ctx, ociAdapter);
+      await new Promise<void>((resolve) => { server.listen(0, () => { resolve(); }); });
+      port = (server.address() as AddressInfo).port;
+    });
+
+    afterAll(async () => {
+      await new Promise<void>((resolve) => { server.close(() => { resolve(); }); });
+    });
+
+    it('should respond to health check', async () => {
+      const { status, body } = await httpGet(port, '/health');
+      expect(status).toBe(200);
+      expect(JSON.parse(body).shim).toBe('oci');
+    });
+
+    it('should serve OCI v2 API check', async () => {
+      const { status, body } = await httpGet(port, '/v2/');
+      expect(status).toBe(200);
+      expect(JSON.parse(body)).toEqual({});
+    });
+
+    it('should reject POST with 405', async () => {
+      const { status } = await httpRequest(port, '/v2/test/manifests/latest', 'POST');
+      expect(status).toBe(405);
+    });
+
+    it('should support HEAD method (not 405)', async () => {
+      // HEAD is a valid OCI method — should NOT return 405.
+      const res = await fetch(`http://localhost:${port}/v2/did:jwk:test/img/manifests/latest`, { method: 'HEAD' });
+      expect(res.status).not.toBe(405);
+    });
+  });
+
+  // =========================================================================
+  // Config edge cases
+  // =========================================================================
+
+  describe('config edge cases', () => {
+    it('should handle config with unknown shim ids gracefully', () => {
+      const config: DaemonConfig = {
+        shims: {
+          unknown_shim: { enabled: true, port: 9999 },
+        },
+      };
+      // Unknown ids are ignored — only built-in adapters are resolved.
+      const resolved = resolveConfig(config);
+      expect(resolved.length).toBe(4);
+      const unknown = resolved.find((r) => r.adapter.id === 'unknown_shim');
+      expect(unknown).toBeUndefined();
+    });
+
+    it('should resolve config with partial shim entries', () => {
+      const config: DaemonConfig = {
+        shims: {
+          github: { port: 1234 },
+          // npm, go, oci not mentioned — should get defaults.
+        },
+      };
+      const resolved = resolveConfig(config);
+      const github = resolved.find((r) => r.adapter.id === 'github');
+      const npm = resolved.find((r) => r.adapter.id === 'npm');
+      expect(github?.port).toBe(1234);
+      expect(github?.enabled).toBe(true);
+      expect(npm?.port).toBe(4873);
+      expect(npm?.enabled).toBe(true);
+    });
+
+    it('should handle port: 0 for OS-assigned ports', async () => {
+      const config: DaemonConfig = {
+        shims: {
+          github : { port: 0 },
+          npm    : { enabled: false },
+          go     : { enabled: false },
+          oci    : { enabled: false },
+        },
+      };
+
+      const instance = await startDaemon({ ctx, config });
+      try {
+        const server = instance.servers.get('github')!;
+        const port = (server.address() as AddressInfo).port;
+        expect(port).toBeGreaterThan(0);
+
+        const { status } = await httpGet(port, '/health');
+        expect(status).toBe(200);
+      } finally {
+        await instance.stop();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add a config-driven daemon that runs all ecosystem shims in a single process (`dwn-git daemon`)
- Introduce the `ShimAdapter` interface — a standard contract that any ecosystem shim implements to plug into the daemon
- Adding a new ecosystem (Maven, Cargo, PyPI, etc.) requires implementing one file and registering it in the adapter registry

## Architecture

```
ShimAdapter (interface)
  ├── githubAdapter   — GitHub REST API v3 (18 endpoints, read + write)
  ├── npmAdapter      — npm registry HTTP API
  ├── goAdapter       — GOPROXY protocol
  └── ociAdapter      — OCI Distribution Spec v2
```

The daemon resolves config (JSON file > env vars > defaults), starts one HTTP server per enabled adapter, and manages lifecycle with graceful SIGINT/SIGTERM shutdown.

### ShimAdapter interface

```typescript
interface ShimAdapter {
  readonly id: string;           // 'github', 'npm', 'go', 'oci'
  readonly name: string;         // Human-readable name
  readonly defaultPort: number;
  readonly portEnvVar: string;   // e.g. 'DWN_GIT_GITHUB_API_PORT'
  handle(ctx, req, res): Promise<void>;  // The only method that matters
}
```

### CLI

```bash
dwn-git daemon                      # Start all shims with defaults
dwn-git daemon --only github,npm    # Only specific shims
dwn-git daemon --disable oci        # Exclude specific shims
dwn-git daemon --config daemon.json # Custom config file
dwn-git daemon --list               # List available adapters
```

### Config file (`dwn-git.daemon.json`)

```json
{
  "shims": {
    "github": { "enabled": true, "port": 8181 },
    "npm":    { "enabled": true, "port": 4873 },
    "go":     { "enabled": true, "port": 4874 },
    "oci":    { "enabled": true, "port": 5555 }
  }
}
```

### Each adapter server provides

- CORS preflight handling (OPTIONS)
- `GET /health` → `{ "status": "ok", "shim": "<id>" }`
- Delegation to `adapter.handle()` for all other requests
- Top-level error catching

## Files Added (10 new, 4 modified)

**New:**
- `src/daemon/adapter.ts` — `ShimAdapter` interface + config types
- `src/daemon/server.ts` — `resolveConfig()`, `createAdapterServer()`, `startDaemon()`
- `src/daemon/index.ts` — barrel exports
- `src/daemon/adapters/index.ts` — adapter registry (`builtinAdapters`, `findAdapter()`)
- `src/daemon/adapters/github.ts` — GitHub API adapter
- `src/daemon/adapters/npm.ts` — npm registry adapter
- `src/daemon/adapters/go.ts` — Go module proxy adapter
- `src/daemon/adapters/oci.ts` — OCI/Docker registry adapter
- `src/cli/commands/daemon.ts` — CLI command with `--config`, `--only`, `--disable`, `--list`
- `tests/daemon.spec.ts` — 34 tests

**Modified:**
- `src/cli/main.ts` — wired up `daemon` command
- `package.json` — added `./daemon` export
- `PLAN.md` — updated Phase 5, directory structure, test counts
- `README.md` — added Unified Daemon section, updated status

## Test Results

- **daemon.spec.ts**: 34 pass, 0 fail, 85 assertions
- **Full suite**: 833 pass, 0 fail, 9 skip, 2055 assertions across 20 files
- Lint: clean, Build: clean