### PR TITLE
fix: credential helper uses identity profiles and signs with correct DID

### DIFF
--- a/.changeset/credential-profile.md
+++ b/.changeset/credential-profile.md
@@ -1,0 +1,16 @@
+---
+"@enbox/gitd": patch
+---
+
+fix: credential helper uses identity profiles and signs with correct DID
+
+The git credential helper (`git-remote-did-credential`) now resolves
+the active identity profile before connecting to the agent, matching
+the same resolution chain used by all `gitd` CLI commands (env var,
+git config, global default, single fallback).
+
+Also fixes a signing bug: the helper previously signed push tokens
+with the internal agent DID but claimed the identity DID in the token
+payload, which would cause signature verification to fail when the
+server resolves the claimed DID's public key. Now signs with the
+identity's own BearerDid signer.


### PR DESCRIPTION
## Summary

- The `git-remote-did-credential` binary now resolves the active identity profile using the same precedence chain as all `gitd` CLI commands (`ENBOX_PROFILE` env, git config `enbox.profile`, global default, single fallback)
- Fixes a signing bug: previously signed push tokens with the internal agent DID but claimed the identity DID in the token payload, which would cause signature verification failures on the server
- Uses `Web5UserAgent.create()` directly instead of `Web5.connect()` to access the identity's `BearerDid` for correct signing

## Changes

- `src/git-remote/credential-main.ts` — Replaced `Web5.connect()` with `Web5UserAgent.create()`, added profile resolution via `resolveProfile()`/`profileDataPath()`, sign with identity's BearerDid signer instead of agent DID signer
- `.changeset/credential-profile.md` — Patch changeset

## Verification

- `bun run build` — zero errors
- `bun run lint` — zero warnings
- `bun test .spec.ts` — 906 pass, 0 fail