### PR TITLE
refactor: rename dwn-git to gitd

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,17 +56,17 @@ jobs:
             out_suffix=".exe"
           fi
 
-          bun build src/cli/main.ts --compile --target "${{ matrix.target }}" --outfile "dist/release/dwn-git${out_suffix}"
+          bun build src/cli/main.ts --compile --target "${{ matrix.target }}" --outfile "dist/release/gitd${out_suffix}"
           bun build src/git-remote/main.ts --compile --target "${{ matrix.target }}" --outfile "dist/release/git-remote-did${out_suffix}"
           bun build src/git-remote/credential-main.ts --compile --target "${{ matrix.target }}" --outfile "dist/release/git-remote-did-credential${out_suffix}"
 
       - name: Package artifact
         run: |
-          artifact="dwn-git-${{ matrix.os }}-${{ matrix.arch }}.${{ matrix.ext }}"
+          artifact="gitd-${{ matrix.os }}-${{ matrix.arch }}.${{ matrix.ext }}"
           if [ "${{ matrix.ext }}" = "zip" ]; then
-            (cd dist/release && zip -q "../../${artifact}" dwn-git.exe git-remote-did.exe git-remote-did-credential.exe)
+            (cd dist/release && zip -q "../../${artifact}" gitd.exe git-remote-did.exe git-remote-did-credential.exe)
           else
-            (cd dist/release && tar -czf "../../${artifact}" dwn-git git-remote-did git-remote-did-credential)
+            (cd dist/release && tar -czf "../../${artifact}" gitd git-remote-did git-remote-did-credential)
           fi
           echo "artifact=${artifact}" >> "$GITHUB_ENV"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md — Agent Instructions for dwn-git
+# CLAUDE.md — Agent Instructions for gitd
 
 ## Workflow: Git Worktrees
 
@@ -10,7 +10,7 @@ All work MUST be done in fresh git worktrees. Never work directly on `main`.
 2. Create a fresh worktree from the latest `main`:
    ```sh
    git fetch origin
-   git worktree add ../dwn-git-<short-name> -b <branch-name> origin/main
+   git worktree add ../gitd-<short-name> -b <branch-name> origin/main
    ```
    Branch naming: `feat/<topic>`, `fix/<topic>`, or `chore/<topic>`.
 3. Work inside the worktree directory for all changes.
@@ -39,7 +39,7 @@ All new or changed behavior must have corresponding tests. Do not skip tests.
 
 1. Delete the worktree and the local branch:
    ```sh
-   git worktree remove ../dwn-git-<short-name>
+   git worktree remove ../gitd-<short-name>
    git branch -d <branch-name>
    ```
 2. New work starts in a new fresh worktree. Never reuse old worktrees.
@@ -52,7 +52,7 @@ All new or changed behavior must have corresponding tests. Do not skip tests.
 - **Test**: `bun test .spec.ts`.
 - **Lint**: `bun run lint` (ESLint with `@typescript-eslint`, `@stylistic`, `--max-warnings 0`).
 - **SDK**: Uses `@enbox/api`, `@enbox/crypto`, `@enbox/dids`, `@enbox/dwn-sdk-js`. Never reference `@web5/*` or `tbddev.org`.
-- **Exports**: Single entry point via `./dist/esm/index.js`. CLI binaries: `dwn-git`, `git-remote-did`, `git-remote-did-credential`.
+- **Exports**: Single entry point via `./dist/esm/index.js`. CLI binaries: `gitd`, `git-remote-did`, `git-remote-did-credential`.
 - **Style**: Explicit return types required (`@typescript-eslint/explicit-function-return-type`). Colon-aligned key-spacing. Single quotes. Semicolons required.
 
 ## Rules

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# dwn-git
+# gitd
 
