### PR TITLE
feat: add linux musl release targets for Alpine/Docker support

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -84,6 +84,14 @@ jobs:
             os: windows
             arch: x64
             ext: zip
+          - target: bun-linux-x64-musl
+            os: linux
+            arch: x64-musl
+            ext: tar.gz
+          - target: bun-linux-arm64-musl
+            os: linux
+            arch: arm64-musl
+            ext: tar.gz
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,14 @@ jobs:
             os: windows
             arch: x64
             ext: zip
+          - target: bun-linux-x64-musl
+            os: linux
+            arch: x64-musl
+            ext: tar.gz
+          - target: bun-linux-arm64-musl
+            os: linux
+            arch: arm64-musl
+            ext: tar.gz
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- Added `bun-linux-x64-musl` and `bun-linux-arm64-musl` compile targets to both `release.yml` and `npm-release.yml` (5 → 7 platform targets).
- Added `detect_libc()` to `install.sh` — automatically detects musl (via `ldd --version` or `/etc/alpine-release`) and downloads the correct binary.

This brings gitd's platform coverage in line with meshd (7 targets each), with the difference that gitd has musl variants instead of freebsd/windows-arm64 (which Bun doesn't support).

Build, test, and lint: workflow + install script changes only, no TypeScript modified.