### PR TITLE
chore: initial changeset for first npm release

### DIFF
--- a/.changeset/initial-release.md
+++ b/.changeset/initial-release.md
@@ -1,0 +1,5 @@
+---
+"@enbox/gitd": patch
+---
+
+Initial npm release of gitd — a decentralized forge (GitHub alternative) built on DWN protocols.


### PR DESCRIPTION
## Summary

Adds the initial changeset to trigger the first npm publish of `@enbox/gitd`.

- **Bump**: minor (0.0.1 → 0.1.0)
- **Package**: `@enbox/gitd`

## What happens on merge

1. The `npm-release.yml` workflow detects the changeset and creates a **"Version Packages"** PR
2. That PR bumps `package.json` to `0.1.0` and generates `CHANGELOG.md`
3. When you merge the "Version Packages" PR, the workflow publishes `@enbox/gitd@0.1.0` to npm and creates a GitHub Release
4. The GitHub Release triggers `release.yml` to build binary artifacts for all platforms