-A decentralized forge (GitHub alternative) built on [DWN](https://github.com/enboxorg/enbox) protocols. Git is already decentralized — `dwn-git` decentralizes the rest: issues, pull requests, code review, CI status, releases, package registry, and social features.
+A decentralized forge (GitHub alternative) built on [DWN](https://github.com/enboxorg/enbox) protocols. Git is already decentralized — `gitd` decentralizes the rest: issues, pull requests, code review, CI status, releases, package registry, and social features.
 
 ## Thesis
 
-GitHub centralizes the social layer around git: identity, access control, issue tracking, code review, package hosting, and discovery all depend on a single provider. `dwn-git` replaces that layer with DWN protocols, where:
+GitHub centralizes the social layer around git: identity, access control, issue tracking, code review, package hosting, and discovery all depend on a single provider. `gitd` replaces that layer with DWN protocols, where:
 
 - **Identity is self-sovereign** — DIDs replace GitHub usernames. Portable across providers.
 - **Every user owns their namespace** — your issues, stars, and contributions live on your DWN, not a central server.
@@ -15,124 +15,124 @@ GitHub centralizes the social layer around git: identity, access control, issue 
 
 ## What Works Today
 
-`dwn-git` has a working MVP covering the full lifecycle:
+`gitd` has a working MVP covering the full lifecycle:
 
-### CLI (`dwn-git`)
+### CLI (`gitd`)
 
 ```bash
 # Setup & transport
-dwn-git setup                     # Configure git for DID-based remotes
-dwn-git clone did:dht:abc/repo   # Clone via DID resolution
-dwn-git init my-repo              # Create a repo record + bare git repo
-dwn-git serve                     # Start git transport server with ref sync + bundle sync
+gitd setup                     # Configure git for DID-based remotes
+gitd clone did:dht:abc/repo   # Clone via DID resolution
+gitd init my-repo              # Create a repo record + bare git repo
+gitd serve                     # Start git transport server with ref sync + bundle sync
 
 # Repository management
-dwn-git repo info                 # Show repo metadata + collaborators
-dwn-git repo add-collaborator <did> maintainer
-dwn-git repo remove-collaborator <did>
+gitd repo info                 # Show repo metadata + collaborators
+gitd repo add-collaborator <did> maintainer
+gitd repo remove-collaborator <did>
 
 # Issues (sequential numbering)
-dwn-git issue create "Bug report" # Create issue #1
-dwn-git issue show 1              # Show issue details + comments
-dwn-git issue comment 1 "On it"  # Add a comment
-dwn-git issue close 1             # Close an issue
-dwn-git issue reopen 1            # Reopen a closed issue
-dwn-git issue list                # List all issues
+gitd issue create "Bug report" # Create issue #1
+gitd issue show 1              # Show issue details + comments
+gitd issue comment 1 "On it"  # Add a comment
+gitd issue close 1             # Close an issue
+gitd issue reopen 1            # Reopen a closed issue
+gitd issue list                # List all issues
 
 # Patches (pull requests)
-dwn-git patch create "Add X"     # Create patch #1
-dwn-git patch show 1              # Show patch details + reviews
-dwn-git patch comment 1 "LGTM"  # Add a review comment
-dwn-git patch merge 1             # Merge a patch
-dwn-git patch close 2             # Close without merging
-dwn-git patch reopen 2            # Reopen a closed patch
-dwn-git patch list                # List all patches
+gitd patch create "Add X"     # Create patch #1
+gitd patch show 1              # Show patch details + reviews
+gitd patch comment 1 "LGTM"  # Add a review comment
+gitd patch merge 1             # Merge a patch
+gitd patch close 2             # Close without merging
+gitd patch reopen 2            # Reopen a closed patch
+gitd patch list                # List all patches
 
 # Releases
-dwn-git release create v1.0.0    # Create a release
-dwn-git release show v1.0.0      # Show release details + assets
-dwn-git release list              # List releases
+gitd release create v1.0.0    # Create a release
+gitd release show v1.0.0      # Show release details + assets
+gitd release list              # List releases
 
 # CI / Check suites
-dwn-git ci create <commit>       # Create a check suite
-dwn-git ci run <suite-id> lint   # Add a check run to a suite
-dwn-git ci update <run-id> --status completed --conclusion success
-dwn-git ci status                 # Show latest CI status
-dwn-git ci show <suite-id>       # Show suite details + runs
-dwn-git ci list                   # List recent check suites
+gitd ci create <commit>       # Create a check suite
+gitd ci run <suite-id> lint   # Add a check run to a suite
+gitd ci update <run-id> --status completed --conclusion success
+gitd ci status                 # Show latest CI status
+gitd ci show <suite-id>       # Show suite details + runs
+gitd ci list                   # List recent check suites
 
 # Package registry
-dwn-git registry publish my-pkg 1.0.0 ./pkg.tgz
-dwn-git registry info my-pkg     # Show package details
-dwn-git registry versions my-pkg # List published versions
-dwn-git registry list             # List all packages
-dwn-git registry yank my-pkg 1.0.0
+gitd registry publish my-pkg 1.0.0 ./pkg.tgz
+gitd registry info my-pkg     # Show package details
+gitd registry versions my-pkg # List published versions
+gitd registry list             # List all packages
+gitd registry yank my-pkg 1.0.0
 
 # Attestations & verification
-dwn-git registry attest my-pkg 1.0.0 --claim reproducible-build
-dwn-git registry attestations my-pkg 1.0.0
-dwn-git registry verify my-pkg 1.0.0 --trusted did:jwk:build-svc
+gitd registry attest my-pkg 1.0.0 --claim reproducible-build
+gitd registry attestations my-pkg 1.0.0
+gitd registry verify my-pkg 1.0.0 --trusted did:jwk:build-svc
 
 # Package resolution & trust chain
-dwn-git registry resolve did:dht:abc/my-pkg@1.0.0
-dwn-git registry verify-deps did:dht:abc/my-pkg@1.0.0 --trusted did:jwk:ci
+gitd registry resolve did:dht:abc/my-pkg@1.0.0
+gitd registry verify-deps did:dht:abc/my-pkg@1.0.0 --trusted did:jwk:ci
 
 # Wiki
-dwn-git wiki create getting-started "Getting Started" --body "# Welcome"
-dwn-git wiki show getting-started
-dwn-git wiki edit getting-started --body "# Updated"
-dwn-git wiki list
+gitd wiki create getting-started "Getting Started" --body "# Welcome"
+gitd wiki show getting-started
+gitd wiki edit getting-started --body "# Updated"
+gitd wiki list
 
 # Organizations & teams
-dwn-git org create my-org        # Create an organization
-dwn-git org info                  # Show org details + members + teams
-dwn-git org add-member <did>     # Add a member
-dwn-git org add-owner <did>      # Add an owner
-dwn-git org team create backend  # Create a team
+gitd org create my-org        # Create an organization
+gitd org info                  # Show org details + members + teams
+gitd org add-member <did>     # Add a member
+gitd org add-owner <did>      # Add an owner
+gitd org team create backend  # Create a team
 
 # Social
-dwn-git social star <did>        # Star a repo
-dwn-git social stars              # List starred repos
-dwn-git social follow <did>      # Follow a user
-dwn-git social following          # List followed users
+gitd social star <did>        # Star a repo
+gitd social stars              # List starred repos
+gitd social follow <did>      # Follow a user
+gitd social following          # List followed users
 
 # Notifications
-dwn-git notification list         # List notifications
-dwn-git notification list --unread
-dwn-git notification read <id>   # Mark as read
-dwn-git notification clear        # Clear read notifications
+gitd notification list         # List notifications
+gitd notification list --unread
+gitd notification read <id>   # Mark as read
+gitd notification clear        # Clear read notifications
 
 # GitHub migration
-dwn-git migrate all owner/repo   # Import repo, issues, PRs, releases from GitHub
-dwn-git migrate issues owner/repo
-dwn-git migrate pulls owner/repo
-dwn-git migrate releases owner/repo
+gitd migrate all owner/repo   # Import repo, issues, PRs, releases from GitHub
+gitd migrate issues owner/repo
+gitd migrate pulls owner/repo
+gitd migrate releases owner/repo
 
 # Web UI
-dwn-git web                       # Start read-only web UI on port 8080
-dwn-git web --port 3000           # Custom port
+gitd web                       # Start read-only web UI on port 8080
+gitd web --port 3000           # Custom port
 
 # Indexer (repo discovery + aggregation)
-dwn-git indexer                   # Start indexer on port 8090
-dwn-git indexer --seed <did>      # Discover DIDs from a seed user
-dwn-git indexer --interval 30     # Crawl every 30 seconds
+gitd indexer                   # Start indexer on port 8090
+gitd indexer --seed <did>      # Discover DIDs from a seed user
+gitd indexer --interval 30     # Crawl every 30 seconds
 
 # Unified daemon — all shims in one process
-dwn-git daemon                    # Start all shims with default ports
-dwn-git daemon --only github,npm  # Only start specific shims
-dwn-git daemon --disable oci      # Disable specific shims
-dwn-git daemon --config cfg.json  # Use a config file
-dwn-git daemon --list             # List available shim adapters
+gitd daemon                    # Start all shims with default ports
+gitd daemon --only github,npm  # Only start specific shims
+gitd daemon --disable oci      # Disable specific shims
+gitd daemon --config cfg.json  # Use a config file
+gitd daemon --list             # List available shim adapters
 
 # Individual shims (standalone mode)
-dwn-git github-api                # GitHub API shim on port 8181
-dwn-git shim npm                  # npm registry shim on port 4873
-dwn-git shim go                   # Go module proxy on port 4874
-dwn-git shim oci                  # OCI/Docker registry on port 5555
+gitd github-api                # GitHub API shim on port 8181
+gitd shim npm                  # npm registry shim on port 4873
+gitd shim go                   # Go module proxy on port 4874
+gitd shim oci                  # OCI/Docker registry on port 5555
 
 # Activity & identity
-dwn-git log                       # Activity feed (recent issues + patches)
-dwn-git whoami                    # Show connected DID
+gitd log                       # Activity feed (recent issues + patches)
+gitd whoami                    # Show connected DID
 ```
 
 ### Git Transport
@@ -155,11 +155,11 @@ dwn-git whoami                    # Show connected DID
 - Landing page at `/` with DID input form; all routes are DID-scoped: `/:did/`, `/:did/issues`, etc.
 - Routes: `/:did` (overview), `/:did/issues`, `/:did/issues/:n`, `/:did/patches`, `/:did/patches/:n`, `/:did/releases`, `/:did/wiki`, `/:did/wiki/:slug`
 - Remote DWN queries use the SDK's `from` parameter — resolved via the target DID's service endpoints
-- Start with `dwn-git web [--port <port>]` (default: 8080, configurable via `DWN_GIT_WEB_PORT`)
+- Start with `gitd web [--port <port>]` (default: 8080, configurable via `GITD_WEB_PORT`)
 
 ### GitHub Migration
 
-- `dwn-git migrate all owner/repo` — import repo metadata, issues, pull requests, and releases
+- `gitd migrate all owner/repo` — import repo metadata, issues, pull requests, and releases
 - Supports pagination, error handling, and author attribution
 - GitHub author info embedded in body as `[migrated from GitHub — @username]` prefix
 
@@ -172,7 +172,7 @@ dwn-git whoami                    # Show connected DID
 - **Trending repos** — ranked by recent star activity within a time window
 - **User profiles** — repo count, total stars received, follower/following counts
 - **REST API** — `/api/repos`, `/api/repos/search?q=`, `/api/repos/trending`, `/api/users/:did`, `/api/stats`
-- Start with `dwn-git indexer [--port <port>] [--interval <sec>] [--seed <did>]`
+- Start with `gitd indexer [--port <port>] [--interval <sec>] [--seed <did>]`
 
 ### GitHub API Compatibility Shim
 
@@ -184,7 +184,7 @@ dwn-git whoami                    # Show connected DID
   - **Write**: create/update issues, create issue comments, create/update/merge pull requests, create pull reviews, create releases
 - GitHub-compatible response shapes: numeric IDs, pagination (`Link` header, `per_page`), rate limit headers
 - CORS enabled, `X-GitHub-Media-Type: github.v3` header
-- Start with `dwn-git github-api [--port <port>]` (default: 8181, configurable via `DWN_GIT_GITHUB_API_PORT`)
+- Start with `gitd github-api [--port <port>]` (default: 8181, configurable via `GITD_GITHUB_API_PORT`)
 
 ### Attestation System
 
@@ -192,9 +192,9 @@ dwn-git whoami                    # Show connected DID
 - Attestors (CI services, auditors) create signed claims about package versions
 - Claims include `reproducible-build`, `code-review`, `security-audit`, etc.
 - Optional `sourceCommit` and `sourceRepo` fields link attestations to specific builds
-- `dwn-git registry attest <name> <version> --claim <claim>` to create attestations
-- `dwn-git registry attestations <name> <version>` to list all attestations
-- `dwn-git registry verify <name> <version> [--trusted <did>,...]` to verify integrity
+- `gitd registry attest <name> <version> --claim <claim>` to create attestations
+- `gitd registry attestations <name> <version>` to list all attestations
+- `gitd registry verify <name> <version> [--trusted <did>,...]` to verify integrity
 
 ### Package Resolver & Trust Chain
 
@@ -202,28 +202,28 @@ dwn-git whoami                    # Show connected DID
 - Resolution flow: resolve DID -> query package -> query version -> fetch tarball
 - Verification checks: package exists, publisher match, version author, tarball integrity, attestations
 - Recursive dependency trust chain validation with cycle detection and depth limiting
-- `dwn-git registry resolve <did>/<name>@<version>` to resolve and inspect a remote package
-- `dwn-git registry verify-deps <did>/<name>@<version>` to build and verify the full dependency tree
+- `gitd registry resolve <did>/<name>@<version>` to resolve and inspect a remote package
+- `gitd registry verify-deps <did>/<name>@<version>` to build and verify the full dependency tree
 - No central authority — the entire chain is verifiable via DIDs and DWN record signatures
 
 ### Package Manager Shims
 
 Local HTTP proxy servers that speak native package manager protocols, resolving DID-scoped packages from DWN records. Each shim acts as a translation layer between standard tooling and the decentralized registry.
 
-**npm registry shim** (`dwn-git shim npm`):
+**npm registry shim** (`gitd shim npm`):
 - Serves the npm registry HTTP API on localhost (default port 4873)
 - Works with `npm install`, `bun install`, `yarn add`, `pnpm add`
 - DID-scoped packages via npm scopes: `npm install --registry=http://localhost:4873 @did:dht:abc123/my-pkg`
 - Endpoints: packument (all versions), version metadata, tarball download
 - Includes DWN provenance metadata in `_dwn` fields
 
-**Go module proxy shim** (`dwn-git shim go`):
+**Go module proxy shim** (`gitd shim go`):
 - Serves the GOPROXY protocol on localhost (default port 4874)
 - Module paths: `GOPROXY=http://localhost:4874 go get did.enbox.org/did:dht:abc123/my-mod@v1.0.0`
 - Endpoints: `/@v/list`, `/@v/{ver}.info`, `/@v/{ver}.mod`, `/@v/{ver}.zip`, `/@latest`
 - Generates `go.mod` files with DID-scoped dependency mappings
 
-**OCI/Docker registry shim** (`dwn-git shim oci`):
+**OCI/Docker registry shim** (`gitd shim oci`):
 - Serves the OCI Distribution Spec v2 on localhost (default port 5555)
 - Works with `docker pull`, `podman pull`, and any OCI-compatible tool
 - Image naming: `docker pull localhost:5555/did:dht:abc123/my-image:v1.0.0`
@@ -232,10 +232,10 @@ Local HTTP proxy servers that speak native package manager protocols, resolving 
 
 ### Unified Daemon
 
-Run all ecosystem shims in a single process with `dwn-git daemon`. Each shim runs on its own port and speaks the native protocol of its ecosystem — no custom plugins or wrappers needed.
+Run all ecosystem shims in a single process with `gitd daemon`. Each shim runs on its own port and speaks the native protocol of its ecosystem — no custom plugins or wrappers needed.
 
 - **Plugin architecture**: `ShimAdapter` interface makes adding new ecosystems trivial (implement one file, register it)
-- **Config-driven**: optional `dwn-git.daemon.json` to set ports and enable/disable shims
+- **Config-driven**: optional `gitd.daemon.json` to set ports and enable/disable shims
 - **CLI flags**: `--only github,npm` to run a subset, `--disable oci` to exclude, `--list` to see all adapters
 - **Health checks**: every adapter's server responds to `GET /health` with `{ status: 'ok', shim: '<id>' }`
 - **Graceful shutdown**: SIGINT/SIGTERM stops all servers cleanly
@@ -287,43 +287,43 @@ See [PLAN.md](./PLAN.md) for the full architecture document covering:
 ## Installation
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/enboxorg/dwn-git/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/enboxorg/gitd/main/install.sh | bash
 ```
 
 The installer works on Linux, macOS, and Windows (Git Bash/WSL). It installs
-the latest prebuilt release binaries (`dwn-git`, `git-remote-did`, and
+the latest prebuilt release binaries (`gitd`, `git-remote-did`, and
 `git-remote-did-credential`).
 
 ```bash
 # Manual install (if you prefer to run steps yourself)
-bun add -g @enbox/dwn-git
+bun add -g @enbox/gitd
 ```
 
 ### Sub-path Exports
 
 ```typescript
 // Protocol definitions and types
-import { ForgeRepoProtocol, ForgeIssuesProtocol } from '@enbox/dwn-git';
+import { ForgeRepoProtocol, ForgeIssuesProtocol } from '@enbox/gitd';
 
 // Git transport server
-import { createGitServer, createBundleSyncer, restoreFromBundles } from '@enbox/dwn-git/git-server';
+import { createGitServer, createBundleSyncer, restoreFromBundles } from '@enbox/gitd/git-server';
 
 // Git remote helper utilities
-import { parseDidUrl, resolveGitEndpoint } from '@enbox/dwn-git/git-remote';
+import { parseDidUrl, resolveGitEndpoint } from '@enbox/gitd/git-remote';
 
 // Indexer service
-import { IndexerStore, IndexerCrawler, handleApiRequest } from '@enbox/dwn-git/indexer';
+import { IndexerStore, IndexerCrawler, handleApiRequest } from '@enbox/gitd/indexer';
 
 // GitHub API compatibility shim
-import { handleShimRequest, startShimServer } from '@enbox/dwn-git/github-shim';
+import { handleShimRequest, startShimServer } from '@enbox/gitd/github-shim';
 
 // Package resolver and trust chain
-import { resolveFullPackage, verifyPackageVersion, buildTrustChain } from '@enbox/dwn-git/resolver';
+import { resolveFullPackage, verifyPackageVersion, buildTrustChain } from '@enbox/gitd/resolver';
 
 // Package manager shims
-import { handleNpmRequest, startNpmShim } from '@enbox/dwn-git/shims/npm';
-import { handleGoProxyRequest, startGoShim } from '@enbox/dwn-git/shims/go';
-import { handleOciRequest, startOciShim } from '@enbox/dwn-git/shims/oci';
+import { handleNpmRequest, startNpmShim } from '@enbox/gitd/shims/npm';
+import { handleGoProxyRequest, startGoShim } from '@enbox/gitd/shims/go';
+import { handleOciRequest, startOciShim } from '@enbox/gitd/shims/oci';
 ```
 
 ## Development
@@ -342,7 +342,7 @@ Production-hardened with 10 security fixes across all server-facing code:
 
 - **Path traversal protection** — repo names validated, resolved paths confined to base directory
 - **Request body size limits** — 1 MB JSON / 50 MB git packs, returns 413 on overflow
-- **Bearer token auth** — optional `DWN_GIT_API_TOKEN` for API write endpoints (constant-time comparison)
+- **Bearer token auth** — optional `GITD_API_TOKEN` for API write endpoints (constant-time comparison)
 - **SSRF protection** — DID-resolved URLs blocked from private/loopback IP ranges
 - **DID resolution timeouts** — 30s timeout prevents hanging on malicious endpoints
 - **XSS protection** — all HTML output escaped in web UI error pages

--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,8 @@
 
 set -euo pipefail
 
-APP='dwn-git'
-REPO='enboxorg/dwn-git'
+APP='gitd'
+REPO='enboxorg/gitd'
 INSTALL_DIR="${HOME}/.${APP}/bin"
 REQUESTED_VERSION="${VERSION:-}"
 NO_MODIFY_PATH=false
@@ -18,7 +18,7 @@ trap cleanup EXIT INT TERM
 
 usage() {
   cat <<'EOF'
-dwn-git installer
+gitd installer
 
 Usage: install.sh [options]
 
@@ -158,7 +158,7 @@ add_to_path() {
   fi
 
   if [ -w "$config" ]; then
-    printf '\n# dwn-git\n%s\n' "$line" >> "$config"
+    printf '\n# gitd\n%s\n' "$line" >> "$config"
     printf 'Updated PATH in %s\n' "$config"
     return
   fi
@@ -201,9 +201,9 @@ main() {
 
   local archive=''
   if [ "$os" = 'windows' ]; then
-    archive="dwn-git-${os}-${arch}.zip"
+    archive="gitd-${os}-${arch}.zip"
   else
-    archive="dwn-git-${os}-${arch}.tar.gz"
+    archive="gitd-${os}-${arch}.tar.gz"
   fi
 
   local url
@@ -211,7 +211,7 @@ main() {
 
   TMP_DIR="$(mktemp -d)"
 
-  printf '==> Installing dwn-git %s\n' "$tag"
+  printf '==> Installing gitd %s\n' "$tag"
   download_file "$url" "${TMP_DIR}/${archive}"
   extract_archive "${TMP_DIR}/${archive}" "$TMP_DIR" "$os"
 
@@ -222,11 +222,11 @@ main() {
     suffix='.exe'
   fi
 
-  cp "${TMP_DIR}/dwn-git${suffix}" "${INSTALL_DIR}/dwn-git${suffix}"
+  cp "${TMP_DIR}/gitd${suffix}" "${INSTALL_DIR}/gitd${suffix}"
   cp "${TMP_DIR}/git-remote-did${suffix}" "${INSTALL_DIR}/git-remote-did${suffix}"
   cp "${TMP_DIR}/git-remote-did-credential${suffix}" "${INSTALL_DIR}/git-remote-did-credential${suffix}"
 
-  chmod +x "${INSTALL_DIR}/dwn-git${suffix}"
+  chmod +x "${INSTALL_DIR}/gitd${suffix}"
   chmod +x "${INSTALL_DIR}/git-remote-did${suffix}"
   chmod +x "${INSTALL_DIR}/git-remote-did-credential${suffix}"
 
@@ -235,8 +235,8 @@ main() {
   fi
 
   printf '==> Installed to %s\n' "$INSTALL_DIR"
-  "${INSTALL_DIR}/dwn-git${suffix}" --version || true
-  printf 'Run: dwn-git setup\n'
+  "${INSTALL_DIR}/gitd${suffix}" --version || true
+  printf 'Run: gitd setup\n'
 }
 
 main "$@"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@enbox/dwn-git",
+  "name": "@enbox/gitd",
   "version": "0.0.1",
   "description": "Decentralized forge (GitHub alternative) built on DWN protocols",
   "type": "module",
@@ -7,7 +7,7 @@
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "bin": {
-    "dwn-git": "./dist/esm/cli/main.js",
+    "gitd": "./dist/esm/cli/main.js",
     "git-remote-did": "./dist/esm/git-remote/main.js",
     "git-remote-did-credential": "./dist/esm/git-remote/credential-main.js"
   },

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -66,7 +66,7 @@ export type AgentContext = {
  * Connect to the local Web5 agent, initializing on first launch.
  *
  * The agent's persistent data lives under `dataPath` (default:
- * `~/.dwn-git/agent`).  Sync is disabled — the CLI operates against
+ * `~/.gitd/agent`).  Sync is disabled — the CLI operates against
  * the local DWN only.
  */
 export async function connectAgent(password: string): Promise<AgentContext> {

--- a/src/cli/commands/ci.ts
+++ b/src/cli/commands/ci.ts
@@ -1,13 +1,13 @@
 /**
- * `dwn-git ci` — view CI check suites and check runs.
+ * `gitd ci` — view CI check suites and check runs.
  *
  * Usage:
- *   dwn-git ci status [<commit>]              Show latest check suite status
- *   dwn-git ci list [--limit <n>]             List recent check suites
- *   dwn-git ci show <suite-id>                Show check suite details + runs
- *   dwn-git ci create <commit> [--app <name>] Create a check suite (for CI bots)
- *   dwn-git ci run <suite-id> <name>          Add a check run to a suite
- *   dwn-git ci update <run-id> --status <s>   Update a check run status
+ *   gitd ci status [<commit>]              Show latest check suite status
+ *   gitd ci list [--limit <n>]             List recent check suites
+ *   gitd ci show <suite-id>                Show check suite details + runs
+ *   gitd ci create <commit> [--app <name>] Create a check suite (for CI bots)
+ *   gitd ci run <suite-id> <name>          Add a check run to a suite
+ *   gitd ci update <run-id> --status <s>   Update a check run status
  *
  * @module
  */
@@ -36,7 +36,7 @@ export async function ciCommand(ctx: AgentContext, args: string[]): Promise<void
     case 'run': return ciRun(ctx, rest);
     case 'update': return ciUpdate(ctx, rest);
     default:
-      console.error('Usage: dwn-git ci <status|list|show|create|run|update>');
+      console.error('Usage: gitd ci <status|list|show|create|run|update>');
       process.exit(1);
   }
 }
@@ -122,7 +122,7 @@ async function ciList(ctx: AgentContext, args: string[]): Promise<void> {
 async function ciShow(ctx: AgentContext, args: string[]): Promise<void> {
   const suiteId = args[0];
   if (!suiteId) {
-    console.error('Usage: dwn-git ci show <suite-id>');
+    console.error('Usage: gitd ci show <suite-id>');
     process.exit(1);
   }
 
@@ -181,11 +181,11 @@ async function ciShow(ctx: AgentContext, args: string[]): Promise<void> {
 
 async function ciCreate(ctx: AgentContext, args: string[]): Promise<void> {
   const commitSha = args[0];
-  const app = flagValue(args, '--app') ?? 'dwn-git-ci';
+  const app = flagValue(args, '--app') ?? 'gitd-ci';
   const branch = flagValue(args, '--branch');
 
   if (!commitSha) {
-    console.error('Usage: dwn-git ci create <commit-sha> [--app <name>] [--branch <branch>]');
+    console.error('Usage: gitd ci create <commit-sha> [--app <name>] [--branch <branch>]');
     process.exit(1);
   }
 
@@ -221,7 +221,7 @@ async function ciRun(ctx: AgentContext, args: string[]): Promise<void> {
   const name = args[1];
 
   if (!suiteId || !name) {
-    console.error('Usage: dwn-git ci run <suite-id> <name>');
+    console.error('Usage: gitd ci run <suite-id> <name>');
     process.exit(1);
   }
 
@@ -260,7 +260,7 @@ async function ciUpdate(ctx: AgentContext, args: string[]): Promise<void> {
   const conclusion = flagValue(args, '--conclusion');
 
   if (!runId || !newStatus) {
-    console.error('Usage: dwn-git ci update <run-id> --status <queued|in_progress|completed> [--conclusion <success|failure|cancelled|skipped>]');
+    console.error('Usage: gitd ci update <run-id> --status <queued|in_progress|completed> [--conclusion <success|failure|cancelled|skipped>]');
     process.exit(1);
   }
 

--- a/src/cli/commands/clone.ts
+++ b/src/cli/commands/clone.ts
@@ -1,11 +1,11 @@
 /**
- * `dwn-git clone <did>/<repo>` — clone a repository by DID.
+ * `gitd clone <did>/<repo>` — clone a repository by DID.
  *
  * Convenience wrapper that:
  * 1. Validates the DID/repo argument
  * 2. Spawns `git clone did::<did>/<repo>` with inherited stdio
  *
- * Usage: dwn-git clone <did>/<repo> [-- <git-clone-args...>]
+ * Usage: gitd clone <did>/<repo> [-- <git-clone-args...>]
  *
  * @module
  */
@@ -20,11 +20,11 @@ export async function cloneCommand(args: string[]): Promise<void> {
   const target = args[0];
 
   if (!target) {
-    console.error('Usage: dwn-git clone <did>/<repo> [-- <git-clone-args...>]');
+    console.error('Usage: gitd clone <did>/<repo> [-- <git-clone-args...>]');
     console.error('');
     console.error('Examples:');
-    console.error('  dwn-git clone did:dht:abc123/my-repo');
-    console.error('  dwn-git clone did:dht:abc123/my-repo -- --depth 1');
+    console.error('  gitd clone did:dht:abc123/my-repo');
+    console.error('  gitd clone did:dht:abc123/my-repo -- --depth 1');
     process.exit(1);
   }
 

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -1,18 +1,18 @@
 /**
- * `dwn-git daemon` — start the unified shim daemon.
+ * `gitd daemon` — start the unified shim daemon.
  *
  * Starts all enabled ecosystem shims in a single process.  Each shim
  * runs on its own port and speaks the native protocol of its ecosystem
  * (GitHub REST API, npm registry, GOPROXY, OCI Distribution, etc.).
  *
  * Usage:
- *   dwn-git daemon                                Start all shims with defaults
- *   dwn-git daemon --config ./daemon.json         Use a config file
- *   dwn-git daemon --only github,npm              Only start specific shims
- *   dwn-git daemon --disable go,oci               Start all except specific shims
- *   dwn-git daemon --list                         List available shims and exit
+ *   gitd daemon                                Start all shims with defaults
+ *   gitd daemon --config ./daemon.json         Use a config file
+ *   gitd daemon --only github,npm              Only start specific shims
+ *   gitd daemon --disable go,oci               Start all except specific shims
+ *   gitd daemon --list                         List available shims and exit
  *
- * Config file format (dwn-git.daemon.json):
+ * Config file format (gitd.daemon.json):
  *   {
  *     "shims": {
  *       "github": { "enabled": true, "port": 8181 },
@@ -40,8 +40,8 @@ import { startDaemon } from '../../daemon/server.js';
 
 /** Default config file name searched in CWD. */
 const DEFAULT_CONFIG_FILES = [
-  'dwn-git.daemon.json',
-  '.dwn-git-daemon.json',
+  'gitd.daemon.json',
+  '.gitd-daemon.json',
 ];
 
 /**

--- a/src/cli/commands/github-api.ts
+++ b/src/cli/commands/github-api.ts
@@ -1,8 +1,8 @@
 /**
- * `dwn-git github-api` — start the GitHub API compatibility shim.
+ * `gitd github-api` — start the GitHub API compatibility shim.
  *
  * Usage:
- *   dwn-git github-api [--port <port>]
+ *   gitd github-api [--port <port>]
  *
  * Starts a read-only HTTP server that translates GitHub REST API v3
  * requests into DWN queries.  Default port: 8181.
@@ -20,7 +20,7 @@ import { flagValue, parsePort } from '../flags.js';
 // ---------------------------------------------------------------------------
 
 export async function githubApiCommand(ctx: AgentContext, args: string[]): Promise<void> {
-  const port = parsePort(flagValue(args, '--port') ?? process.env.DWN_GIT_GITHUB_API_PORT ?? '8181');
+  const port = parsePort(flagValue(args, '--port') ?? process.env.GITD_GITHUB_API_PORT ?? '8181');
 
   console.log('Starting GitHub API compatibility shim...');
   startShimServer({ ctx, port });

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,8 +1,8 @@
 /**
- * `dwn-git init` — create a forge repository record on the local DWN
+ * `gitd init` — create a forge repository record on the local DWN
  * and initialize a bare git repository on the filesystem.
  *
- * Usage: dwn-git init <name> [--description <text>] [--branch <name>] [--repos <path>]
+ * Usage: gitd init <name> [--description <text>] [--branch <name>] [--repos <path>]
  *
  * @module
  */
@@ -20,10 +20,10 @@ export async function initCommand(ctx: AgentContext, args: string[]): Promise<vo
   const name = args[0];
   const description = flagValue(args, '--description') ?? flagValue(args, '-d');
   const branch = flagValue(args, '--branch') ?? flagValue(args, '-b') ?? 'main';
-  const reposPath = flagValue(args, '--repos') ?? process.env.DWN_GIT_REPOS ?? './repos';
+  const reposPath = flagValue(args, '--repos') ?? process.env.GITD_REPOS ?? './repos';
 
   if (!name) {
-    console.error('Usage: dwn-git init <name> [--description <text>] [--branch <name>] [--repos <path>]');
+    console.error('Usage: gitd init <name> [--description <text>] [--branch <name>] [--repos <path>]');
     process.exit(1);
   }
 

--- a/src/cli/commands/issue.ts
+++ b/src/cli/commands/issue.ts
@@ -1,13 +1,13 @@
 /**
- * `dwn-git issue` — create, list, show, comment on, and manage issues.
+ * `gitd issue` — create, list, show, comment on, and manage issues.
  *
  * Usage:
- *   dwn-git issue create <title> [--body <text>]
- *   dwn-git issue show <number>
- *   dwn-git issue comment <number> <body>
- *   dwn-git issue close <number> [--reason <text>]
- *   dwn-git issue reopen <number>
- *   dwn-git issue list [--status <open|closed>]
+ *   gitd issue create <title> [--body <text>]
+ *   gitd issue show <number>
+ *   gitd issue comment <number> <body>
+ *   gitd issue close <number> [--reason <text>]
+ *   gitd issue reopen <number>
+ *   gitd issue list [--status <open|closed>]
  *
  * @module
  */
@@ -34,7 +34,7 @@ export async function issueCommand(ctx: AgentContext, args: string[]): Promise<v
     case 'list':
     case 'ls': return issueList(ctx, rest);
     default:
-      console.error('Usage: dwn-git issue <create|show|comment|close|reopen|list>');
+      console.error('Usage: gitd issue <create|show|comment|close|reopen|list>');
       process.exit(1);
   }
 }
@@ -48,7 +48,7 @@ async function issueCreate(ctx: AgentContext, args: string[]): Promise<void> {
   const body = flagValue(args, '--body') ?? flagValue(args, '-m') ?? '';
 
   if (!title) {
-    console.error('Usage: dwn-git issue create <title> [--body <text>]');
+    console.error('Usage: gitd issue create <title> [--body <text>]');
     process.exit(1);
   }
 
@@ -79,7 +79,7 @@ async function issueCreate(ctx: AgentContext, args: string[]): Promise<void> {
 async function issueShow(ctx: AgentContext, args: string[]): Promise<void> {
   const numberStr = args[0];
   if (!numberStr) {
-    console.error('Usage: dwn-git issue show <number>');
+    console.error('Usage: gitd issue show <number>');
     process.exit(1);
   }
 
@@ -134,7 +134,7 @@ async function issueComment(ctx: AgentContext, args: string[]): Promise<void> {
   const body = args.slice(1).join(' ') || (flagValue(args, '--body') ?? flagValue(args, '-m'));
 
   if (!numberStr || !body) {
-    console.error('Usage: dwn-git issue comment <number> <body>');
+    console.error('Usage: gitd issue comment <number> <body>');
     process.exit(1);
   }
 
@@ -165,7 +165,7 @@ async function issueComment(ctx: AgentContext, args: string[]): Promise<void> {
 async function issueClose(ctx: AgentContext, args: string[]): Promise<void> {
   const numberStr = args[0];
   if (!numberStr) {
-    console.error('Usage: dwn-git issue close <number>');
+    console.error('Usage: gitd issue close <number>');
     process.exit(1);
   }
 
@@ -204,7 +204,7 @@ async function issueClose(ctx: AgentContext, args: string[]): Promise<void> {
 async function issueReopen(ctx: AgentContext, args: string[]): Promise<void> {
   const numberStr = args[0];
   if (!numberStr) {
-    console.error('Usage: dwn-git issue reopen <number>');
+    console.error('Usage: gitd issue reopen <number>');
     process.exit(1);
   }
 

--- a/src/cli/commands/log.ts
+++ b/src/cli/commands/log.ts
@@ -1,10 +1,10 @@
 /**
- * `dwn-git log` — show recent forge activity.
+ * `gitd log` — show recent forge activity.
  *
  * Displays recent issues, patches, and ref updates in reverse chronological
  * order, giving a unified activity feed for the repository.
  *
- * Usage: dwn-git log [--limit <n>]
+ * Usage: gitd log [--limit <n>]
  *
  * @module
  */

--- a/src/cli/commands/notification.ts
+++ b/src/cli/commands/notification.ts
@@ -1,13 +1,13 @@
 /**
- * `dwn-git notification` — personal notification inbox.
+ * `gitd notification` — personal notification inbox.
  *
  * Notifications are private (`published: false`) and only the DWN owner
  * can read, mark as read, or delete them.
  *
  * Usage:
- *   dwn-git notification list [--unread]       List notifications
- *   dwn-git notification read <id>             Mark a notification as read
- *   dwn-git notification clear                 Delete all read notifications
+ *   gitd notification list [--unread]       List notifications
+ *   gitd notification read <id>             Mark a notification as read
+ *   gitd notification clear                 Delete all read notifications
  *
  * @module
  */
@@ -32,7 +32,7 @@ export async function notificationCommand(ctx: AgentContext, args: string[]): Pr
     case 'read': return notificationRead(ctx, rest);
     case 'clear': return notificationClear(ctx);
     default:
-      console.error('Usage: dwn-git notification <list|read|clear>');
+      console.error('Usage: gitd notification <list|read|clear>');
       process.exit(1);
   }
 }
@@ -89,7 +89,7 @@ async function notificationList(ctx: AgentContext, args: string[]): Promise<void
 async function notificationRead(ctx: AgentContext, args: string[]): Promise<void> {
   const id = args[0];
   if (!id) {
-    console.error('Usage: dwn-git notification read <id>');
+    console.error('Usage: gitd notification read <id>');
     process.exit(1);
   }
 

--- a/src/cli/commands/org.ts
+++ b/src/cli/commands/org.ts
@@ -1,16 +1,16 @@
 /**
- * `dwn-git org` — organization and team management.
+ * `gitd org` — organization and team management.
  *
  * Usage:
- *   dwn-git org create <name> [--description <text>]
- *   dwn-git org info
- *   dwn-git org add-member <did> [--alias <name>]
- *   dwn-git org remove-member <did>
- *   dwn-git org list-members
- *   dwn-git org add-owner <did> [--alias <name>]
- *   dwn-git org team create <name> [--description <text>] [--privacy <visible|secret>]
- *   dwn-git org team list
- *   dwn-git org team add-member <team-name> <did>
+ *   gitd org create <name> [--description <text>]
+ *   gitd org info
+ *   gitd org add-member <did> [--alias <name>]
+ *   gitd org remove-member <did>
+ *   gitd org list-members
+ *   gitd org add-owner <did> [--alias <name>]
+ *   gitd org team create <name> [--description <text>] [--privacy <visible|secret>]
+ *   gitd org team list
+ *   gitd org team add-member <team-name> <did>
  *
  * @module
  */
@@ -36,7 +36,7 @@ export async function orgCommand(ctx: AgentContext, args: string[]): Promise<voi
     case 'add-owner': return orgAddOwner(ctx, rest);
     case 'team': return orgTeam(ctx, rest);
     default:
-      console.error('Usage: dwn-git org <create|info|add-member|remove-member|list-members|add-owner|team>');
+      console.error('Usage: gitd org <create|info|add-member|remove-member|list-members|add-owner|team>');
       process.exit(1);
   }
 }
@@ -48,7 +48,7 @@ export async function orgCommand(ctx: AgentContext, args: string[]): Promise<voi
 async function getOrgRecord(ctx: AgentContext): Promise<any> {
   const { records } = await ctx.org.records.query('org');
   if (records.length === 0) {
-    console.error('No organization found. Run `dwn-git org create <name>` first.');
+    console.error('No organization found. Run `gitd org create <name>` first.');
     process.exit(1);
   }
   return records[0];
@@ -63,7 +63,7 @@ async function orgCreate(ctx: AgentContext, args: string[]): Promise<void> {
   const description = flagValue(args, '--description') ?? '';
 
   if (!name) {
-    console.error('Usage: dwn-git org create <name> [--description <text>]');
+    console.error('Usage: gitd org create <name> [--description <text>]');
     process.exit(1);
   }
 
@@ -151,7 +151,7 @@ async function orgAddMember(ctx: AgentContext, args: string[]): Promise<void> {
   const alias = flagValue(args, '--alias');
 
   if (!did) {
-    console.error('Usage: dwn-git org add-member <did> [--alias <name>]');
+    console.error('Usage: gitd org add-member <did> [--alias <name>]');
     process.exit(1);
   }
 
@@ -179,7 +179,7 @@ async function orgAddMember(ctx: AgentContext, args: string[]): Promise<void> {
 async function orgRemoveMember(ctx: AgentContext, args: string[]): Promise<void> {
   const did = args[0];
   if (!did) {
-    console.error('Usage: dwn-git org remove-member <did>');
+    console.error('Usage: gitd org remove-member <did>');
     process.exit(1);
   }
 
@@ -252,7 +252,7 @@ async function orgAddOwner(ctx: AgentContext, args: string[]): Promise<void> {
   const alias = flagValue(args, '--alias');
 
   if (!did) {
-    console.error('Usage: dwn-git org add-owner <did> [--alias <name>]');
+    console.error('Usage: gitd org add-owner <did> [--alias <name>]');
     process.exit(1);
   }
 
@@ -287,7 +287,7 @@ async function orgTeam(ctx: AgentContext, args: string[]): Promise<void> {
     case 'ls': return teamList(ctx, rest);
     case 'add-member': return teamAddMember(ctx, rest);
     default:
-      console.error('Usage: dwn-git org team <create|list|add-member>');
+      console.error('Usage: gitd org team <create|list|add-member>');
       process.exit(1);
   }
 }
@@ -298,7 +298,7 @@ async function teamCreate(ctx: AgentContext, args: string[]): Promise<void> {
   const privacy = flagValue(args, '--privacy') ?? 'visible';
 
   if (!name) {
-    console.error('Usage: dwn-git org team create <name> [--description <text>] [--privacy <visible|secret>]');
+    console.error('Usage: gitd org team create <name> [--description <text>] [--privacy <visible|secret>]');
     process.exit(1);
   }
 
@@ -343,7 +343,7 @@ async function teamAddMember(ctx: AgentContext, args: string[]): Promise<void> {
   const did = args[1];
 
   if (!teamName || !did) {
-    console.error('Usage: dwn-git org team add-member <team-name> <did>');
+    console.error('Usage: gitd org team add-member <team-name> <did>');
     process.exit(1);
   }
 

--- a/src/cli/commands/patch.ts
+++ b/src/cli/commands/patch.ts
@@ -1,14 +1,14 @@
 /**
- * `dwn-git patch` — create, list, show, comment on, and merge patches (pull requests).
+ * `gitd patch` — create, list, show, comment on, and merge patches (pull requests).
  *
  * Usage:
- *   dwn-git patch create <title> [--body <text>] [--base <branch>] [--head <branch>]
- *   dwn-git patch show <number>
- *   dwn-git patch comment <number> <body>
- *   dwn-git patch merge <number> [--strategy <merge|squash|rebase>]
- *   dwn-git patch close <number>
- *   dwn-git patch reopen <number>
- *   dwn-git patch list [--status <draft|open|closed|merged>]
+ *   gitd patch create <title> [--body <text>] [--base <branch>] [--head <branch>]
+ *   gitd patch show <number>
+ *   gitd patch comment <number> <body>
+ *   gitd patch merge <number> [--strategy <merge|squash|rebase>]
+ *   gitd patch close <number>
+ *   gitd patch reopen <number>
+ *   gitd patch list [--status <draft|open|closed|merged>]
  *
  * @module
  */
@@ -36,7 +36,7 @@ export async function patchCommand(ctx: AgentContext, args: string[]): Promise<v
     case 'list':
     case 'ls': return patchList(ctx, rest);
     default:
-      console.error('Usage: dwn-git patch <create|show|comment|merge|close|reopen|list>');
+      console.error('Usage: gitd patch <create|show|comment|merge|close|reopen|list>');
       process.exit(1);
   }
 }
@@ -52,7 +52,7 @@ async function patchCreate(ctx: AgentContext, args: string[]): Promise<void> {
   const head = flagValue(args, '--head');
 
   if (!title) {
-    console.error('Usage: dwn-git patch create <title> [--body <text>] [--base <branch>] [--head <branch>]');
+    console.error('Usage: gitd patch create <title> [--body <text>] [--base <branch>] [--head <branch>]');
     process.exit(1);
   }
 
@@ -90,7 +90,7 @@ async function patchCreate(ctx: AgentContext, args: string[]): Promise<void> {
 async function patchShow(ctx: AgentContext, args: string[]): Promise<void> {
   const numberStr = args[0];
   if (!numberStr) {
-    console.error('Usage: dwn-git patch show <number>');
+    console.error('Usage: gitd patch show <number>');
     process.exit(1);
   }
 
@@ -153,7 +153,7 @@ async function patchComment(ctx: AgentContext, args: string[]): Promise<void> {
   const body = args.slice(1).join(' ') || (flagValue(args, '--body') ?? flagValue(args, '-m'));
 
   if (!numberStr || !body) {
-    console.error('Usage: dwn-git patch comment <number> <body>');
+    console.error('Usage: gitd patch comment <number> <body>');
     process.exit(1);
   }
 
@@ -188,7 +188,7 @@ async function patchMerge(ctx: AgentContext, args: string[]): Promise<void> {
   const strategy = flagValue(args, '--strategy') ?? 'merge';
 
   if (!numberStr) {
-    console.error('Usage: dwn-git patch merge <number> [--strategy <merge|squash|rebase>]');
+    console.error('Usage: gitd patch merge <number> [--strategy <merge|squash|rebase>]');
     process.exit(1);
   }
 
@@ -245,7 +245,7 @@ async function patchMerge(ctx: AgentContext, args: string[]): Promise<void> {
 async function patchClose(ctx: AgentContext, args: string[]): Promise<void> {
   const numberStr = args[0];
   if (!numberStr) {
-    console.error('Usage: dwn-git patch close <number>');
+    console.error('Usage: gitd patch close <number>');
     process.exit(1);
   }
 
@@ -289,7 +289,7 @@ async function patchClose(ctx: AgentContext, args: string[]): Promise<void> {
 async function patchReopen(ctx: AgentContext, args: string[]): Promise<void> {
   const numberStr = args[0];
   if (!numberStr) {
-    console.error('Usage: dwn-git patch reopen <number>');
+    console.error('Usage: gitd patch reopen <number>');
     process.exit(1);
   }
 

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -1,22 +1,22 @@
 /**
- * `dwn-git registry` — DID-scoped package publishing and management.
+ * `gitd registry` — DID-scoped package publishing and management.
  *
  * Packages are scoped to the publisher's DID. Versions and tarballs are
  * immutable — once published, content cannot be silently replaced.
  *
  * Usage:
- *   dwn-git registry publish <name> <version> <tarball-path>
+ *   gitd registry publish <name> <version> <tarball-path>
  *       [--ecosystem <npm|cargo|pip|go>] [--description <text>]
- *   dwn-git registry info <name>
- *   dwn-git registry versions <name>
- *   dwn-git registry list [--ecosystem <npm|cargo|pip|go>]
- *   dwn-git registry yank <name> <version>
- *   dwn-git registry attest <name> <version> --claim <claim>
+ *   gitd registry info <name>
+ *   gitd registry versions <name>
+ *   gitd registry list [--ecosystem <npm|cargo|pip|go>]
+ *   gitd registry yank <name> <version>
+ *   gitd registry attest <name> <version> --claim <claim>
  *       [--source-commit <sha>] [--source-repo <did/id>]
- *   dwn-git registry attestations <name> <version>
- *   dwn-git registry verify <name> <version> [--trusted <did>,...]
- *   dwn-git registry resolve <did>/<name>@<version>
- *   dwn-git registry verify-deps <did>/<name>@<version> [--trusted <did>,...]
+ *   gitd registry attestations <name> <version>
+ *   gitd registry verify <name> <version> [--trusted <did>,...]
+ *   gitd registry resolve <did>/<name>@<version>
+ *   gitd registry verify-deps <did>/<name>@<version> [--trusted <did>,...]
  *
  * @module
  */
@@ -52,7 +52,7 @@ export async function registryCommand(ctx: AgentContext, args: string[]): Promis
     case 'resolve': return registryResolve(ctx, rest);
     case 'verify-deps': return registryVerifyDeps(ctx, rest);
     default:
-      console.error('Usage: dwn-git registry <publish|info|versions|list|yank|attest|attestations|verify|resolve|verify-deps>');
+      console.error('Usage: gitd registry <publish|info|versions|list|yank|attest|attestations|verify|resolve|verify-deps>');
       process.exit(1);
   }
 }
@@ -69,7 +69,7 @@ async function registryPublish(ctx: AgentContext, args: string[]): Promise<void>
   const description = flagValue(args, '--description');
 
   if (!name || !version || !tarballPath) {
-    console.error('Usage: dwn-git registry publish <name> <version> <tarball-path> [--ecosystem <npm|cargo|pip|go>]');
+    console.error('Usage: gitd registry publish <name> <version> <tarball-path> [--ecosystem <npm|cargo|pip|go>]');
     process.exit(1);
   }
 
@@ -152,7 +152,7 @@ async function registryPublish(ctx: AgentContext, args: string[]): Promise<void>
 async function registryInfo(ctx: AgentContext, args: string[]): Promise<void> {
   const name = args[0];
   if (!name) {
-    console.error('Usage: dwn-git registry info <name>');
+    console.error('Usage: gitd registry info <name>');
     process.exit(1);
   }
 
@@ -193,7 +193,7 @@ async function registryInfo(ctx: AgentContext, args: string[]): Promise<void> {
 async function registryVersions(ctx: AgentContext, args: string[]): Promise<void> {
   const name = args[0];
   if (!name) {
-    console.error('Usage: dwn-git registry versions <name>');
+    console.error('Usage: gitd registry versions <name>');
     process.exit(1);
   }
 
@@ -267,7 +267,7 @@ async function registryYank(ctx: AgentContext, args: string[]): Promise<void> {
   const version = args[1];
 
   if (!name || !version) {
-    console.error('Usage: dwn-git registry yank <name> <version>');
+    console.error('Usage: gitd registry yank <name> <version>');
     process.exit(1);
   }
 
@@ -308,7 +308,7 @@ async function registryAttest(ctx: AgentContext, args: string[]): Promise<void> 
   const sourceRepo = flagValue(args, '--source-repo');
 
   if (!name || !version || !claim) {
-    console.error('Usage: dwn-git registry attest <name> <version> --claim <claim> [--source-commit <sha>] [--source-repo <did/id>]');
+    console.error('Usage: gitd registry attest <name> <version> --claim <claim> [--source-commit <sha>] [--source-repo <did/id>]');
     process.exit(1);
   }
 
@@ -359,7 +359,7 @@ async function registryAttestations(ctx: AgentContext, args: string[]): Promise<
   const version = args[1];
 
   if (!name || !version) {
-    console.error('Usage: dwn-git registry attestations <name> <version>');
+    console.error('Usage: gitd registry attestations <name> <version>');
     process.exit(1);
   }
 
@@ -404,7 +404,7 @@ async function registryVerify(ctx: AgentContext, args: string[]): Promise<void> 
   const trustedAttestors = trustedArg ? trustedArg.split(',') : [];
 
   if (!name || !version) {
-    console.error('Usage: dwn-git registry verify <name> <version> [--trusted <did>,...]');
+    console.error('Usage: gitd registry verify <name> <version> [--trusted <did>,...]');
     process.exit(1);
   }
 
@@ -437,7 +437,7 @@ async function registryResolve(ctx: AgentContext, args: string[]): Promise<void>
   const ecosystem = flagValue(args, '--ecosystem') ?? 'npm';
 
   if (!specifier) {
-    console.error('Usage: dwn-git registry resolve <did>/<name>@<version> [--ecosystem <eco>]');
+    console.error('Usage: gitd registry resolve <did>/<name>@<version> [--ecosystem <eco>]');
     process.exit(1);
   }
 
@@ -488,7 +488,7 @@ async function registryVerifyDeps(ctx: AgentContext, args: string[]): Promise<vo
   const ecosystem = flagValue(args, '--ecosystem') ?? 'npm';
 
   if (!specifier) {
-    console.error('Usage: dwn-git registry verify-deps <did>/<name>@<version> [--trusted <did>,...] [--ecosystem <eco>]');
+    console.error('Usage: gitd registry verify-deps <did>/<name>@<version> [--trusted <did>,...] [--ecosystem <eco>]');
     process.exit(1);
   }
 

--- a/src/cli/commands/release.ts
+++ b/src/cli/commands/release.ts
@@ -1,10 +1,10 @@
 /**
- * `dwn-git release` — create, list, and show releases with immutable assets.
+ * `gitd release` — create, list, and show releases with immutable assets.
  *
  * Usage:
- *   dwn-git release create <tag> [--name <name>] [--body <text>] [--commit <sha>] [--prerelease] [--draft]
- *   dwn-git release show <tag>
- *   dwn-git release list [--limit <n>]
+ *   gitd release create <tag> [--name <name>] [--body <text>] [--commit <sha>] [--prerelease] [--draft]
+ *   gitd release show <tag>
+ *   gitd release list [--limit <n>]
  *
  * @module
  */
@@ -30,7 +30,7 @@ export async function releaseCommand(ctx: AgentContext, args: string[]): Promise
     case 'list':
     case 'ls': return releaseList(ctx, rest);
     default:
-      console.error('Usage: dwn-git release <create|show|list>');
+      console.error('Usage: gitd release <create|show|list>');
       process.exit(1);
   }
 }
@@ -48,7 +48,7 @@ async function releaseCreate(ctx: AgentContext, args: string[]): Promise<void> {
   const draft = args.includes('--draft');
 
   if (!tagName) {
-    console.error('Usage: dwn-git release create <tag> [--name <name>] [--body <text>] [--commit <sha>] [--prerelease] [--draft]');
+    console.error('Usage: gitd release create <tag> [--name <name>] [--body <text>] [--commit <sha>] [--prerelease] [--draft]');
     process.exit(1);
   }
 
@@ -83,7 +83,7 @@ async function releaseCreate(ctx: AgentContext, args: string[]): Promise<void> {
 async function releaseShow(ctx: AgentContext, args: string[]): Promise<void> {
   const tagName = args[0];
   if (!tagName) {
-    console.error('Usage: dwn-git release show <tag>');
+    console.error('Usage: gitd release show <tag>');
     process.exit(1);
   }
 

--- a/src/cli/commands/repo.ts
+++ b/src/cli/commands/repo.ts
@@ -1,10 +1,10 @@
 /**
- * `dwn-git repo` — repository management commands.
+ * `gitd repo` — repository management commands.
  *
  * Usage:
- *   dwn-git repo info                           Show repository metadata
- *   dwn-git repo add-collaborator <did> <role>  Grant a role
- *   dwn-git repo remove-collaborator <did>      Revoke a collaborator role
+ *   gitd repo info                           Show repository metadata
+ *   gitd repo add-collaborator <did> <role>  Grant a role
+ *   gitd repo remove-collaborator <did>      Revoke a collaborator role
  *
  * Roles: maintainer, triager, contributor
  *
@@ -36,7 +36,7 @@ export async function repoCommand(ctx: AgentContext, args: string[]): Promise<vo
     case 'add-collaborator': return addCollaborator(ctx, rest);
     case 'remove-collaborator': return removeCollaborator(ctx, rest);
     default:
-      console.error('Usage: dwn-git repo <info|add-collaborator|remove-collaborator>');
+      console.error('Usage: gitd repo <info|add-collaborator|remove-collaborator>');
       process.exit(1);
   }
 }
@@ -49,7 +49,7 @@ async function repoInfo(ctx: AgentContext): Promise<void> {
   const { records } = await ctx.repo.records.query('repo');
 
   if (records.length === 0) {
-    console.error('No repository found. Run `dwn-git init <name>` first.');
+    console.error('No repository found. Run `gitd init <name>` first.');
     process.exit(1);
   }
 
@@ -95,7 +95,7 @@ async function addCollaborator(ctx: AgentContext, args: string[]): Promise<void>
   const alias = flagValue(args, '--alias') ?? flagValue(args, '-a');
 
   if (!did || !role) {
-    console.error('Usage: dwn-git repo add-collaborator <did> <role> [--alias <name>]');
+    console.error('Usage: gitd repo add-collaborator <did> <role> [--alias <name>]');
     console.error(`  Roles: ${VALID_ROLES.join(', ')}`);
     process.exit(1);
   }
@@ -131,7 +131,7 @@ async function removeCollaborator(ctx: AgentContext, args: string[]): Promise<vo
   const did = args[0];
 
   if (!did) {
-    console.error('Usage: dwn-git repo remove-collaborator <did>');
+    console.error('Usage: gitd repo remove-collaborator <did>');
     process.exit(1);
   }
 

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1,19 +1,19 @@
 /**
- * `dwn-git serve` — start the git transport sidecar server.
+ * `gitd serve` — start the git transport sidecar server.
  *
  * Starts a smart HTTP git server that serves bare repositories and
  * authenticates pushes using DID-signed tokens. After each successful
  * push, git refs are mirrored to DWN records via ForgeRefsProtocol and
  * a git bundle is synced to a DWN record via ForgeRepoProtocol.
  *
- * Usage: dwn-git serve [--port <port>] [--repos <path>] [--prefix <path>]
+ * Usage: gitd serve [--port <port>] [--repos <path>] [--prefix <path>]
  *                       [--public-url <url>]
  *
  * Environment:
- *   DWN_GIT_PORT        — server port (default: 9418)
- *   DWN_GIT_REPOS       — base path for bare repos (default: ./repos)
- *   DWN_GIT_PREFIX      — URL path prefix (default: none)
- *   DWN_GIT_PUBLIC_URL  — public URL for the server (enables DID service registration)
+ *   GITD_PORT        — server port (default: 9418)
+ *   GITD_REPOS       — base path for bare repos (default: ./repos)
+ *   GITD_PREFIX      — URL path prefix (default: none)
+ *   GITD_PUBLIC_URL  — public URL for the server (enables DID service registration)
  *
  * @module
  */
@@ -36,10 +36,10 @@ import { flagValue, parsePort } from '../flags.js';
 // ---------------------------------------------------------------------------
 
 export async function serveCommand(ctx: AgentContext, args: string[]): Promise<void> {
-  const port = parsePort(flagValue(args, '--port') ?? process.env.DWN_GIT_PORT ?? '9418');
-  const basePath = flagValue(args, '--repos') ?? process.env.DWN_GIT_REPOS ?? './repos';
-  const pathPrefix = flagValue(args, '--prefix') ?? process.env.DWN_GIT_PREFIX;
-  const publicUrl = flagValue(args, '--public-url') ?? process.env.DWN_GIT_PUBLIC_URL;
+  const port = parsePort(flagValue(args, '--port') ?? process.env.GITD_PORT ?? '9418');
+  const basePath = flagValue(args, '--repos') ?? process.env.GITD_REPOS ?? './repos';
+  const pathPrefix = flagValue(args, '--prefix') ?? process.env.GITD_PREFIX;
+  const publicUrl = flagValue(args, '--public-url') ?? process.env.GITD_PUBLIC_URL;
 
   // Look up the repo context (contextId + visibility) for ref/bundle syncing.
   const { contextId: repoContextId, visibility } = await getRepoContext(ctx);
@@ -123,7 +123,7 @@ export async function serveCommand(ctx: AgentContext, args: string[]): Promise<v
     }
   }
 
-  console.log(`dwn-git server listening on port ${server.port}`);
+  console.log(`gitd server listening on port ${server.port}`);
   console.log(`  DID:     ${ctx.did}`);
   console.log(`  Repos:   ${basePath}`);
   if (pathPrefix) {

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -1,13 +1,13 @@
 /**
- * `dwn-git setup` — configure git to use DID-based remotes and push auth.
+ * `gitd setup` — configure git to use DID-based remotes and push auth.
  *
  * Creates symlinks for `git-remote-did` and `git-remote-did-credential` in
  * a directory on the user's PATH, and configures the git credential helper
  * for any host using the DID transport.
  *
- * Usage: dwn-git setup [--bin-dir <path>]
+ * Usage: gitd setup [--bin-dir <path>]
  *
- * The default bin directory is `~/.dwn-git/bin`. The command also ensures
+ * The default bin directory is `~/.gitd/bin`. The command also ensures
  * that directory is in the user's PATH (prints instructions if not).
  *
  * @module
@@ -23,7 +23,7 @@ import { flagValue } from '../flags.js';
 // Constants
 // ---------------------------------------------------------------------------
 
-const DEFAULT_BIN_DIR = join(homedir(), '.dwn-git', 'bin');
+const DEFAULT_BIN_DIR = join(homedir(), '.gitd', 'bin');
 
 /** Binary names that must be on PATH for git DID transport to work. */
 const BINARIES = ['git-remote-did', 'git-remote-did-credential'] as const;
@@ -58,7 +58,7 @@ export async function setupCommand(args: string[]): Promise<void> {
 
     if (!existsSync(target)) {
       console.error(`Warning: source binary not found at ${target}`);
-      console.error('  Run `bun run build` first, or install @enbox/dwn-git globally.');
+      console.error('  Run `bun run build` first, or install @enbox/gitd globally.');
       continue;
     }
 
@@ -91,7 +91,7 @@ export async function setupCommand(args: string[]): Promise<void> {
   console.log('  git clone did::<did>/<repo>');
   console.log('');
   console.log('Or use the convenience wrapper:');
-  console.log('  dwn-git clone <did>/<repo>');
+  console.log('  gitd clone <did>/<repo>');
 }
 
 

--- a/src/cli/commands/shim.ts
+++ b/src/cli/commands/shim.ts
@@ -1,10 +1,10 @@
 /**
- * `dwn-git shim` — start a package manager / registry compatibility shim.
+ * `gitd shim` — start a package manager / registry compatibility shim.
  *
  * Usage:
- *   dwn-git shim npm [--port 4873]   Start npm registry shim
- *   dwn-git shim go  [--port 4874]   Start Go module proxy shim
- *   dwn-git shim oci [--port 5555]   Start OCI/Docker registry shim
+ *   gitd shim npm [--port 4873]   Start npm registry shim
+ *   gitd shim go  [--port 4874]   Start Go module proxy shim
+ *   gitd shim oci [--port 5555]   Start OCI/Docker registry shim
  *
  * Each shim starts a local HTTP proxy that speaks the native protocol of
  * the ecosystem tool, resolving DID-scoped packages from DWN records.
@@ -38,7 +38,7 @@ export async function shimCommand(ctx: AgentContext, args: string[]): Promise<vo
   switch (sub) {
     case 'npm': {
       const port = parsePort(
-        flagValue(rest, '--port') ?? process.env.DWN_GIT_NPM_SHIM_PORT ?? DEFAULT_NPM_PORT,
+        flagValue(rest, '--port') ?? process.env.GITD_NPM_SHIM_PORT ?? DEFAULT_NPM_PORT,
       );
       console.log('Starting npm registry shim...');
       startNpmShim({ ctx, port });
@@ -48,7 +48,7 @@ export async function shimCommand(ctx: AgentContext, args: string[]): Promise<vo
 
     case 'go': {
       const port = parsePort(
-        flagValue(rest, '--port') ?? process.env.DWN_GIT_GO_SHIM_PORT ?? DEFAULT_GO_PORT,
+        flagValue(rest, '--port') ?? process.env.GITD_GO_SHIM_PORT ?? DEFAULT_GO_PORT,
       );
       console.log('Starting Go module proxy shim...');
       startGoShim({ ctx, port });
@@ -59,7 +59,7 @@ export async function shimCommand(ctx: AgentContext, args: string[]): Promise<vo
     case 'oci':
     case 'docker': {
       const port = parsePort(
-        flagValue(rest, '--port') ?? process.env.DWN_GIT_OCI_SHIM_PORT ?? DEFAULT_OCI_PORT,
+        flagValue(rest, '--port') ?? process.env.GITD_OCI_SHIM_PORT ?? DEFAULT_OCI_PORT,
       );
       console.log('Starting OCI/Docker registry shim...');
       startOciShim({ ctx, port });
@@ -68,7 +68,7 @@ export async function shimCommand(ctx: AgentContext, args: string[]): Promise<vo
     }
 
     default:
-      console.error('Usage: dwn-git shim <npm|go|oci> [--port <port>]');
+      console.error('Usage: gitd shim <npm|go|oci> [--port <port>]');
       console.error('');
       console.error('Shims:');
       console.error(`  npm     npm registry proxy (default port: ${DEFAULT_NPM_PORT})`);

--- a/src/cli/commands/social.ts
+++ b/src/cli/commands/social.ts
@@ -1,16 +1,16 @@
 /**
- * `dwn-git social` — stars, follows, and activity feeds.
+ * `gitd social` — stars, follows, and activity feeds.
  *
  * Stars and follows live on the actor's DWN (data sovereignty).
  * Aggregate counts require an indexer.
  *
  * Usage:
- *   dwn-git star <did>                         Star a repo (by owner DID)
- *   dwn-git unstar <did>                       Remove a star
- *   dwn-git stars                              List starred repos
- *   dwn-git follow <did>                       Follow a user
- *   dwn-git unfollow <did>                     Unfollow a user
- *   dwn-git following                          List followed users
+ *   gitd star <did>                         Star a repo (by owner DID)
+ *   gitd unstar <did>                       Remove a star
+ *   gitd stars                              List starred repos
+ *   gitd follow <did>                       Follow a user
+ *   gitd unfollow <did>                     Unfollow a user
+ *   gitd following                          List followed users
  *
  * @module
  */
@@ -33,7 +33,7 @@ export async function socialCommand(ctx: AgentContext, args: string[]): Promise<
     case 'unfollow': return unfollowUser(ctx, rest);
     case 'following': return listFollowing(ctx);
     default:
-      console.error('Usage: dwn-git social <star|unstar|stars|follow|unfollow|following>');
+      console.error('Usage: gitd social <star|unstar|stars|follow|unfollow|following>');
       process.exit(1);
   }
 }
@@ -45,7 +45,7 @@ export async function socialCommand(ctx: AgentContext, args: string[]): Promise<
 async function starRepo(ctx: AgentContext, args: string[]): Promise<void> {
   const repoDid = args[0];
   if (!repoDid) {
-    console.error('Usage: dwn-git social star <repo-owner-did>');
+    console.error('Usage: gitd social star <repo-owner-did>');
     process.exit(1);
   }
 
@@ -95,7 +95,7 @@ async function starRepo(ctx: AgentContext, args: string[]): Promise<void> {
 async function unstarRepo(ctx: AgentContext, args: string[]): Promise<void> {
   const repoDid = args[0];
   if (!repoDid) {
-    console.error('Usage: dwn-git social unstar <repo-owner-did>');
+    console.error('Usage: gitd social unstar <repo-owner-did>');
     process.exit(1);
   }
 
@@ -144,7 +144,7 @@ async function listStars(ctx: AgentContext): Promise<void> {
 async function followUser(ctx: AgentContext, args: string[]): Promise<void> {
   const targetDid = args[0];
   if (!targetDid) {
-    console.error('Usage: dwn-git social follow <did>');
+    console.error('Usage: gitd social follow <did>');
     process.exit(1);
   }
 
@@ -178,7 +178,7 @@ async function followUser(ctx: AgentContext, args: string[]): Promise<void> {
 async function unfollowUser(ctx: AgentContext, args: string[]): Promise<void> {
   const targetDid = args[0];
   if (!targetDid) {
-    console.error('Usage: dwn-git social unfollow <did>');
+    console.error('Usage: gitd social unfollow <did>');
     process.exit(1);
   }
 

--- a/src/cli/commands/web.ts
+++ b/src/cli/commands/web.ts
@@ -1,8 +1,8 @@
 /**
- * `dwn-git web` — start the read-only web UI server.
+ * `gitd web` — start the read-only web UI server.
  *
  * Usage:
- *   dwn-git web [--port <port>]
+ *   gitd web [--port <port>]
  *
  * Serves a read-only HTML interface for browsing repo metadata, issues,
  * patches, releases, and wiki pages.  Default port: 8080.
@@ -20,9 +20,9 @@ import { startWebServer } from '../../web/server.js';
 // ---------------------------------------------------------------------------
 
 export async function webCommand(ctx: AgentContext, args: string[]): Promise<void> {
-  const port = parseInt(flagValue(args, '--port') ?? process.env.DWN_GIT_WEB_PORT ?? '8080', 10);
+  const port = parseInt(flagValue(args, '--port') ?? process.env.GITD_WEB_PORT ?? '8080', 10);
 
-  console.log('Starting dwn-git web UI...');
+  console.log('Starting gitd web UI...');
   startWebServer({ ctx, port });
 
   // Keep the process alive — the server runs until Ctrl+C.

--- a/src/cli/commands/wiki.ts
+++ b/src/cli/commands/wiki.ts
@@ -1,11 +1,11 @@
 /**
- * `dwn-git wiki` — collaborative documentation pages.
+ * `gitd wiki` — collaborative documentation pages.
  *
  * Usage:
- *   dwn-git wiki create <slug> <title> [--body <markdown>]
- *   dwn-git wiki show <slug>
- *   dwn-git wiki edit <slug> --body <markdown> [--summary <text>]
- *   dwn-git wiki list
+ *   gitd wiki create <slug> <title> [--body <markdown>]
+ *   gitd wiki show <slug>
+ *   gitd wiki edit <slug> --body <markdown> [--summary <text>]
+ *   gitd wiki list
  *
  * @module
  */
@@ -30,7 +30,7 @@ export async function wikiCommand(ctx: AgentContext, args: string[]): Promise<vo
     case 'list':
     case 'ls': return wikiList(ctx, rest);
     default:
-      console.error('Usage: dwn-git wiki <create|show|edit|list>');
+      console.error('Usage: gitd wiki <create|show|edit|list>');
       process.exit(1);
   }
 }
@@ -45,7 +45,7 @@ async function wikiCreate(ctx: AgentContext, args: string[]): Promise<void> {
   const body = flagValue(args, '--body') ?? '';
 
   if (!slug || !title) {
-    console.error('Usage: dwn-git wiki create <slug> <title> [--body <markdown>]');
+    console.error('Usage: gitd wiki create <slug> <title> [--body <markdown>]');
     process.exit(1);
   }
 
@@ -54,7 +54,7 @@ async function wikiCreate(ctx: AgentContext, args: string[]): Promise<void> {
   // Check for duplicate slug.
   const existing = await findPageBySlug(ctx, repoContextId, slug);
   if (existing) {
-    console.error(`Wiki page "${slug}" already exists. Use \`dwn-git wiki edit ${slug}\` to update it.`);
+    console.error(`Wiki page "${slug}" already exists. Use \`gitd wiki edit ${slug}\` to update it.`);
     process.exit(1);
   }
 
