### PR TITLE
fix: make git content migration the default in `gitd migrate`

### DIFF
--- a/.changeset/migrate-git-default.md
+++ b/.changeset/migrate-git-default.md
@@ -1,0 +1,5 @@
+---
+"@enbox/gitd": patch
+---
+
+Make git content migration the default for `gitd migrate`. Previously, git content (clone, bundle, refs) was only included when `--repos <path>` was explicitly provided. Now it defaults to `./repos` (matching `gitd serve`), and a new `--no-git` flag skips git content when not needed.

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -11,6 +11,11 @@ export function flagValue(args: string[], flag: string): string | undefined {
   return args[idx + 1];
 }
 
+/** Check whether a boolean flag is present in argv. */
+export function hasFlag(args: string[], flag: string): boolean {
+  return args.includes(flag);
+}
+
 /**
  * Parse a port number string, validating that it's a valid TCP port.
  * Exits the process with an error if the value is not a valid port.

--- a/tests/cli.spec.ts
+++ b/tests/cli.spec.ts
@@ -1311,10 +1311,10 @@ describe('gitd CLI commands', () => {
       // When no owner/repo arg is given, resolveGhRepo falls back to
       // the current directory's git remotes.  We're inside the gitd repo
       // so this should succeed (and the repo record already exists).
-      // No --repos flag → git content migration is skipped.
+      // Pass --no-git since the test mock doesn't serve real git content.
       mockGitHubApi({});
       const { migrateCommand } = await import('../src/cli/commands/migrate.js');
-      const logs = await captureLog(() => migrateCommand(ctx, ['repo']));
+      const logs = await captureLog(() => migrateCommand(ctx, ['repo', '--no-git']));
       expect(logs.some((l) => l.includes('Detected GitHub repo'))).toBe(true);
       expect(logs.some((l) => l.includes('already exists'))).toBe(true);
       expect(logs.some((l) => l.includes('Skipping git content'))).toBe(true);
@@ -1325,7 +1325,7 @@ describe('gitd CLI commands', () => {
       // falls through to auto-detection from git remotes.
       mockGitHubApi({});
       const { migrateCommand } = await import('../src/cli/commands/migrate.js');
-      const logs = await captureLog(() => migrateCommand(ctx, ['repo', 'noslash']));
+      const logs = await captureLog(() => migrateCommand(ctx, ['repo', 'noslash', '--no-git']));
       expect(logs.some((l) => l.includes('Detected GitHub repo'))).toBe(true);
     });
 
@@ -1369,7 +1369,7 @@ describe('gitd CLI commands', () => {
     it('should skip repo import when repo already exists', async () => {
       mockGitHubApi({});
       const { migrateCommand } = await import('../src/cli/commands/migrate.js');
-      const logs = await captureLog(() => migrateCommand(ctx, ['repo', 'testowner/testrepo']));
+      const logs = await captureLog(() => migrateCommand(ctx, ['repo', 'testowner/testrepo', '--no-git']));
       expect(logs.some((l) => l.includes('already exists'))).toBe(true);
       expect(logs.some((l) => l.includes('skipping'))).toBe(true);
     });


### PR DESCRIPTION
## Summary

- `gitd migrate repo` and `gitd migrate all` now include git content (clone, bundle, refs) **by default**, matching the `./repos` default used by `gitd serve`.
- Added `--no-git` flag to skip git content when not needed.
- Added `hasFlag()` helper to `flags.ts` for boolean flag parsing.

## Details

Previously, git content was only migrated when `--repos <path>` was explicitly provided. This was backwards — users had to opt _in_ to the most important part of migration. Now `resolveReposPath()` defaults to `./repos` (same as `gitd serve`), and `--no-git` is available to skip git content (e.g., for metadata-only imports).

## Checks

- `bun run build` — zero errors
- `bun run lint` — zero warnings/errors
- `bun test .spec.ts` — 913 pass, 9 skip, 0 fail