### PR TITLE
fix: inline binary builds into release workflow after npm publish

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -18,6 +18,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
+      publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -51,3 +54,79 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  build-artifacts:
+    name: Build ${{ matrix.target }}
+    needs: release
+    if: needs.release.outputs.published == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: bun-linux-x64
+            os: linux
+            arch: x64
+            ext: tar.gz
+          - target: bun-linux-arm64
+            os: linux
+            arch: arm64
+            ext: tar.gz
+          - target: bun-darwin-x64
+            os: darwin
+            arch: x64
+            ext: tar.gz
+          - target: bun-darwin-arm64
+            os: darwin
+            arch: arm64
+            ext: tar.gz
+          - target: bun-windows-x64
+            os: windows
+            arch: x64
+            ext: zip
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Determine version
+        id: version
+        run: |
+          version=$(node -p "require('./package.json').version")
+          echo "version=v${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build release binaries
+        run: |
+          mkdir -p dist/release
+          out_suffix=""
+          if [ "${{ matrix.os }}" = "windows" ]; then
+            out_suffix=".exe"
+          fi
+
+          bun build src/cli/main.ts --compile --target "${{ matrix.target }}" --outfile "dist/release/gitd${out_suffix}"
+          bun build src/git-remote/main.ts --compile --target "${{ matrix.target }}" --outfile "dist/release/git-remote-did${out_suffix}"
+          bun build src/git-remote/credential-main.ts --compile --target "${{ matrix.target }}" --outfile "dist/release/git-remote-did-credential${out_suffix}"
+
+      - name: Package artifact
+        run: |
+          artifact="gitd-${{ matrix.os }}-${{ matrix.arch }}.${{ matrix.ext }}"
+          if [ "${{ matrix.ext }}" = "zip" ]; then
+            (cd dist/release && zip -q "../../${artifact}" gitd.exe git-remote-did.exe git-remote-did-credential.exe)
+          else
+            (cd dist/release && tar -czf "../../${artifact}" gitd git-remote-did git-remote-did-credential)
+          fi
+          echo "artifact=${artifact}" >> "$GITHUB_ENV"
+
+      - name: Upload artifact to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.version }}
+          files: ${{ env.artifact }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ name: Release Artifacts
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g. v0.0.2)'
+        required: true
 
 permissions:
   contents: write
@@ -39,6 +44,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -73,4 +80,5 @@ jobs:
       - name: Upload artifact to release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.event.inputs.tag || github.event.release.tag_name }}
           files: ${{ env.artifact }}


### PR DESCRIPTION
## Summary

- **Problem**: `changesets/action` creates GitHub Releases using `GITHUB_TOKEN`, which does not trigger other workflows (GitHub's anti-loop policy). This meant `release.yml` never ran for changesets-created releases — e.g. v0.0.2 has no binary artifacts.
- **Fix**: Added a `build-artifacts` job to `npm-release.yml` that runs after changesets publishes (`if: needs.release.outputs.published == 'true'`). It builds all 5 platform binaries and uploads them to the release.
- **Bonus**: Added `workflow_dispatch` to `release.yml` with a `tag` input for manual re-triggering (backfill artifacts on existing releases like v0.0.2).

Build, test, and lint: workflow-only changes (YAML), no TypeScript modified.