### PR TITLE
docs: clean up README and add ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,144 @@
+# Architecture
+
+This document provides a high-level overview of how `gitd` works. For detailed protocol definitions, schema layouts, and the implementation roadmap, see [PLAN.md](./PLAN.md).
+
+## Design Principles
+
+1. **Everyone owns their namespace** — you write to your own DWN, not someone else's. Contributions are scoped by the contributor's DID. No global write access means no spam by design.
+
+2. **Git stays git** — git objects use git's native transport protocol (smart HTTP). DWN handles the social layer. The two are connected by the DID document, which advertises both DWN endpoints and git transport endpoints.
+
+3. **Composable protocols** — rather than one monolithic protocol, `gitd` uses independent protocol definitions (repo, issues, patches, CI, releases, registry, social, etc.). Each handles one domain and references others via `uses` for cross-protocol role authorization.
+
+4. **Immutability where it matters** — status changes, reviews, release assets, and package versions use `$immutable` records that cannot be silently edited, providing the same auditability guarantees as git's content-addressed storage.
+
+5. **Indexers bridge the gaps** — features that require global aggregation (star counts, cross-DWN search, trending repos) are handled by indexer services. Multiple competing indexers can exist — no single indexer is authoritative.
+
+## System Overview
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        User's Machine                       │
+│                                                             │
+│  ┌──────┐  ┌──────────────┐  ┌──────────────────────────┐  │
+│  │ gitd │  │ git-remote-  │  │ git-remote-did-          │  │
+│  │ CLI  │  │ did          │  │ credential               │  │
+│  └──┬───┘  └──────┬───────┘  └────────────┬─────────────┘  │
+│     │             │                        │                │
+│     │    ┌────────┴────────────────────────┘                │
+│     │    │  Git invokes these automatically                 │
+│     │    │  for did:: remotes                               │
+└─────┼────┼──────────────────────────────────────────────────┘
+      │    │
+      │    │  DID resolution
+      │    ▼
+┌─────┴────────────────────┐     ┌──────────────────────────┐
+│     DWN Service          │     │   Git Transport Server   │
+│                          │     │   (gitd serve)           │
+│  - Forge protocols       │     │                          │
+│  - Identity & roles      │◄───►│  - Smart HTTP            │
+│  - Issues, patches, etc. │     │  - DID-signed push auth  │
+│  - Bundles & refs        │     │  - Ref mirroring to DWN  │
+│  - Registry packages     │     │  - Bundle sync to DWN    │
+└──────────────────────────┘     └──────────────────────────┘
+```
+
+## Protocols
+
+`gitd` defines a set of DWN protocols under the `https://enbox.org/protocols/forge/` namespace. Each protocol is self-contained with its own types, schemas, and authorization rules.
+
+| Protocol | Purpose |
+|---|---|
+| **forge-repo** | Repository metadata, collaborator roles, bundles, settings |
+| **forge-refs** | Git ref records (branches, tags) for DWN subscriptions |
+| **forge-issues** | Issues, comments, labels, status changes |
+| **forge-patches** | Pull requests, revisions, reviews, merge results |
+| **forge-ci** | Check suites, check runs, artifacts |
+| **forge-releases** | Release management, immutable assets |
+| **forge-registry** | Package publishing, versions, tarballs, attestations |
+| **forge-social** | Stars, follows, activity feeds |
+| **forge-notifications** | Personal notification inbox |
+| **forge-wiki** | Collaborative documentation pages |
+| **forge-org** | Organizations, teams, membership |
+
+### Role-Based Authorization
+
+The repo protocol defines three roles: **maintainer**, **triager**, and **contributor**. Other protocols reference these roles via `uses` to control who can do what. For example, only maintainers can merge patches, but triagers can close issues.
+
+Roles are DWN records with `$role: true`, which means the DWN enforces authorization natively — no application-level permission checks needed.
+
+### Cross-Protocol References
+
+Protocols that relate to a specific repository (issues, patches, CI, releases, wiki) compose with `forge-repo` using DWN's `$ref` mechanism. This links records to a repository via `parentContextId` without duplicating data.
+
+## Git Transport
+
+### DID-Addressed Remotes
+
+```
+git clone did::did:dht:abc123/my-repo
+```
+
+When git encounters a `did::` remote URL:
+
+1. `git-remote-did` is invoked (git discovers it by the `did` scheme name)
+2. The DID document is resolved to find the `GitTransport` service endpoint
+3. `git-remote-https` is exec'd with the resolved HTTPS URL
+
+### Push Authentication
+
+When pushing to a DID-addressed remote:
+
+1. `git-remote-did-credential` is invoked as a git credential helper
+2. It creates a signed push token using the local Web5 agent's identity
+3. The git transport server verifies the signature and checks the pusher's DWN role
+
+### Bundle Sync
+
+After each push, the git transport server:
+
+1. Mirrors branch/tag refs to DWN records (enables subscriptions and offline discovery)
+2. Creates git bundles and stores them as DWN records (full, incremental, and squash bundles)
+3. On cold start, if no local repo exists, it restores from the latest DWN bundles automatically
+
+## Compatibility Layer
+
+`gitd` includes proxy servers ("shims") that speak native tool protocols and translate them into DWN operations:
+
+| Shim | Protocol | Use Case |
+|---|---|---|
+| GitHub API | REST API v3 | `gh` CLI, VS Code extensions, CI systems |
+| npm | npm registry HTTP API | `npm install`, `bun add`, `yarn add` |
+| Go | GOPROXY protocol | `go get`, `go mod download` |
+| OCI | OCI Distribution Spec v2 | `docker pull`, `podman pull` |
+
+All shims can run as standalone servers or together via `gitd daemon`.
+
+## Indexer
+
+The indexer crawls DWN records across the network and builds materialized views for discovery:
+
+- **DID discovery** — follows the social graph (stars + follows) to find users and repos
+- **Search** — full-text search by name, description, topic, or language
+- **Aggregation** — star counts, trending repos, user profiles
+- **REST API** — query endpoints for search, trending, user profiles, and stats
+
+Indexers are read-only consumers of published DWN data. Anyone can run one. Multiple indexers can coexist and compete on quality.
+
+## Directory Structure
+
+```
+src/
+├── cli/              # CLI entry point and subcommands
+│   ├── main.ts       # gitd binary entry point
+│   └── commands/     # One file per subcommand
+├── git-remote/       # git-remote-did and credential helper
+├── git-server/       # Smart HTTP server, bundle sync, auth
+├── web/              # Read-only web UI (server-rendered HTML)
+├── daemon/           # Unified shim daemon with adapter interface
+├── github-shim/      # GitHub REST API v3 compatibility
+├── shims/            # Package manager shims (npm, go, oci)
+├── indexer/          # Indexer service (crawler + REST API)
+├── resolver/         # Package resolution and trust chain
+└── protocols/        # DWN protocol definitions and schemas
+```

