### PR TITLE
feat: migrate git content (clone, bundle, refs) from GitHub

### DIFF
--- a/.changeset/migrate-git-content.md
+++ b/.changeset/migrate-git-content.md
@@ -1,0 +1,15 @@
+---
+"@enbox/gitd": minor
+---
+
+feat: migrate git content (clone, bundle, refs) from GitHub
+
+The `gitd migrate repo` and `gitd migrate all` commands now support
+migrating actual git content — not just metadata. When `--repos <path>`
+or `GITD_REPOS` is provided, migration will:
+
+1. Clone the GitHub repo as a bare repository on disk
+2. Create a full git bundle and upload it to DWN
+3. Sync all git refs (branches + tags) to DWN records
+
+This enables the full e2e flow: migrate → serve → clone-via-DID.


### PR DESCRIPTION
## Summary

- Adds git content migration to `gitd migrate repo` and `gitd migrate all` commands
- When `--repos <path>` or `GITD_REPOS` env is provided, migration clones the GitHub repo as a bare repo, creates a full git bundle uploaded to DWN, and syncs all refs (branches + tags) to DWN records
- Without `--repos`/`GITD_REPOS`, only metadata is migrated (backward compatible)
- Git content errors during `migrate all` are non-fatal — issues/PRs/releases still import
- Adds tests for git content migration flow (bare repo setup, bundle upload, ref sync)

## Checks

- `bun run build` — zero errors
- `bun run lint` — zero warnings/errors
- `bun test .spec.ts` — 890 pass, 0 fail

Closes #59