@@ -81,7 +81,7 @@ async function wikiCreate(ctx: AgentContext, args: string[]): Promise<void> {
 async function wikiShow(ctx: AgentContext, args: string[]): Promise<void> {
   const slug = args[0];
   if (!slug) {
-    console.error('Usage: dwn-git wiki show <slug>');
+    console.error('Usage: gitd wiki show <slug>');
     process.exit(1);
   }
 
@@ -121,14 +121,14 @@ async function wikiEdit(ctx: AgentContext, args: string[]): Promise<void> {
   const summary = flagValue(args, '--summary');
 
   if (!slug || !body) {
-    console.error('Usage: dwn-git wiki edit <slug> --body <markdown> [--summary <text>]');
+    console.error('Usage: gitd wiki edit <slug> --body <markdown> [--summary <text>]');
     process.exit(1);
   }
 
   const repoContextId = await getRepoContextId(ctx);
   const page = await findPageBySlug(ctx, repoContextId, slug);
   if (!page) {
-    console.error(`Wiki page "${slug}" not found. Use \`dwn-git wiki create\` first.`);
+    console.error(`Wiki page "${slug}" not found. Use \`gitd wiki create\` first.`);
     process.exit(1);
   }
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,67 +1,67 @@
 #!/usr/bin/env bun
 /**
- * dwn-git CLI — decentralized forge powered by DWN protocols.
+ * gitd CLI — decentralized forge powered by DWN protocols.
  *
  * Usage:
- *   dwn-git setup                              Configure git for DID transport
- *   dwn-git clone <did>/<repo>                 Clone a repo via DID
- *   dwn-git init <name> [--description <text>] Create a repo record + bare git repo
- *   dwn-git repo info                          Show repo metadata
- *   dwn-git repo add-collaborator <did> <role> Grant a role
- *   dwn-git repo remove-collaborator <did>     Revoke a collaborator role
- *   dwn-git issue create <title>               File an issue
- *   dwn-git issue show <number>                Show issue details + comments
- *   dwn-git issue comment <number> <body>      Add a comment to an issue
- *   dwn-git issue close <number>               Close an issue
- *   dwn-git issue list [--status <open|closed>]
- *   dwn-git patch create <title>               Open a patch (PR)
- *   dwn-git patch show <number>                Show patch details + reviews
- *   dwn-git patch comment <number> <body>      Add a comment/review
- *   dwn-git patch merge <number>               Merge a patch
- *   dwn-git patch list [--status <status>]
- *   dwn-git release create <tag>               Create a release
- *   dwn-git release show <tag>                 Show release details
- *   dwn-git release list                       List releases
- *   dwn-git ci status [<commit>]               Show latest CI status
- *   dwn-git ci create <commit>                 Create a check suite
- *   dwn-git ci run <suite-id> <name>           Add a check run
- *   dwn-git ci update <run-id> --status <s>    Update a check run status
- *   dwn-git registry publish <name> <ver> <tarball>  Publish a package version
- *   dwn-git registry info <name>               Show package details
- *   dwn-git registry versions <name>           List published versions
- *   dwn-git registry list                      List all packages
- *   dwn-git registry yank <name> <version>     Mark a version as deprecated
- *   dwn-git registry attest <name> <ver> --claim <c>  Create attestation
- *   dwn-git registry attestations <name> <ver> List attestations
- *   dwn-git registry verify <name> <ver>       Verify a package version
- *   dwn-git registry resolve <did>/<name>@<ver> Resolve a remote package
- *   dwn-git registry verify-deps <did>/<name>@<ver> Verify trust chain
- *   dwn-git wiki create <slug> <title>         Create a wiki page
- *   dwn-git wiki show <slug>                   Show a wiki page
- *   dwn-git org create <name>                  Create an organization
- *   dwn-git org info                           Show org details
- *   dwn-git social star <did>                  Star a repo
- *   dwn-git social follow <did>                Follow a user
- *   dwn-git notification list [--unread]       List notifications
- *   dwn-git migrate all <owner/repo>            Import everything from GitHub
- *   dwn-git migrate issues <owner/repo>         Import issues + comments
- *   dwn-git migrate pulls <owner/repo>          Import PRs as patches
- *   dwn-git migrate releases <owner/repo>       Import releases
- *   dwn-git web [--port <port>]                Start the read-only web UI
- *   dwn-git indexer [--port] [--interval] [--seed]  Start the indexer service
- *   dwn-git daemon [--config <path>] [--only ...] Start unified shim daemon
- *   dwn-git github-api [--port <port>]         Start GitHub API compatibility shim
- *   dwn-git shim npm [--port 4873]             Start npm registry proxy
- *   dwn-git shim go  [--port 4874]             Start Go module proxy (GOPROXY)
- *   dwn-git shim oci [--port 5555]             Start OCI/Docker registry proxy
- *   dwn-git log                                Show recent activity
- *   dwn-git serve [--port <port>]              Start the git transport server
- *   dwn-git whoami                             Show connected DID
+ *   gitd setup                              Configure git for DID transport
+ *   gitd clone <did>/<repo>                 Clone a repo via DID
+ *   gitd init <name> [--description <text>] Create a repo record + bare git repo
+ *   gitd repo info                          Show repo metadata
+ *   gitd repo add-collaborator <did> <role> Grant a role
+ *   gitd repo remove-collaborator <did>     Revoke a collaborator role
+ *   gitd issue create <title>               File an issue
+ *   gitd issue show <number>                Show issue details + comments
+ *   gitd issue comment <number> <body>      Add a comment to an issue
+ *   gitd issue close <number>               Close an issue
+ *   gitd issue list [--status <open|closed>]
+ *   gitd patch create <title>               Open a patch (PR)
+ *   gitd patch show <number>                Show patch details + reviews
+ *   gitd patch comment <number> <body>      Add a comment/review
+ *   gitd patch merge <number>               Merge a patch
+ *   gitd patch list [--status <status>]
+ *   gitd release create <tag>               Create a release
+ *   gitd release show <tag>                 Show release details
+ *   gitd release list                       List releases
+ *   gitd ci status [<commit>]               Show latest CI status
+ *   gitd ci create <commit>                 Create a check suite
+ *   gitd ci run <suite-id> <name>           Add a check run
+ *   gitd ci update <run-id> --status <s>    Update a check run status
+ *   gitd registry publish <name> <ver> <tarball>  Publish a package version
+ *   gitd registry info <name>               Show package details
+ *   gitd registry versions <name>           List published versions
+ *   gitd registry list                      List all packages
+ *   gitd registry yank <name> <version>     Mark a version as deprecated
+ *   gitd registry attest <name> <ver> --claim <c>  Create attestation
+ *   gitd registry attestations <name> <ver> List attestations
+ *   gitd registry verify <name> <ver>       Verify a package version
+ *   gitd registry resolve <did>/<name>@<ver> Resolve a remote package
+ *   gitd registry verify-deps <did>/<name>@<ver> Verify trust chain
+ *   gitd wiki create <slug> <title>         Create a wiki page
+ *   gitd wiki show <slug>                   Show a wiki page
+ *   gitd org create <name>                  Create an organization
+ *   gitd org info                           Show org details
+ *   gitd social star <did>                  Star a repo
+ *   gitd social follow <did>                Follow a user
+ *   gitd notification list [--unread]       List notifications
+ *   gitd migrate all <owner/repo>            Import everything from GitHub
+ *   gitd migrate issues <owner/repo>         Import issues + comments
+ *   gitd migrate pulls <owner/repo>          Import PRs as patches
+ *   gitd migrate releases <owner/repo>       Import releases
+ *   gitd web [--port <port>]                Start the read-only web UI
+ *   gitd indexer [--port] [--interval] [--seed]  Start the indexer service
+ *   gitd daemon [--config <path>] [--only ...] Start unified shim daemon
+ *   gitd github-api [--port <port>]         Start GitHub API compatibility shim
+ *   gitd shim npm [--port 4873]             Start npm registry proxy
+ *   gitd shim go  [--port 4874]             Start Go module proxy (GOPROXY)
+ *   gitd shim oci [--port 5555]             Start OCI/Docker registry proxy
+ *   gitd log                                Show recent activity
+ *   gitd serve [--port <port>]              Start the git transport server
+ *   gitd whoami                             Show connected DID
  *
  * Environment:
- *   DWN_GIT_PASSWORD  — vault password (prompted interactively if not set)
- *   DWN_GIT_PORT      — server port for `serve` (default: 9418)
- *   DWN_GIT_REPOS     — base path for bare repos (default: ./repos)
+ *   GITD_PASSWORD  — vault password (prompted interactively if not set)
+ *   GITD_PORT      — server port for `serve` (default: 9418)
+ *   GITD_REPOS     — base path for bare repos (default: ./repos)
  *
  * @module
  */
@@ -102,7 +102,7 @@ const rest = args.slice(1);
 // ---------------------------------------------------------------------------
 
 function printUsage(): void {
-  console.log('dwn-git — decentralized forge powered by DWN protocols\n');
+  console.log('gitd — decentralized forge powered by DWN protocols\n');
   console.log('Commands:');
   console.log('  setup                                       Configure git for DID-based remotes');
   console.log('  clone <did>/<repo>                          Clone a repository via DID');
@@ -194,16 +194,16 @@ function printUsage(): void {
   console.log('  whoami                                      Show connected DID');
   console.log('  help                                        Show this message\n');
   console.log('Environment:');
-  console.log('  DWN_GIT_PASSWORD  vault password (prompted if not set)');
-  console.log('  DWN_GIT_PORT      server port for `serve` (default: 9418)');
-  console.log('  DWN_GIT_WEB_PORT  web UI port for `web` (default: 8080)');
-  console.log('  DWN_GIT_REPOS     base path for bare repos (default: ./repos)');
-  console.log('  DWN_GIT_INDEXER_PORT      indexer API port (default: 8090)');
-  console.log('  DWN_GIT_INDEXER_INTERVAL  crawl interval in seconds (default: 60)');
-  console.log('  DWN_GIT_GITHUB_API_PORT   GitHub API shim port (default: 8181)');
-  console.log('  DWN_GIT_NPM_SHIM_PORT    npm shim port (default: 4873)');
-  console.log('  DWN_GIT_GO_SHIM_PORT     Go proxy shim port (default: 4874)');
-  console.log('  DWN_GIT_OCI_SHIM_PORT    OCI registry shim port (default: 5555)');
+  console.log('  GITD_PASSWORD  vault password (prompted if not set)');
+  console.log('  GITD_PORT      server port for `serve` (default: 9418)');
+  console.log('  GITD_WEB_PORT  web UI port for `web` (default: 8080)');
+  console.log('  GITD_REPOS     base path for bare repos (default: ./repos)');
+  console.log('  GITD_INDEXER_PORT      indexer API port (default: 8090)');
+  console.log('  GITD_INDEXER_INTERVAL  crawl interval in seconds (default: 60)');
+  console.log('  GITD_GITHUB_API_PORT   GitHub API shim port (default: 8181)');
+  console.log('  GITD_NPM_SHIM_PORT    npm shim port (default: 4873)');
+  console.log('  GITD_GO_SHIM_PORT     Go proxy shim port (default: 4874)');
+  console.log('  GITD_OCI_SHIM_PORT    OCI registry shim port (default: 5555)');
   console.log('  GITHUB_TOKEN      GitHub API token for migration (optional, higher rate limits)');
 }
 
@@ -213,7 +213,7 @@ function printUsage(): void {
 
 async function getPassword(): Promise<string> {
   // Prefer env var for non-interactive use / testing.
-  const env = process.env.DWN_GIT_PASSWORD;
+  const env = process.env.GITD_PASSWORD;
   if (env) { return env; }
 
   // Interactive prompt via stdin.

--- a/src/cli/repo-context.ts
+++ b/src/cli/repo-context.ts
@@ -26,7 +26,7 @@ export async function getRepoContext(ctx: AgentContext): Promise<RepoContext> {
   const { records } = await ctx.repo.records.query('repo');
 
   if (records.length === 0) {
-    console.error('No repository found. Run `dwn-git init <name>` first.');
+    console.error('No repository found. Run `gitd init <name>` first.');
     process.exit(1);
   }
 

--- a/src/daemon/adapter.ts
+++ b/src/daemon/adapter.ts
@@ -34,7 +34,7 @@ export interface ShimAdapter {
   /** Default port when none is configured. */
   readonly defaultPort: number;
 
-  /** Environment variable that overrides the default port (e.g. `'DWN_GIT_GITHUB_API_PORT'`). */
+  /** Environment variable that overrides the default port (e.g. `'GITD_GITHUB_API_PORT'`). */
   readonly portEnvVar: string;
 
   /**

--- a/src/daemon/adapters/github.ts
+++ b/src/daemon/adapters/github.ts
@@ -25,7 +25,7 @@ export const githubAdapter: ShimAdapter = {
   id          : 'github',
   name        : 'GitHub API',
   defaultPort : 8181,
-  portEnvVar  : 'DWN_GIT_GITHUB_API_PORT',
+  portEnvVar  : 'GITD_GITHUB_API_PORT',
   corsMethods : 'GET, POST, PATCH, PUT, DELETE, OPTIONS',
   corsHeaders : 'Authorization, Accept, Content-Type',
   usageHint   : 'GitHub REST API v3 compatible — point tools at http://localhost:{port}',

--- a/src/daemon/adapters/go.ts
+++ b/src/daemon/adapters/go.ts
@@ -21,7 +21,7 @@ export const goAdapter: ShimAdapter = {
   id          : 'go',
   name        : 'Go module proxy',
   defaultPort : 4874,
-  portEnvVar  : 'DWN_GIT_GO_SHIM_PORT',
+  portEnvVar  : 'GITD_GO_SHIM_PORT',
   corsMethods : 'GET, OPTIONS',
   corsHeaders : 'Authorization, Accept',
   usageHint   : 'GOPROXY=http://localhost:{port} go get did.enbox.org/did:dht:<id>/<module>@v1.0.0',

--- a/src/daemon/adapters/npm.ts
+++ b/src/daemon/adapters/npm.ts
@@ -21,7 +21,7 @@ export const npmAdapter: ShimAdapter = {
   id          : 'npm',
   name        : 'npm registry',
   defaultPort : 4873,
-  portEnvVar  : 'DWN_GIT_NPM_SHIM_PORT',
+  portEnvVar  : 'GITD_NPM_SHIM_PORT',
   corsMethods : 'GET, OPTIONS',
   corsHeaders : 'Authorization, Accept',
   usageHint   : 'npm install --registry=http://localhost:{port} @did:dht:<id>/<package>',

--- a/src/daemon/adapters/oci.ts
+++ b/src/daemon/adapters/oci.ts
@@ -21,7 +21,7 @@ export const ociAdapter: ShimAdapter = {
   id          : 'oci',
   name        : 'OCI/Docker registry',
   defaultPort : 5555,
-  portEnvVar  : 'DWN_GIT_OCI_SHIM_PORT',
+  portEnvVar  : 'GITD_OCI_SHIM_PORT',
   corsMethods : 'GET, HEAD, OPTIONS',
   corsHeaders : 'Authorization, Accept, Docker-Distribution-Api-Version',
   usageHint   : 'docker pull localhost:{port}/did:dht:<id>/<image>:<tag>',

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -170,7 +170,7 @@ export async function startDaemon(options: DaemonOptions): Promise<DaemonInstanc
   await Promise.all(startPromises);
 
   // Print status summary.
-  console.log('[daemon] dwn-git daemon started');
+  console.log('[daemon] gitd daemon started');
   console.log('');
   for (const r of enabledAdapters) {
     const running = servers.has(r.adapter.id);

--- a/src/git-remote/credential-helper.ts
+++ b/src/git-remote/credential-helper.ts
@@ -13,10 +13,10 @@
  *
  * Usage in .gitconfig:
  *   [credential "https://git.example.com"]
- *     helper = /path/to/dwn-git-credential-helper
+ *     helper = /path/to/gitd-credential-helper
  *
  * Environment:
- *   DWN_GIT_PASSWORD — vault password for the local agent
+ *   GITD_PASSWORD — vault password for the local agent
  *
  * @module
  */

--- a/src/git-remote/credential-main.ts
+++ b/src/git-remote/credential-main.ts
@@ -16,7 +16,7 @@
  *     helper = /path/to/git-remote-did-credential
  *
  * Environment:
- *   DWN_GIT_PASSWORD — vault password for the local agent
+ *   GITD_PASSWORD — vault password for the local agent
  *
  * @module
  */
@@ -56,7 +56,7 @@ async function main(): Promise<void> {
   }
 
   // Connect to the local agent to get the DID and signing key.
-  const password = process.env.DWN_GIT_PASSWORD;
+  const password = process.env.GITD_PASSWORD;
   if (!password) {
     // Credential helpers must be non-interactive. If no password is set,
     // silently exit and let git fall back to another credential helper.

--- a/src/git-remote/service.ts
+++ b/src/git-remote/service.ts
@@ -11,7 +11,7 @@
  *
  * @example
  * ```ts
- * import { createGitTransportService } from '@enbox/dwn-git/git-remote/service';
+ * import { createGitTransportService } from '@enbox/gitd/git-remote/service';
  *
  * const service = createGitTransportService({
  *   id              : '#git',

--- a/src/git-server/bundle-restore.ts
+++ b/src/git-server/bundle-restore.ts
@@ -146,7 +146,7 @@ export async function restoreFromBundles(
 
 /** Generate a unique temp file path for a bundle. */
 function tempBundlePath(): string {
-  return join(tmpdir(), `dwn-git-restore-${Date.now()}-${Math.random().toString(36).slice(2)}.bundle`);
+  return join(tmpdir(), `gitd-restore-${Date.now()}-${Math.random().toString(36).slice(2)}.bundle`);
 }
 
 /** Ensure the parent directory of a path exists. */

--- a/src/git-server/bundle-sync.ts
+++ b/src/git-server/bundle-sync.ts
@@ -177,7 +177,7 @@ export function createBundleSyncer(options: BundleSyncOptions): OnPushComplete {
  * @returns Bundle metadata and file path
  */
 export async function createFullBundle(repoPath: string): Promise<BundleInfo> {
-  const bundlePath = join(tmpdir(), `dwn-git-bundle-${Date.now()}-${Math.random().toString(36).slice(2)}.bundle`);
+  const bundlePath = join(tmpdir(), `gitd-bundle-${Date.now()}-${Math.random().toString(36).slice(2)}.bundle`);
 
   await spawnChecked('git', ['bundle', 'create', bundlePath, '--all'], repoPath);
 
@@ -208,7 +208,7 @@ export async function createIncrementalBundle(
   repoPath: string,
   baseCommit: string,
 ): Promise<BundleInfo> {
-  const bundlePath = join(tmpdir(), `dwn-git-bundle-${Date.now()}-${Math.random().toString(36).slice(2)}.bundle`);
+  const bundlePath = join(tmpdir(), `gitd-bundle-${Date.now()}-${Math.random().toString(36).slice(2)}.bundle`);
 
   // `--all ^<base>` means: include all refs, exclude objects reachable from base.
   await spawnChecked('git', ['bundle', 'create', bundlePath, '--all', `^${baseCommit}`], repoPath);

--- a/src/git-server/http-handler.ts
+++ b/src/git-server/http-handler.ts
@@ -151,7 +151,7 @@ export function createGitHttpHandler(
         if (!authorized) {
           return new Response('Unauthorized', {
             status  : 401,
-            headers : { 'WWW-Authenticate': 'Basic realm="dwn-git"' },
+            headers : { 'WWW-Authenticate': 'Basic realm="gitd"' },
           });
         }
       }
@@ -184,7 +184,7 @@ export function createGitHttpHandler(
         if (!authorized) {
           return new Response('Unauthorized', {
             status  : 401,
-            headers : { 'WWW-Authenticate': 'Basic realm="dwn-git"' },
+            headers : { 'WWW-Authenticate': 'Basic realm="gitd"' },
           });
         }
       }

--- a/src/git-server/server.ts
+++ b/src/git-server/server.ts
@@ -6,10 +6,10 @@
  *
  * Usage:
  * ```ts
- * import { createGitServer } from '@enbox/dwn-git/git-server/server';
+ * import { createGitServer } from '@enbox/gitd/git-server/server';
  *
  * const server = createGitServer({
- *   basePath : '/var/lib/dwn-git/repos',
+ *   basePath : '/var/lib/gitd/repos',
  *   port     : 9418,
  * });
  *

--- a/src/github-shim/helpers.ts
+++ b/src/github-shim/helpers.ts
@@ -293,11 +293,11 @@ export function jsonUnauthorized(message: string): JsonResponse {
 
 /**
  * Validate a Bearer token from the Authorization header.
- * Returns `true` if the token matches `DWN_GIT_API_TOKEN`, or if
+ * Returns `true` if the token matches `GITD_API_TOKEN`, or if
  * no token is configured (open access).
  */
 export function validateBearerToken(authHeader: string | null): boolean {
-  const expected = process.env.DWN_GIT_API_TOKEN;
+  const expected = process.env.GITD_API_TOKEN;
   if (!expected) { return true; } // No token configured — open access.
   if (!authHeader?.startsWith('Bearer ')) { return false; }
   const token = authHeader.slice(7);

--- a/src/github-shim/repos.ts
+++ b/src/github-shim/repos.ts
@@ -4,7 +4,7 @@
  * Maps the DWN singleton repo record to a GitHub REST API v3
  * repository response.  The `:repo` segment is validated against the
  * stored repo name but is otherwise informational — repos are singletons
- * per DID in dwn-git.
+ * per DID in gitd.
  *
  * @module
  */

--- a/src/github-shim/server.ts
+++ b/src/github-shim/server.ts
@@ -96,7 +96,7 @@ export async function handleShimRequest(
   reqBody: Record<string, unknown> = {},
   authHeader: string | null = null,
 ): Promise<JsonResponse> {
-  // Authenticate mutating requests when DWN_GIT_API_TOKEN is configured.
+  // Authenticate mutating requests when GITD_API_TOKEN is configured.
   if (method === 'POST' || method === 'PATCH' || method === 'PUT' || method === 'DELETE') {
     if (!validateBearerToken(authHeader)) {
       return jsonUnauthorized('Valid Bearer token required for write operations.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @enbox/dwn-git — Decentralized forge protocols for DWN.
+ * @enbox/gitd — Decentralized forge protocols for DWN.
  *
  * Protocol definitions for a decentralized GitHub alternative.
  * See PLAN.md for full architecture documentation.

--- a/src/indexer/main.ts
+++ b/src/indexer/main.ts
@@ -3,12 +3,12 @@
  * Indexer entry point — starts the crawler loop and REST API server.
  *
  * Usage:
- *   dwn-git indexer [--port <api-port>] [--interval <seconds>] [--seed <did>]
+ *   gitd indexer [--port <api-port>] [--interval <seconds>] [--seed <did>]
  *
  * Environment:
- *   DWN_GIT_PASSWORD       Vault password (prompted if not set)
- *   DWN_GIT_INDEXER_PORT   API port (default: 8090)
- *   DWN_GIT_INDEXER_INTERVAL  Crawl interval in seconds (default: 60)
+ *   GITD_PASSWORD       Vault password (prompted if not set)
+ *   GITD_INDEXER_PORT   API port (default: 8090)
+ *   GITD_INDEXER_INTERVAL  Crawl interval in seconds (default: 60)
  *
  * The indexer requires a local Web5 agent for signing DWN query
  * messages.  On first run it initializes the agent vault.  Subsequent
@@ -30,10 +30,10 @@ import { flagValue, parsePort } from '../cli/flags.js';
 
 export async function indexerCommand(ctx: AgentContext, args: string[]): Promise<void> {
   const port = parsePort(
-    flagValue(args, '--port') ?? process.env.DWN_GIT_INDEXER_PORT ?? '8090',
+    flagValue(args, '--port') ?? process.env.GITD_INDEXER_PORT ?? '8090',
   );
   const intervalRaw = parseInt(
-    flagValue(args, '--interval') ?? process.env.DWN_GIT_INDEXER_INTERVAL ?? '60', 10,
+    flagValue(args, '--interval') ?? process.env.GITD_INDEXER_INTERVAL ?? '60', 10,
   );
   const intervalSec = Number.isNaN(intervalRaw) || intervalRaw <= 0 ? 60 : intervalRaw;
   const seedDid = flagValue(args, '--seed');

--- a/src/shims/go/server.ts
+++ b/src/shims/go/server.ts
@@ -5,7 +5,7 @@
  * Go modules from DWN records.
  *
  * Usage:
- *   dwn-git shim go [--port 4874]
+ *   gitd shim go [--port 4874]
  *
  * Then:
  *   GOPROXY=http://localhost:4874 go get did.enbox.org/did:dht:abc123/my-mod@v1.0.0

--- a/src/shims/npm/server.ts
+++ b/src/shims/npm/server.ts
@@ -5,7 +5,7 @@
  * packages from DWN records.
  *
  * Usage:
- *   dwn-git shim npm [--port 4873]
+ *   gitd shim npm [--port 4873]
  *
  * Then:
  *   npm install --registry=http://localhost:4873 @did:dht:abc123/my-pkg

--- a/src/shims/oci/server.ts
+++ b/src/shims/oci/server.ts
@@ -5,7 +5,7 @@
  * container images from DWN records.
  *
  * Usage:
- *   dwn-git shim oci [--port 5555]
+ *   gitd shim oci [--port 5555]
  *
  * Then:
  *   docker pull localhost:5555/did:dht:abc123/my-image:v1.0.0

--- a/src/web/html.ts
+++ b/src/web/html.ts
@@ -23,7 +23,7 @@ export function layout(title: string, repoName: string, body: string, basePath: 
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>${esc(title)} — ${esc(repoName)} — dwn-git</title>
+  <title>${esc(title)} — ${esc(repoName)} — gitd</title>
   <style>
     *, *::before, *::after { box-sizing: border-box; }
     body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
@@ -62,7 +62,7 @@ export function layout(title: string, repoName: string, body: string, basePath: 
   <header>
     <div class="container">
       <a href="${base || '/'}" class="repo-name">${esc(repoName)}</a>
-      <span style="color:#8b949e;margin-left:8px">dwn-git</span>
+      <span style="color:#8b949e;margin-left:8px">gitd</span>
     </div>
   </header>
   <nav>

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -1,5 +1,5 @@
 /**
- * Web UI module — read-only web interface for dwn-git repositories.
+ * Web UI module — read-only web interface for gitd repositories.
  *
  * @module
  */

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -51,7 +51,7 @@ async function getRepoRecord(ctx: AgentContext, targetDid: string): Promise<Repo
 }
 
 function repoName(repo: { name: string } | null): string {
-  return repo?.name ?? 'dwn-git';
+  return repo?.name ?? 'gitd';
 }
 
 // ---------------------------------------------------------------------------
@@ -63,7 +63,7 @@ export async function overviewPage(ctx: AgentContext, targetDid: string, basePat
   const repo = await getRepoRecord(ctx, targetDid);
 
   if (!repo) {
-    return layout('Overview', 'dwn-git', '<div class="card"><p class="empty">No repository found for this DID.</p></div>', basePath);
+    return layout('Overview', 'gitd', '<div class="card"><p class="empty">No repository found for this DID.</p></div>', basePath);
   }
 
   // Count issues.
@@ -127,7 +127,7 @@ export async function overviewPage(ctx: AgentContext, targetDid: string, basePat
 export async function issuesListPage(ctx: AgentContext, targetDid: string, basePath: string): Promise<string> {
   const from = fromOpt(ctx, targetDid);
   const repo = await getRepoRecord(ctx, targetDid);
-  if (!repo) { return layout('Issues', 'dwn-git', '<p class="empty">No repository found.</p>', basePath); }
+  if (!repo) { return layout('Issues', 'gitd', '<p class="empty">No repository found.</p>', basePath); }
 
   const { records } = await ctx.issues.records.query('repo/issue', {
     from,
@@ -228,7 +228,7 @@ export async function issueDetailPage(
 export async function patchesListPage(ctx: AgentContext, targetDid: string, basePath: string): Promise<string> {
   const from = fromOpt(ctx, targetDid);
   const repo = await getRepoRecord(ctx, targetDid);
-  if (!repo) { return layout('Patches', 'dwn-git', '<p class="empty">No repository found.</p>', basePath); }
+  if (!repo) { return layout('Patches', 'gitd', '<p class="empty">No repository found.</p>', basePath); }
 
   const { records } = await ctx.patches.records.query('repo/patch', {
     from,
@@ -339,7 +339,7 @@ export async function patchDetailPage(
 export async function releasesListPage(ctx: AgentContext, targetDid: string, basePath: string): Promise<string> {
   const from = fromOpt(ctx, targetDid);
   const repo = await getRepoRecord(ctx, targetDid);
-  if (!repo) { return layout('Releases', 'dwn-git', '<p class="empty">No repository found.</p>', basePath); }
+  if (!repo) { return layout('Releases', 'gitd', '<p class="empty">No repository found.</p>', basePath); }
 
   const { records } = await ctx.releases.records.query('repo/release' as any, {
     from,

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -1,5 +1,5 @@
 /**
- * Read-only web UI server for dwn-git.
+ * Read-only web UI server for gitd.
  *
  * Serves HTML pages rendered from DWN records.  Supports viewing ANY
  * DWN-enabled git repo — the target DID is extracted from the URL path:
@@ -216,7 +216,7 @@ function landingPage(localDid: string): string {
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>dwn-git — Decentralized Code Forge</title>
+  <title>gitd — Decentralized Code Forge</title>
   <style>
     *, *::before, *::after { box-sizing: border-box; }
     body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
@@ -238,7 +238,7 @@ function landingPage(localDid: string): string {
 <body>
   <div class="container">
     <div class="card">
-      <h1>dwn-git</h1>
+      <h1>gitd</h1>
       <p>Browse any DWN-enabled git repository by entering a DID below.</p>
       <form onsubmit="location.href='/'+document.getElementById('did').value;return false">
         <input type="text" id="did" placeholder="did:dht:..." autocomplete="off">

--- a/tests/cli.spec.ts
+++ b/tests/cli.spec.ts
@@ -82,7 +82,7 @@ function captureError(fn: () => Promise<void>): Promise<{ errors: string[]; exit
 // Test suite
 // ---------------------------------------------------------------------------
 
-describe('dwn-git CLI commands', () => {
+describe('gitd CLI commands', () => {
   let web5: Web5;
   let did: string;
   let ctx: AgentContext;

--- a/tests/daemon.spec.ts
+++ b/tests/daemon.spec.ts
@@ -255,7 +255,7 @@ describe('Unified daemon', () => {
         id          : 'maven',
         name        : 'Maven Central',
         defaultPort : 8082,
-        portEnvVar  : 'DWN_GIT_MAVEN_PORT',
+        portEnvVar  : 'GITD_MAVEN_PORT',
         async handle(): Promise<void> { /* noop */ },
       };
       const resolved = resolveConfig({}, [custom]);

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -144,7 +144,7 @@ describe('E2E: init → serve → clone → push → verify', () => {
     await exec('git config user.email "e2e@test.com"', { cwd: CLONE_PATH });
     await exec('git config user.name "E2E Test"', { cwd: CLONE_PATH });
     await exec('git checkout -b main', { cwd: CLONE_PATH });
-    await exec('echo "hello from dwn-git" > README.md', { cwd: CLONE_PATH });
+    await exec('echo "hello from gitd" > README.md', { cwd: CLONE_PATH });
     await exec('git add README.md', { cwd: CLONE_PATH });
     await exec('git commit -m "initial commit"', { cwd: CLONE_PATH });
     await exec('git push -u origin main', { cwd: CLONE_PATH });
@@ -206,7 +206,7 @@ describe('E2E: init → serve → clone → push → verify', () => {
     await exec(`git clone --branch main "${cloneUrl}" "${secondClone}"`);
 
     const { stdout } = await exec('cat README.md', { cwd: secondClone });
-    expect(stdout).toContain('hello from dwn-git');
+    expect(stdout).toContain('hello from gitd');
     expect(stdout).toContain('update');
 
     rmSync(secondClone, { recursive: true, force: true });
@@ -608,7 +608,7 @@ describe('E2E: authenticated push with DID-signed tokens', () => {
   });
 
   it('should verify repo state via repo record query (repo info)', async () => {
-    // Verify the DWN repo record matches expectations (equivalent to `dwn-git repo info`).
+    // Verify the DWN repo record matches expectations (equivalent to `gitd repo info`).
     const { records } = await repoHandle.records.query('repo');
     expect(records.length).toBe(1);
 

--- a/tests/hardening.spec.ts
+++ b/tests/hardening.spec.ts
@@ -236,10 +236,10 @@ describe('GitHub shim — Bearer token auth', () => {
     expect(result.status).not.toBe(401);
   });
 
-  it('should reject write requests when DWN_GIT_API_TOKEN is set but no token provided', async () => {
-    const originalToken = process.env.DWN_GIT_API_TOKEN;
+  it('should reject write requests when GITD_API_TOKEN is set but no token provided', async () => {
+    const originalToken = process.env.GITD_API_TOKEN;
     try {
-      process.env.DWN_GIT_API_TOKEN = 'test-secret-token';
+      process.env.GITD_API_TOKEN = 'test-secret-token';
       const mockCtx = {} as any;
       const url = new URL('/repos/did:dht:abc/repo/issues', 'http://localhost:8181');
       const result = await handleShimRequest(mockCtx, url, 'POST', { title: 'test' }, null);
@@ -247,114 +247,114 @@ describe('GitHub shim — Bearer token auth', () => {
       expect(result.body).toContain('Bearer token required');
     } finally {
       if (originalToken !== undefined) {
-        process.env.DWN_GIT_API_TOKEN = originalToken;
+        process.env.GITD_API_TOKEN = originalToken;
       } else {
-        delete process.env.DWN_GIT_API_TOKEN;
+        delete process.env.GITD_API_TOKEN;
       }
     }
   });
 
   it('should reject write requests with wrong Bearer token', async () => {
-    const originalToken = process.env.DWN_GIT_API_TOKEN;
+    const originalToken = process.env.GITD_API_TOKEN;
     try {
-      process.env.DWN_GIT_API_TOKEN = 'test-secret-token';
+      process.env.GITD_API_TOKEN = 'test-secret-token';
       const mockCtx = {} as any;
       const url = new URL('/repos/did:dht:abc/repo/issues', 'http://localhost:8181');
       const result = await handleShimRequest(mockCtx, url, 'POST', { title: 'test' }, 'Bearer wrong-token');
       expect(result.status).toBe(401);
     } finally {
       if (originalToken !== undefined) {
-        process.env.DWN_GIT_API_TOKEN = originalToken;
+        process.env.GITD_API_TOKEN = originalToken;
       } else {
-        delete process.env.DWN_GIT_API_TOKEN;
+        delete process.env.GITD_API_TOKEN;
       }
     }
   });
 
-  it('should allow write requests when no DWN_GIT_API_TOKEN is configured', async () => {
-    const originalToken = process.env.DWN_GIT_API_TOKEN;
+  it('should allow write requests when no GITD_API_TOKEN is configured', async () => {
+    const originalToken = process.env.GITD_API_TOKEN;
     try {
-      delete process.env.DWN_GIT_API_TOKEN;
+      delete process.env.GITD_API_TOKEN;
       const mockCtx = {} as any;
       const url = new URL('/repos/did:dht:abc/repo/issues', 'http://localhost:8181');
-      // Without DWN_GIT_API_TOKEN, auth passes — but the handler will fail later
+      // Without GITD_API_TOKEN, auth passes — but the handler will fail later
       // (no real agent). We just verify it's NOT 401.
       const result = await handleShimRequest(mockCtx, url, 'POST', { title: 'test' }, null);
       expect(result.status).not.toBe(401);
     } finally {
       if (originalToken !== undefined) {
-        process.env.DWN_GIT_API_TOKEN = originalToken;
+        process.env.GITD_API_TOKEN = originalToken;
       } else {
-        delete process.env.DWN_GIT_API_TOKEN;
+        delete process.env.GITD_API_TOKEN;
       }
     }
   });
 });
 
 describe('validateBearerToken', () => {
-  it('should return true when no DWN_GIT_API_TOKEN is set', () => {
-    const original = process.env.DWN_GIT_API_TOKEN;
+  it('should return true when no GITD_API_TOKEN is set', () => {
+    const original = process.env.GITD_API_TOKEN;
     try {
-      delete process.env.DWN_GIT_API_TOKEN;
+      delete process.env.GITD_API_TOKEN;
       expect(validateBearerToken(null)).toBe(true);
       expect(validateBearerToken('Bearer anything')).toBe(true);
     } finally {
-      if (original !== undefined) { process.env.DWN_GIT_API_TOKEN = original; }
+      if (original !== undefined) { process.env.GITD_API_TOKEN = original; }
     }
   });
 
   it('should reject null header when token is required', () => {
-    const original = process.env.DWN_GIT_API_TOKEN;
+    const original = process.env.GITD_API_TOKEN;
     try {
-      process.env.DWN_GIT_API_TOKEN = 'secret';
+      process.env.GITD_API_TOKEN = 'secret';
       expect(validateBearerToken(null)).toBe(false);
     } finally {
-      if (original !== undefined) { process.env.DWN_GIT_API_TOKEN = original; }
-      else { delete process.env.DWN_GIT_API_TOKEN; }
+      if (original !== undefined) { process.env.GITD_API_TOKEN = original; }
+      else { delete process.env.GITD_API_TOKEN; }
     }
   });
 
   it('should reject non-Bearer auth', () => {
-    const original = process.env.DWN_GIT_API_TOKEN;
+    const original = process.env.GITD_API_TOKEN;
     try {
-      process.env.DWN_GIT_API_TOKEN = 'secret';
+      process.env.GITD_API_TOKEN = 'secret';
       expect(validateBearerToken('Basic base64stuff')).toBe(false);
     } finally {
-      if (original !== undefined) { process.env.DWN_GIT_API_TOKEN = original; }
-      else { delete process.env.DWN_GIT_API_TOKEN; }
+      if (original !== undefined) { process.env.GITD_API_TOKEN = original; }
+      else { delete process.env.GITD_API_TOKEN; }
     }
   });
 
   it('should accept correct Bearer token', () => {
-    const original = process.env.DWN_GIT_API_TOKEN;
+    const original = process.env.GITD_API_TOKEN;
     try {
-      process.env.DWN_GIT_API_TOKEN = 'my-secret';
+      process.env.GITD_API_TOKEN = 'my-secret';
       expect(validateBearerToken('Bearer my-secret')).toBe(true);
     } finally {
-      if (original !== undefined) { process.env.DWN_GIT_API_TOKEN = original; }
-      else { delete process.env.DWN_GIT_API_TOKEN; }
+      if (original !== undefined) { process.env.GITD_API_TOKEN = original; }
+      else { delete process.env.GITD_API_TOKEN; }
     }
   });
 
   it('should reject wrong Bearer token', () => {
-    const original = process.env.DWN_GIT_API_TOKEN;
+    const original = process.env.GITD_API_TOKEN;
     try {
-      process.env.DWN_GIT_API_TOKEN = 'my-secret';
+      process.env.GITD_API_TOKEN = 'my-secret';
       expect(validateBearerToken('Bearer wrong')).toBe(false);
     } finally {
-      if (original !== undefined) { process.env.DWN_GIT_API_TOKEN = original; }
-      else { delete process.env.DWN_GIT_API_TOKEN; }
+      if (original !== undefined) { process.env.GITD_API_TOKEN = original; }
+      else { delete process.env.GITD_API_TOKEN; }
     }
   });
 
   it('should reject tokens of different length (timing attack protection)', () => {
-    const original = process.env.DWN_GIT_API_TOKEN;
+    const original = process.env.GITD_API_TOKEN;
     try {
-      process.env.DWN_GIT_API_TOKEN = 'short';
+      process.env.GITD_API_TOKEN = 'short';
       expect(validateBearerToken('Bearer a-much-longer-token-string')).toBe(false);
     } finally {
-      if (original !== undefined) { process.env.DWN_GIT_API_TOKEN = original; }
-      else { delete process.env.DWN_GIT_API_TOKEN; }
+      if (original !== undefined) { process.env.GITD_API_TOKEN = original; }
+      else { delete process.env.GITD_API_TOKEN; }
     }
   });
 });

--- a/tests/indexer.spec.ts
+++ b/tests/indexer.spec.ts
@@ -51,7 +51,7 @@ function parseJson(body: string): any {
 // Test suite
 // ---------------------------------------------------------------------------
 
-describe('dwn-git indexer', () => {
+describe('gitd indexer', () => {
   let ctx: AgentContext;
   let store: IndexerStore;
   let crawler: IndexerCrawler;

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Integration tests for dwn-git forge protocols against a real in-memory DWN.
+ * Integration tests for gitd forge protocols against a real in-memory DWN.
  *
  * These tests validate that protocol definitions can be installed, records can
  * be written/queried/read/deleted, roles work correctly, and cross-protocol
@@ -111,7 +111,7 @@ async function queryRecords(
 // Test suite
 // ---------------------------------------------------------------------------
 
-describe('dwn-git integration', () => {
+describe('gitd integration', () => {
   let dwn: Dwn;
   let messageStore: MessageStoreLevel;
   let dataStore: DataStoreLevel;

--- a/tests/protocols.spec.ts
+++ b/tests/protocols.spec.ts
@@ -25,7 +25,7 @@ import {
   ForgeWikiProtocol,
 } from '../src/index.js';
 
-describe('@enbox/dwn-git', () => {
+describe('@enbox/gitd', () => {
 
   // =========================================================================
   // ForgeRepoProtocol

--- a/tests/web.spec.ts
+++ b/tests/web.spec.ts
@@ -56,7 +56,7 @@ function didUrl(subPath: string): URL {
 // Test suite
 // ---------------------------------------------------------------------------
 
-describe('dwn-git web UI', () => {
+describe('gitd web UI', () => {
   let ctx: AgentContext;
 
   beforeAll(async () => {
@@ -185,7 +185,7 @@ describe('dwn-git web UI', () => {
     it('should return 200 with landing page', async () => {
       const res = await handleRequest(ctx, url('/'));
       expect(res.status).toBe(200);
-      expect(res.body).toContain('dwn-git');
+      expect(res.body).toContain('gitd');
       expect(res.body).toContain('Browse');
     });
 
@@ -467,7 +467,7 @@ describe('dwn-git web UI', () => {
       const res = await handleRequest(ctx, didUrl('/'));
       expect(res.body).toContain('<title>Overview');
       expect(res.body).toContain('test-repo');
-      expect(res.body).toContain('dwn-git</title>');
+      expect(res.body).toContain('gitd</title>');
     });
   });
 });


### PR DESCRIPTION
## Summary

Complete rebrand from `dwn-git` to `gitd` across the entire codebase (62 files, 497 lines changed):

- **Package**: `@enbox/dwn-git` -> `@enbox/gitd`
- **CLI binary**: `dwn-git` -> `gitd`
- **Env var prefix**: `DWN_GIT_*` -> `GITD_*`
- **Config paths**: `~/.dwn-git/` -> `~/.gitd/`
- **Config files**: `dwn-git.daemon.json` -> `gitd.daemon.json`
- **Release artifacts**: `dwn-git-<os>-<arch>` -> `gitd-<os>-<arch>`
- **Install script**: updated repo ref, binary names, archive names
- **Docs**: README.md, CLAUDE.md, PLAN.md all updated
- **Tests**: all test references updated

## Not changed

- `git-remote-did` and `git-remote-did-credential` binaries (no `dwn-git` in their names)
- Protocol URIs (`https://enbox.org/protocols/forge/...`)
- No source filenames contain `dwn-git`

## Validation

- `bun run build` -- pass
- `bun test .spec.ts` -- 882 pass, 9 skip, 0 fail
- `bun run lint` -- pass (zero warnings)

## Follow-up (after merge)

- Rename GitHub repo `enboxorg/dwn-git` -> `enboxorg/gitd`
- Update inline install script in `enboxorg/gitd-site` Pages Function