--- a/README.md
+++ b/README.md
@@ -1,330 +1,124 @@
 # gitd
 
+> **Research preview** — this project is under active development and not yet ready for production use. APIs, protocols, and CLI commands may change without notice.
+
 A decentralized forge (GitHub alternative) built on [DWN](https://github.com/enboxorg/enbox) protocols. Git is already decentralized — `gitd` decentralizes the rest: issues, pull requests, code review, CI status, releases, package registry, and social features.
 
-## Thesis
+## Why
 
 GitHub centralizes the social layer around git: identity, access control, issue tracking, code review, package hosting, and discovery all depend on a single provider. `gitd` replaces that layer with DWN protocols, where:
 
 - **Identity is self-sovereign** — DIDs replace GitHub usernames. Portable across providers.
-- **Every user owns their namespace** — your issues, stars, and contributions live on your DWN, not a central server.
+- **Every user owns their data** — your issues, stars, and contributions live on your DWN, not a central server.
 - **Access control is protocol-level** — roles (maintainer, triager, contributor) are DWN records with cryptographic authorization.
 - **Git transport is DID-addressed** — `git clone did::did:dht:abc123/my-repo` resolves via the DID document.
 - **Packages are DID-scoped** — no global namespace squatting, cryptographic provenance by default.
 - **Repos are self-healing** — git bundles stored as DWN records enable any host to restore a repo on demand.
 
-## What Works Today
+## Install
 
-`gitd` has a working MVP covering the full lifecycle:
+```bash
+curl -fsSL https://gitd.sh/install | bash
+```
 
-### CLI (`gitd`)
+Installs prebuilt binaries for Linux, macOS, and Windows (Git Bash/WSL). Three binaries are installed:
+
+| Binary | Purpose |
+|---|---|
+| `gitd` | Main CLI — forge commands, servers, shims |
+| `git-remote-did` | Git remote helper — resolves `did::` URLs to git endpoints |
+| `git-remote-did-credential` | Git credential helper — generates DID-signed push tokens |
+
+```bash
+# Or install via bun/npm
+bun add -g @enbox/gitd
+```
+
+## CLI
 
 ```bash
 # Setup & transport
 gitd setup                     # Configure git for DID-based remotes
-gitd clone did:dht:abc/repo   # Clone via DID resolution
+gitd clone did:dht:abc/repo    # Clone via DID resolution
 gitd init my-repo              # Create a repo record + bare git repo
-gitd serve                     # Start git transport server with ref sync + bundle sync
+gitd serve                     # Start git transport server
 
-# Repository management
-gitd repo info                 # Show repo metadata + collaborators
-gitd repo add-collaborator <did> maintainer
-gitd repo remove-collaborator <did>
-
-# Issues (sequential numbering)
-gitd issue create "Bug report" # Create issue #1
-gitd issue show 1              # Show issue details + comments
-gitd issue comment 1 "On it"  # Add a comment
-gitd issue close 1             # Close an issue
-gitd issue reopen 1            # Reopen a closed issue
-gitd issue list                # List all issues
+# Issues
+gitd issue create "Bug report"
+gitd issue show 1
+gitd issue comment 1 "On it"
+gitd issue close 1
+gitd issue list
 
 # Patches (pull requests)
-gitd patch create "Add X"     # Create patch #1
-gitd patch show 1              # Show patch details + reviews
-gitd patch comment 1 "LGTM"  # Add a review comment
-gitd patch merge 1             # Merge a patch
-gitd patch close 2             # Close without merging
-gitd patch reopen 2            # Reopen a closed patch
-gitd patch list                # List all patches
+gitd patch create "Add feature"
+gitd patch show 1
+gitd patch comment 1 "LGTM"
+gitd patch merge 1
+gitd patch list
 
 # Releases
-gitd release create v1.0.0    # Create a release
-gitd release show v1.0.0      # Show release details + assets
-gitd release list              # List releases
+gitd release create v1.0.0
+gitd release show v1.0.0
+gitd release list
 
 # CI / Check suites
-gitd ci create <commit>       # Create a check suite
-gitd ci run <suite-id> lint   # Add a check run to a suite
+gitd ci create <commit>
+gitd ci run <suite-id> lint
 gitd ci update <run-id> --status completed --conclusion success
-gitd ci status                 # Show latest CI status
-gitd ci show <suite-id>       # Show suite details + runs
-gitd ci list                   # List recent check suites
+gitd ci status
 
 # Package registry
 gitd registry publish my-pkg 1.0.0 ./pkg.tgz
-gitd registry info my-pkg     # Show package details
-gitd registry versions my-pkg # List published versions
-gitd registry list             # List all packages
-gitd registry yank my-pkg 1.0.0
-
-# Attestations & verification
-gitd registry attest my-pkg 1.0.0 --claim reproducible-build
-gitd registry attestations my-pkg 1.0.0
+gitd registry info my-pkg
 gitd registry verify my-pkg 1.0.0 --trusted did:jwk:build-svc
 
-# Package resolution & trust chain
-gitd registry resolve did:dht:abc/my-pkg@1.0.0
-gitd registry verify-deps did:dht:abc/my-pkg@1.0.0 --trusted did:jwk:ci
-
-# Wiki
-gitd wiki create getting-started "Getting Started" --body "# Welcome"
-gitd wiki show getting-started
-gitd wiki edit getting-started --body "# Updated"
-gitd wiki list
-
-# Organizations & teams
-gitd org create my-org        # Create an organization
-gitd org info                  # Show org details + members + teams
-gitd org add-member <did>     # Add a member
-gitd org add-owner <did>      # Add an owner
-gitd org team create backend  # Create a team
-
-# Social
-gitd social star <did>        # Star a repo
-gitd social stars              # List starred repos
-gitd social follow <did>      # Follow a user
-gitd social following          # List followed users
-
-# Notifications
-gitd notification list         # List notifications
-gitd notification list --unread
-gitd notification read <id>   # Mark as read
-gitd notification clear        # Clear read notifications
+# Wiki, orgs, social, notifications
+gitd wiki create getting-started "Getting Started"
+gitd org create my-org
+gitd social star <did>
+gitd notification list
 
 # GitHub migration
-gitd migrate all owner/repo   # Import repo, issues, PRs, releases from GitHub
-gitd migrate issues owner/repo
-gitd migrate pulls owner/repo
-gitd migrate releases owner/repo
+gitd migrate all owner/repo    # Import repo, issues, PRs, releases
 
-# Web UI
-gitd web                       # Start read-only web UI on port 8080
-gitd web --port 3000           # Custom port
-
-# Indexer (repo discovery + aggregation)
-gitd indexer                   # Start indexer on port 8090
-gitd indexer --seed <did>      # Discover DIDs from a seed user
-gitd indexer --interval 30     # Crawl every 30 seconds
-
-# Unified daemon — all shims in one process
-gitd daemon                    # Start all shims with default ports
-gitd daemon --only github,npm  # Only start specific shims
-gitd daemon --disable oci      # Disable specific shims
-gitd daemon --config cfg.json  # Use a config file
-gitd daemon --list             # List available shim adapters
-
-# Individual shims (standalone mode)
-gitd github-api                # GitHub API shim on port 8181
-gitd shim npm                  # npm registry shim on port 4873
-gitd shim go                   # Go module proxy on port 4874
-gitd shim oci                  # OCI/Docker registry on port 5555
-
-# Activity & identity
-gitd log                       # Activity feed (recent issues + patches)
+# Web UI & services
+gitd web                       # Read-only web UI
+gitd indexer                   # Repo discovery + search service
+gitd daemon                    # Unified shim daemon (GitHub API, npm, Go, OCI)
 gitd whoami                    # Show connected DID
 ```
 
-### Git Transport
+## Git Transport
 
-- **Smart HTTP server** — serves `git clone`, `git push` via native git protocol
+- **Smart HTTP server** — `git clone` and `git push` via native git protocol
 - **DID-signed push auth** — pushers prove DID ownership, server checks DWN role records
-- **Ref mirroring** — branch/tag refs sync to DWN records after each push (enables subscriptions)
-- **Bundle sync** — git bundles sync to DWN records after each push (full + incremental + squash)
+- **Ref mirroring** — branch/tag refs sync to DWN records after each push
+- **Bundle sync** — git bundles sync to DWN records after each push (full, incremental, and squash)
 - **Cold-start restore** — repos auto-restore from DWN bundles when a host has no local copy
 
-### Git Remote Helper
+## Web UI
 
-- `git-remote-did` — resolves `did::` URLs to git endpoints via DID document service discovery
-- `git-remote-did-credential` — generates DID-signed push tokens for authentication
+Server-rendered HTML interface for browsing any DWN-enabled git repo. Enter a DID to browse their repos, issues, patches, releases, and wiki pages. No client-side JavaScript.
 
-### Web UI
-
-- Read-only server-rendered HTML interface — no client-side JavaScript, no build step
-- **Browse ANY DWN-enabled git repo** by entering a DID — works as a universal viewer
-- Landing page at `/` with DID input form; all routes are DID-scoped: `/:did/`, `/:did/issues`, etc.
-- Routes: `/:did` (overview), `/:did/issues`, `/:did/issues/:n`, `/:did/patches`, `/:did/patches/:n`, `/:did/releases`, `/:did/wiki`, `/:did/wiki/:slug`
-- Remote DWN queries use the SDK's `from` parameter — resolved via the target DID's service endpoints
-- Start with `gitd web [--port <port>]` (default: 8080, configurable via `GITD_WEB_PORT`)
-
-### GitHub Migration
-
-- `gitd migrate all owner/repo` — import repo metadata, issues, pull requests, and releases
-- Supports pagination, error handling, and author attribution
-- GitHub author info embedded in body as `[migrated from GitHub — @username]` prefix
-
-### Indexer Service
-
-- Crawls distributed DWN records and builds materialized views for discovery and aggregation
-- **DID discovery** — follows the social graph (stars + follows) to find new users and repos
-- **Repo search** — full-text search by name, description, topic, or language
-- **Star aggregation** — counts stars across DWNs (stars live on each starrer's DWN)
-- **Trending repos** — ranked by recent star activity within a time window
-- **User profiles** — repo count, total stars received, follower/following counts
-- **REST API** — `/api/repos`, `/api/repos/search?q=`, `/api/repos/trending`, `/api/users/:did`, `/api/stats`
-- Start with `gitd indexer [--port <port>] [--interval <sec>] [--seed <did>]`
-
-### GitHub API Compatibility Shim
-
-- HTTP server that translates GitHub REST API v3 requests into DWN queries and writes
-- Allows existing GitHub-compatible tools (VS Code extensions, `gh` CLI, CI systems) to interact with DWN data
-- DID is used as the GitHub "owner" in URLs: `GET /repos/:did/:repo/issues`
-- 18 endpoints (10 read, 8 write):
-  - **Read (GET)**: repo info, issues (list/detail/comments), pulls (list/detail/reviews), releases (list/by-tag), user profile
-  - **Write**: create/update issues, create issue comments, create/update/merge pull requests, create pull reviews, create releases
-- GitHub-compatible response shapes: numeric IDs, pagination (`Link` header, `per_page`), rate limit headers
-- CORS enabled, `X-GitHub-Media-Type: github.v3` header
-- Start with `gitd github-api [--port <port>]` (default: 8181, configurable via `GITD_GITHUB_API_PORT`)
-
-### Attestation System
-
-- Third-party build verification via `$immutable` attestation records
-- Attestors (CI services, auditors) create signed claims about package versions
-- Claims include `reproducible-build`, `code-review`, `security-audit`, etc.
-- Optional `sourceCommit` and `sourceRepo` fields link attestations to specific builds
-- `gitd registry attest <name> <version> --claim <claim>` to create attestations
-- `gitd registry attestations <name> <version>` to list all attestations
-- `gitd registry verify <name> <version> [--trusted <did>,...]` to verify integrity
-
-### Package Resolver & Trust Chain
-
-- Resolves DID-scoped packages from remote DWNs: `did:dht:abc123/my-pkg@1.0.0`
-- Resolution flow: resolve DID -> query package -> query version -> fetch tarball
-- Verification checks: package exists, publisher match, version author, tarball integrity, attestations
-- Recursive dependency trust chain validation with cycle detection and depth limiting
-- `gitd registry resolve <did>/<name>@<version>` to resolve and inspect a remote package
-- `gitd registry verify-deps <did>/<name>@<version>` to build and verify the full dependency tree
-- No central authority — the entire chain is verifiable via DIDs and DWN record signatures
-
-### Package Manager Shims
-
-Local HTTP proxy servers that speak native package manager protocols, resolving DID-scoped packages from DWN records. Each shim acts as a translation layer between standard tooling and the decentralized registry.
-
-**npm registry shim** (`gitd shim npm`):
-- Serves the npm registry HTTP API on localhost (default port 4873)
-- Works with `npm install`, `bun install`, `yarn add`, `pnpm add`
-- DID-scoped packages via npm scopes: `npm install --registry=http://localhost:4873 @did:dht:abc123/my-pkg`
-- Endpoints: packument (all versions), version metadata, tarball download
-- Includes DWN provenance metadata in `_dwn` fields
-
-**Go module proxy shim** (`gitd shim go`):
-- Serves the GOPROXY protocol on localhost (default port 4874)
-- Module paths: `GOPROXY=http://localhost:4874 go get did.enbox.org/did:dht:abc123/my-mod@v1.0.0`
-- Endpoints: `/@v/list`, `/@v/{ver}.info`, `/@v/{ver}.mod`, `/@v/{ver}.zip`, `/@latest`
-- Generates `go.mod` files with DID-scoped dependency mappings
-
-**OCI/Docker registry shim** (`gitd shim oci`):
-- Serves the OCI Distribution Spec v2 on localhost (default port 5555)
-- Works with `docker pull`, `podman pull`, and any OCI-compatible tool
-- Image naming: `docker pull localhost:5555/did:dht:abc123/my-image:v1.0.0`
-- Endpoints: `/v2/` version check, manifests (by tag or digest), blobs, tags list
-- Content-addressable: manifests include SHA-256 digest headers
-
-### Unified Daemon
-
-Run all ecosystem shims in a single process with `gitd daemon`. Each shim runs on its own port and speaks the native protocol of its ecosystem — no custom plugins or wrappers needed.
-
-- **Plugin architecture**: `ShimAdapter` interface makes adding new ecosystems trivial (implement one file, register it)
-- **Config-driven**: optional `gitd.daemon.json` to set ports and enable/disable shims
-- **CLI flags**: `--only github,npm` to run a subset, `--disable oci` to exclude, `--list` to see all adapters
-- **Health checks**: every adapter's server responds to `GET /health` with `{ status: 'ok', shim: '<id>' }`
-- **Graceful shutdown**: SIGINT/SIGTERM stops all servers cleanly
-- **4 built-in adapters**: GitHub API, npm registry, Go module proxy, OCI/Docker registry
-- **Extensible**: future adapters (Maven, Cargo/crates.io, PyPI, etc.) implement `ShimAdapter` and plug in
-
-```json
-{
-  "shims": {
-    "github": { "enabled": true, "port": 8181 },
-    "npm":    { "enabled": true, "port": 4873 },
-    "go":     { "enabled": true, "port": 4874 },
-    "oci":    { "enabled": true, "port": 5555 }
-  }
-}
+```bash
+gitd web --port 3000
 ```
+
+## Compatibility Shims
+
+Local proxy servers that translate native tool protocols into DWN queries, so existing tools work without modification:
+
+- **GitHub API** (`gitd github-api`) — GitHub REST API v3 compatible; works with `gh` CLI, VS Code extensions, CI systems
+- **npm** (`gitd shim npm`) — `npm install --registry=http://localhost:4873 @did:dht:abc/my-pkg`
+- **Go** (`gitd shim go`) — `GOPROXY=http://localhost:4874 go get did.enbox.org/did:dht:abc/my-mod`
+- **OCI/Docker** (`gitd shim oci`) — `docker pull localhost:5555/did:dht:abc/my-image:v1.0.0`
+
+Run all shims in one process with `gitd daemon`, or start them individually.
 
 ## Architecture
 
-See [PLAN.md](./PLAN.md) for the full architecture document covering:
-
-- Prior art analysis (Radicle, ForgeFed, git-bug)
-- 11 composable DWN protocol definitions (repo, refs, issues, patches, CI, releases, registry, social, notifications, wiki, org)
-- DID-addressed git remotes and transport
-- Decentralized bundle storage (`$squash`, encryption model, cold-start restore)
-- DID-scoped package registry
-- Namespace-based contribution model (no spam by design)
-- Indexer integration patterns
-- Identity and access control
-- Technical challenges and mitigations
-- Implementation roadmap with phased milestones
-
-## Protocols
-
-| Protocol | URI | Purpose |
-|---|---|---|
-| `forge-repo` | `forge/repo` | Repository metadata, collaborator roles, bundles, settings |
-| `forge-refs` | `forge/refs` | Git ref records (branches, tags) for DWN subscriptions |
-| `forge-issues` | `forge/issues` | Issues, comments, labels, status changes, assignments |
-| `forge-patches` | `forge/patches` | Pull requests, revisions, reviews, merge results |
-| `forge-ci` | `forge/ci` | Check suites, check runs, artifacts |
-| `forge-releases` | `forge/releases` | Release management, immutable assets, signatures |
-| `forge-registry` | `forge/registry` | Package publishing, versions, tarballs, attestations |
-| `forge-social` | `forge/social` | Stars, follows, activity feeds |
-| `forge-notifications` | `forge/notifications` | Personal notification inbox |
-| `forge-wiki` | `forge/wiki` | Collaborative documentation pages |
-| `forge-org` | `forge/org` | Organizations, teams, team membership |
-
-## Installation
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/enboxorg/gitd/main/install.sh | bash
-```
-
-The installer works on Linux, macOS, and Windows (Git Bash/WSL). It installs
-the latest prebuilt release binaries (`gitd`, `git-remote-did`, and
-`git-remote-did-credential`).
-
-```bash
-# Manual install (if you prefer to run steps yourself)
-bun add -g @enbox/gitd
-```
-
-### Sub-path Exports
-
-```typescript
-// Protocol definitions and types
-import { ForgeRepoProtocol, ForgeIssuesProtocol } from '@enbox/gitd';
-
-// Git transport server
-import { createGitServer, createBundleSyncer, restoreFromBundles } from '@enbox/gitd/git-server';
-
-// Git remote helper utilities
-import { parseDidUrl, resolveGitEndpoint } from '@enbox/gitd/git-remote';
-
-// Indexer service
-import { IndexerStore, IndexerCrawler, handleApiRequest } from '@enbox/gitd/indexer';
-
-// GitHub API compatibility shim
-import { handleShimRequest, startShimServer } from '@enbox/gitd/github-shim';
-
-// Package resolver and trust chain
-import { resolveFullPackage, verifyPackageVersion, buildTrustChain } from '@enbox/gitd/resolver';
-
-// Package manager shims
-import { handleNpmRequest, startNpmShim } from '@enbox/gitd/shims/npm';
-import { handleGoProxyRequest, startGoShim } from '@enbox/gitd/shims/go';
-import { handleOciRequest, startOciShim } from '@enbox/gitd/shims/oci';
-```
+See [ARCHITECTURE.md](./ARCHITECTURE.md) for a high-level overview of protocols, transport, and system design. See [PLAN.md](./PLAN.md) for the full implementation plan with detailed protocol definitions and roadmap.
 
 ## Development
 
@@ -332,30 +126,8 @@ import { handleOciRequest, startOciShim } from '@enbox/gitd/shims/oci';
 bun install            # Install dependencies
 bun run build          # Build (clean + tsc)
 bun run lint           # Lint (ESLint, zero warnings)
-bun run lint:fix       # Auto-fix lint issues
-bun test               # Run all tests
+bun test .spec.ts      # Run all tests
 ```
-
-## Security Hardening
-
-Production-hardened with 10 security fixes across all server-facing code:
-
-- **Path traversal protection** — repo names validated, resolved paths confined to base directory
-- **Request body size limits** — 1 MB JSON / 50 MB git packs, returns 413 on overflow
-- **Bearer token auth** — optional `GITD_API_TOKEN` for API write endpoints (constant-time comparison)
-- **SSRF protection** — DID-resolved URLs blocked from private/loopback IP ranges
-- **DID resolution timeouts** — 30s timeout prevents hanging on malicious endpoints
-- **XSS protection** — all HTML output escaped in web UI error pages
-- **Nonce replay protection** — push auth tokens tracked with TTL eviction
-- **Indexer size limits** — configurable caps with FIFO eviction (default 100K repos)
-- **Health endpoints** — `GET /health` on all servers for monitoring
-- **Port validation** — CLI rejects invalid `--port` values with clear errors
-
-See PLAN.md Section 14 for full details.
-
-## Status
-
-**All phases complete + production hardened** — working MVP with CLI commands for all 11 protocols, git transport, DID-signed push auth, ref mirroring, bundle storage, package registry with attestation system and dependency trust chain verification, GitHub migration tool, read-only web UI, indexer service, GitHub API compatibility shim (read + write), package manager shims (npm, Go, OCI/Docker), unified daemon with `ShimAdapter` plugin architecture, and comprehensive security hardening. 871+ tests across 21 test files. See PLAN.md Section 12 for the full roadmap.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Add **research preview** warning at the top of the README
- Remove **Security Hardening** section (internal implementation detail, not user-facing)
- Remove **Status** section (was a completed task tracker)
- Remove protocol count ("11 composable protocols") — nobody cares about the count
- Remove **Sub-path Exports** section (API docs concern)
- Replace `raw.githubusercontent.com` install URL with `gitd.sh/install`
- Streamline CLI examples — show representative commands, not every flag
- Rename "Thesis" heading to "Why"
- Create **ARCHITECTURE.md** with:
  - Design principles
  - System overview diagram
  - Protocol summary table
  - Role-based authorization explanation
  - Git transport flow (DID remotes, push auth, bundle sync)
  - Compatibility layer overview
  - Directory structure

README went from 362 lines to 128 lines.

## Validation

- `bun run build` — pass
- `bun run lint` — pass
- `bun test .spec.ts` — 882 pass, 9 skip, 0 fail