### PR TITLE
feat: multi-repo architecture — a DID can own multiple repositories

### DIFF
--- a/.changeset/multi-repo.md
+++ b/.changeset/multi-repo.md
@@ -1,0 +1,5 @@
+---
+"@enbox/gitd": minor
+---
+
+Multi-repo architecture: a DID can now own multiple repositories. Removes the `$recordLimit` singleton constraint on repo records. All CLI commands, the GitHub shim, the web UI, and migration resolve repos by name. Web UI routes change from `/:did/...` to `/:did/:repo/...` with a new repo list page at `/:did`. The `--repo` flag, `GITD_REPO` env, and `git config enbox.repo` select the active repo when multiple exist.

--- a/src/cli/commands/ci.ts
+++ b/src/cli/commands/ci.ts
@@ -16,8 +16,8 @@ import type { AgentContext } from '../agent.js';
 
 import { DateSort } from '@enbox/dwn-sdk-js';
 
-import { flagValue } from '../flags.js';
 import { getRepoContextId } from '../repo-context.js';
+import { flagValue, resolveRepoName } from '../flags.js';
 
 // ---------------------------------------------------------------------------
 // Sub-command dispatch
@@ -47,7 +47,7 @@ export async function ciCommand(ctx: AgentContext, args: string[]): Promise<void
 
 async function ciStatus(ctx: AgentContext, args: string[]): Promise<void> {
   const commitFilter = args[0];
-  const repoContextId = await getRepoContextId(ctx);
+  const repoContextId = await getRepoContextId(ctx, resolveRepoName(args));
 
   const filter: Record<string, unknown> = { contextId: repoContextId };
   if (commitFilter) {
@@ -87,7 +87,7 @@ async function ciStatus(ctx: AgentContext, args: string[]): Promise<void> {
 
 async function ciList(ctx: AgentContext, args: string[]): Promise<void> {
   const limit = parseInt(flagValue(args, '--limit') ?? '10', 10);
-  const repoContextId = await getRepoContextId(ctx);
+  const repoContextId = await getRepoContextId(ctx, resolveRepoName(args));
 
   const { records } = await ctx.ci.records.query('repo/checkSuite' as any, {
     filter     : { contextId: repoContextId },
@@ -189,7 +189,7 @@ async function ciCreate(ctx: AgentContext, args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const repoContextId = await getRepoContextId(ctx);
+  const repoContextId = await getRepoContextId(ctx, resolveRepoName(args));
 
   const tags: Record<string, string> = {
     commitSha,

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -27,12 +27,12 @@ export async function initCommand(ctx: AgentContext, args: string[]): Promise<vo
     process.exit(1);
   }
 
-  // Check if a repo already exists (singleton).
-  const { records: existing } = await ctx.repo.records.query('repo');
+  // Check if a repo with this name already exists.
+  const { records: existing } = await ctx.repo.records.query('repo', {
+    filter: { tags: { name } },
+  });
   if (existing.length > 0) {
-    const data = await existing[0].data.json();
-    console.error(`Repository "${data.name}" already exists (recordId: ${existing[0].id}).`);
-    console.error('The forge-repo protocol allows only one repo record per DWN.');
+    console.error(`Repository "${name}" already exists (recordId: ${existing[0].id}).`);
     process.exit(1);
   }
 

--- a/src/cli/commands/issue.ts
+++ b/src/cli/commands/issue.ts
@@ -14,8 +14,8 @@
 
 import type { AgentContext } from '../agent.js';
 
-import { flagValue } from '../flags.js';
 import { getRepoContextId } from '../repo-context.js';
+import { flagValue, resolveRepoName } from '../flags.js';
 
 // ---------------------------------------------------------------------------
 // Sub-command dispatch
@@ -52,7 +52,7 @@ async function issueCreate(ctx: AgentContext, args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const repoContextId = await getRepoContextId(ctx);
+  const repoContextId = await getRepoContextId(ctx, resolveRepoName(args));
 
   // Assign the next sequential number.
   const number = await getNextNumber(ctx, repoContextId);
@@ -83,7 +83,7 @@ async function issueShow(ctx: AgentContext, args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const repoContextId = await getRepoContextId(ctx);
+  const repoContextId = await getRepoContextId(ctx, resolveRepoName(args));
   const record = await findIssueByNumber(ctx, repoContextId, numberStr);
   if (!record) {
     console.error(`Issue #${numberStr} not found.`);
@@ -138,7 +138,7 @@ async function issueComment(ctx: AgentContext, args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const repoContextId = await getRepoContextId(ctx);
+  const repoContextId = await getRepoContextId(ctx, resolveRepoName(args));
   const issue = await findIssueByNumber(ctx, repoContextId, numberStr);
   if (!issue) {
     console.error(`Issue #${numberStr} not found.`);
@@ -169,7 +169,7 @@ async function issueClose(ctx: AgentContext, args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const repoContextId = await getRepoContextId(ctx);
+  const repoContextId = await getRepoContextId(ctx, resolveRepoName(args));
   const issue = await findIssueByNumber(ctx, repoContextId, numberStr);
   if (!issue) {
     console.error(`Issue #${numberStr} not found.`);
@@ -208,7 +208,7 @@ async function issueReopen(ctx: AgentContext, args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const repoContextId = await getRepoContextId(ctx);
+  const repoContextId = await getRepoContextId(ctx, resolveRepoName(args));
   const issue = await findIssueByNumber(ctx, repoContextId, numberStr);
   if (!issue) {
     console.error(`Issue #${numberStr} not found.`);
@@ -243,7 +243,7 @@ async function issueReopen(ctx: AgentContext, args: string[]): Promise<void> {
 async function issueList(ctx: AgentContext, args: string[]): Promise<void> {
   const statusFilter = flagValue(args, '--status') ?? flagValue(args, '-s');
 
-  const repoContextId = await getRepoContextId(ctx);
+  const repoContextId = await getRepoContextId(ctx, resolveRepoName(args));
 
   const filter: Record<string, unknown> = {};
   if (repoContextId) {

--- a/src/cli/commands/log.ts
+++ b/src/cli/commands/log.ts
@@ -11,8 +11,8 @@
 
 import type { AgentContext } from '../agent.js';
 
-import { flagValue } from '../flags.js';
 import { getRepoContextId } from '../repo-context.js';
+import { flagValue, resolveRepoName } from '../flags.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -32,7 +32,7 @@ export async function logCommand(ctx: AgentContext, args: string[]): Promise<voi
   const limitStr = flagValue(args, '--limit') ?? flagValue(args, '-n') ?? '20';
   const limit = parseInt(limitStr, 10);
 
-  const repoContextId = await getRepoContextId(ctx);
+  const repoContextId = await getRepoContextId(ctx, resolveRepoName(args));
 
   const entries: ActivityEntry[] = [];
 

--- a/src/cli/commands/patch.ts
+++ b/src/cli/commands/patch.ts
@@ -15,8 +15,8 @@
 
 import type { AgentContext } from '../agent.js';
 
-import { flagValue } from '../flags.js';
 import { getRepoContextId } from '../repo-context.js';
+import { flagValue, resolveRepoName } from '../flags.js';
 
 // ---------------------------------------------------------------------------
 // Sub-command dispatch
@@ -56,7 +56,7 @@ async function patchCreate(ctx: AgentContext, args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const repoContextId = await getRepoContextId(ctx);
+  const repoContextId = await getRepoContextId(ctx, resolveRepoName(args));
 
   // Assign the next sequential number.
   const number = await getNextNumber(ctx, repoContextId);
@@ -94,7 +94,7 @@ async function patchShow(ctx: AgentContext, args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const repoContextId = await getRepoContextId(ctx);
+  const repoContextId = await getRepoContextId(ctx, resolveRepoName(args));
   const record = await findPatchByNumber(ctx, repoContextId, numberStr);
   if (!record) {
     console.error(`Patch #${numberStr} not found.`);
@@ -157,7 +157,7 @@ async function patchComment(ctx: AgentContext, args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const repoContextId = await getRepoContextId(ctx);
+  const repoContextId = await getRepoContextId(ctx, resolveRepoName(args));
   const patch = await findPatchByNumber(ctx, repoContextId, numberStr);
   if (!patch) {
     console.error(`Patch #${numberStr} not found.`);
@@ -197,7 +197,7 @@ async function patchMerge(ctx: AgentContext, args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const repoContextId = await getRepoContextId(ctx);
+  const repoContextId = await getRepoContextId(ctx, resolveRepoName(args));
   const patch = await findPatchByNumber(ctx, repoContextId, numberStr);
   if (!patch) {
     console.error(`Patch #${numberStr} not found.`);
@@ -249,7 +249,7 @@ async function patchClose(ctx: AgentContext, args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const repoContextId = await getRepoContextId(ctx);
+  const repoContextId = await getRepoContextId(ctx, resolveRepoName(args));
   const patch = await findPatchByNumber(ctx, repoContextId, numberStr);
   if (!patch) {
     console.error(`Patch #${numberStr} not found.`);
@@ -293,7 +293,7 @@ async function patchReopen(ctx: AgentContext, args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const repoContextId = await getRepoContextId(ctx);
+  const repoContextId = await getRepoContextId(ctx, resolveRepoName(args));
   const patch = await findPatchByNumber(ctx, repoContextId, numberStr);
   if (!patch) {
     console.error(`Patch #${numberStr} not found.`);
@@ -333,7 +333,7 @@ async function patchReopen(ctx: AgentContext, args: string[]): Promise<void> {
 async function patchList(ctx: AgentContext, args: string[]): Promise<void> {
   const statusFilter = flagValue(args, '--status') ?? flagValue(args, '-s');
 
-  const repoContextId = await getRepoContextId(ctx);
+  const repoContextId = await getRepoContextId(ctx, resolveRepoName(args));
 
   const filter: Record<string, unknown> = {};
   if (repoContextId) {

--- a/src/cli/commands/release.ts
+++ b/src/cli/commands/release.ts
@@ -13,8 +13,8 @@ import type { AgentContext } from '../agent.js';
 
 import { DateSort } from '@enbox/dwn-sdk-js';
 
-import { flagValue } from '../flags.js';
 import { getRepoContextId } from '../repo-context.js';
+import { flagValue, resolveRepoName } from '../flags.js';
 
 // ---------------------------------------------------------------------------
 // Sub-command dispatch
@@ -52,7 +52,7 @@ async function releaseCreate(ctx: AgentContext, args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const repoContextId = await getRepoContextId(ctx);
+  const repoContextId = await getRepoContextId(ctx, resolveRepoName(args));
 
   const tags: Record<string, unknown> = { tagName };
   if (commitSha) { tags.commitSha = commitSha; }
@@ -87,7 +87,7 @@ async function releaseShow(ctx: AgentContext, args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const repoContextId = await getRepoContextId(ctx);
+  const repoContextId = await getRepoContextId(ctx, resolveRepoName(args));
   const release = await findReleaseByTag(ctx, repoContextId, tagName);
   if (!release) {
     console.error(`Release ${tagName} not found.`);
@@ -138,7 +138,7 @@ async function releaseShow(ctx: AgentContext, args: string[]): Promise<void> {
 
 async function releaseList(ctx: AgentContext, args: string[]): Promise<void> {
   const limit = parseInt(flagValue(args, '--limit') ?? '20', 10);
-  const repoContextId = await getRepoContextId(ctx);
+  const repoContextId = await getRepoContextId(ctx, resolveRepoName(args));
 
   const { records } = await ctx.releases.records.query('repo/release' as any, {
     filter     : { contextId: repoContextId },

--- a/src/cli/commands/wiki.ts
+++ b/src/cli/commands/wiki.ts
@@ -12,8 +12,8 @@
 
 import type { AgentContext } from '../agent.js';
 
-import { flagValue } from '../flags.js';
 import { getRepoContextId } from '../repo-context.js';
+import { flagValue, resolveRepoName } from '../flags.js';
 
 // ---------------------------------------------------------------------------
 // Sub-command dispatch
@@ -49,7 +49,7 @@ async function wikiCreate(ctx: AgentContext, args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const repoContextId = await getRepoContextId(ctx);
+  const repoContextId = await getRepoContextId(ctx, resolveRepoName(args));
 
   // Check for duplicate slug.
   const existing = await findPageBySlug(ctx, repoContextId, slug);
@@ -85,7 +85,7 @@ async function wikiShow(ctx: AgentContext, args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const repoContextId = await getRepoContextId(ctx);
+  const repoContextId = await getRepoContextId(ctx, resolveRepoName(args));
   const page = await findPageBySlug(ctx, repoContextId, slug);
   if (!page) {
     console.error(`Wiki page "${slug}" not found.`);
@@ -125,7 +125,7 @@ async function wikiEdit(ctx: AgentContext, args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const repoContextId = await getRepoContextId(ctx);
+  const repoContextId = await getRepoContextId(ctx, resolveRepoName(args));
   const page = await findPageBySlug(ctx, repoContextId, slug);
   if (!page) {
     console.error(`Wiki page "${slug}" not found. Use \`gitd wiki create\` first.`);
@@ -158,8 +158,8 @@ async function wikiEdit(ctx: AgentContext, args: string[]): Promise<void> {
 // wiki list
 // ---------------------------------------------------------------------------
 
-async function wikiList(ctx: AgentContext, _args: string[]): Promise<void> {
-  const repoContextId = await getRepoContextId(ctx);
+async function wikiList(ctx: AgentContext, args: string[]): Promise<void> {
+  const repoContextId = await getRepoContextId(ctx, resolveRepoName(args));
 
   const { records } = await ctx.wiki.records.query('repo/page' as any, {
     filter: { contextId: repoContextId },

--- a/src/cli/repo-context.ts
+++ b/src/cli/repo-context.ts
@@ -1,9 +1,14 @@
 /**
- * Shared helper to locate the repo record's contextId and visibility.
+ * Shared helper to locate a repo record's contextId and visibility.
  *
  * All composing protocols (issues, patches) need the repo's `contextId`
  * as the `parentContextId` for their top-level writes (via `$ref`).
  * The `visibility` tag determines whether bundle records are encrypted.
+ *
+ * Multi-repo: a DID can own multiple repos.  The `repoName` parameter
+ * selects the target.  When omitted and only one repo exists, it is
+ * used automatically.  When multiple repos exist the caller must supply
+ * a name (resolved from `--repo`, env, or git config).
  *
  * @module
  */
@@ -16,13 +21,36 @@ export type RepoContext = {
   contextId: string;
   /** Repo visibility — controls encryption of bundle records. */
   visibility: 'public' | 'private';
+  /** The repo name. */
+  name: string;
 };
 
 /**
- * Query the local DWN for the singleton repo record and return its context.
- * Exits with an error if no repo has been initialized.
+ * Query the local DWN for a repo record and return its context.
+ *
+ * @param ctx - Agent context with typed protocol handles.
+ * @param repoName - Repo name to look up.  When `undefined`, falls back
+ *   to the only repo if exactly one exists, or exits with an error.
  */
-export async function getRepoContext(ctx: AgentContext): Promise<RepoContext> {
+export async function getRepoContext(
+  ctx: AgentContext,
+  repoName?: string,
+): Promise<RepoContext> {
+  if (repoName) {
+    // Look up by name tag.
+    const { records } = await ctx.repo.records.query('repo', {
+      filter: { tags: { name: repoName } },
+    });
+
+    if (records.length === 0) {
+      console.error(`Repository "${repoName}" not found. Run \`gitd init ${repoName}\` first.`);
+      process.exit(1);
+    }
+
+    return extractContext(records[0], repoName);
+  }
+
+  // No name provided — fall back to single-repo or error.
   const { records } = await ctx.repo.records.query('repo');
 
   if (records.length === 0) {
@@ -30,8 +58,31 @@ export async function getRepoContext(ctx: AgentContext): Promise<RepoContext> {
     process.exit(1);
   }
 
-  const record = records[0];
+  if (records.length > 1) {
+    console.error('Multiple repositories exist. Specify one with --repo <name>, GITD_REPO env, or `git config enbox.repo <name>`.');
+    process.exit(1);
+  }
 
+  const data = await records[0].data.json();
+  return extractContext(records[0], data.name ?? 'unnamed');
+}
+
+/**
+ * Convenience wrapper — returns only the contextId.
+ */
+export async function getRepoContextId(
+  ctx: AgentContext,
+  repoName?: string,
+): Promise<string> {
+  const { contextId } = await getRepoContext(ctx, repoName);
+  return contextId;
+}
+
+// ---------------------------------------------------------------------------
+// Internal
+// ---------------------------------------------------------------------------
+
+function extractContext(record: any, name: string): RepoContext {
   const contextId = record.contextId;
   if (!contextId) {
     console.error('Repository record has no contextId — this should not happen.');
@@ -39,17 +90,5 @@ export async function getRepoContext(ctx: AgentContext): Promise<RepoContext> {
   }
 
   const visibility = (record.tags?.visibility as 'public' | 'private') ?? 'public';
-
-  return { contextId, visibility };
-}
-
-/**
- * Query the local DWN for the singleton repo record and return its contextId.
- * Exits with an error if no repo has been initialized.
- *
- * @deprecated Use {@link getRepoContext} instead to also get visibility.
- */
-export async function getRepoContextId(ctx: AgentContext): Promise<string> {
-  const { contextId } = await getRepoContext(ctx);
-  return contextId;
+  return { contextId, visibility, name };
 }

--- a/src/github-shim/helpers.ts
+++ b/src/github-shim/helpers.ts
@@ -82,12 +82,17 @@ export function fromOpt(ctx: AgentContext, targetDid: string): string | undefine
 }
 
 /**
- * Look up the singleton repo record for a target DID.  Returns `null`
- * if no repo record exists.
+ * Look up a repo record for a target DID by name.  Returns `null`
+ * if no matching repo record exists.
  */
-export async function getRepoRecord(ctx: AgentContext, targetDid: string): Promise<RepoInfo | null> {
+export async function getRepoRecord(
+  ctx: AgentContext, targetDid: string, repoName: string,
+): Promise<RepoInfo | null> {
   const from = fromOpt(ctx, targetDid);
-  const { records } = await ctx.repo.records.query('repo', { from });
+  const { records } = await ctx.repo.records.query('repo', {
+    from,
+    filter: { tags: { name: repoName } },
+  });
   if (records.length === 0) { return null; }
 
   const rec = records[0];

--- a/src/github-shim/issues.ts
+++ b/src/github-shim/issues.ts
@@ -80,7 +80,7 @@ function buildIssueResponse(
 export async function handleListIssues(
   ctx: AgentContext, targetDid: string, repoName: string, url: URL,
 ): Promise<JsonResponse> {
-  const repo = await getRepoRecord(ctx, targetDid);
+  const repo = await getRepoRecord(ctx, targetDid, repoName);
   if (!repo) {
     return jsonNotFound(`Repository '${repoName}' not found for DID '${targetDid}'.`);
   }
@@ -141,7 +141,7 @@ export async function handleListIssues(
 export async function handleGetIssue(
   ctx: AgentContext, targetDid: string, repoName: string, number: string, url: URL,
 ): Promise<JsonResponse> {
-  const repo = await getRepoRecord(ctx, targetDid);
+  const repo = await getRepoRecord(ctx, targetDid, repoName);
   if (!repo) {
     return jsonNotFound(`Repository '${repoName}' not found for DID '${targetDid}'.`);
   }
@@ -181,7 +181,7 @@ export async function handleGetIssue(
 export async function handleListIssueComments(
   ctx: AgentContext, targetDid: string, repoName: string, number: string, url: URL,
 ): Promise<JsonResponse> {
-  const repo = await getRepoRecord(ctx, targetDid);
+  const repo = await getRepoRecord(ctx, targetDid, repoName);
   if (!repo) {
     return jsonNotFound(`Repository '${repoName}' not found for DID '${targetDid}'.`);
   }
@@ -248,7 +248,7 @@ export async function handleCreateIssue(
   ctx: AgentContext, targetDid: string, repoName: string,
   reqBody: Record<string, unknown>, url: URL,
 ): Promise<JsonResponse> {
-  const repo = await getRepoRecord(ctx, targetDid);
+  const repo = await getRepoRecord(ctx, targetDid, repoName);
   if (!repo) {
     return jsonNotFound(`Repository '${repoName}' not found for DID '${targetDid}'.`);
   }
@@ -287,7 +287,7 @@ export async function handleUpdateIssue(
   ctx: AgentContext, targetDid: string, repoName: string,
   number: string, reqBody: Record<string, unknown>, url: URL,
 ): Promise<JsonResponse> {
-  const repo = await getRepoRecord(ctx, targetDid);
+  const repo = await getRepoRecord(ctx, targetDid, repoName);
   if (!repo) {
     return jsonNotFound(`Repository '${repoName}' not found for DID '${targetDid}'.`);
   }
@@ -339,7 +339,7 @@ export async function handleCreateIssueComment(
   ctx: AgentContext, targetDid: string, repoName: string,
   number: string, reqBody: Record<string, unknown>, url: URL,
 ): Promise<JsonResponse> {
-  const repo = await getRepoRecord(ctx, targetDid);
+  const repo = await getRepoRecord(ctx, targetDid, repoName);
   if (!repo) {
     return jsonNotFound(`Repository '${repoName}' not found for DID '${targetDid}'.`);
   }

--- a/src/github-shim/pulls.ts
+++ b/src/github-shim/pulls.ts
@@ -124,7 +124,7 @@ function buildPullResponse(
 export async function handleListPulls(
   ctx: AgentContext, targetDid: string, repoName: string, url: URL,
 ): Promise<JsonResponse> {
-  const repo = await getRepoRecord(ctx, targetDid);
+  const repo = await getRepoRecord(ctx, targetDid, repoName);
   if (!repo) {
     return jsonNotFound(`Repository '${repoName}' not found for DID '${targetDid}'.`);
   }
@@ -184,7 +184,7 @@ export async function handleListPulls(
 export async function handleGetPull(
   ctx: AgentContext, targetDid: string, repoName: string, number: string, url: URL,
 ): Promise<JsonResponse> {
-  const repo = await getRepoRecord(ctx, targetDid);
+  const repo = await getRepoRecord(ctx, targetDid, repoName);
   if (!repo) {
     return jsonNotFound(`Repository '${repoName}' not found for DID '${targetDid}'.`);
   }
@@ -215,7 +215,7 @@ export async function handleGetPull(
 export async function handleListPullReviews(
   ctx: AgentContext, targetDid: string, repoName: string, number: string, url: URL,
 ): Promise<JsonResponse> {
-  const repo = await getRepoRecord(ctx, targetDid);
+  const repo = await getRepoRecord(ctx, targetDid, repoName);
   if (!repo) {
     return jsonNotFound(`Repository '${repoName}' not found for DID '${targetDid}'.`);
   }
@@ -284,7 +284,7 @@ export async function handleCreatePull(
   ctx: AgentContext, targetDid: string, repoName: string,
   reqBody: Record<string, unknown>, url: URL,
 ): Promise<JsonResponse> {
-  const repo = await getRepoRecord(ctx, targetDid);
+  const repo = await getRepoRecord(ctx, targetDid, repoName);
   if (!repo) {
     return jsonNotFound(`Repository '${repoName}' not found for DID '${targetDid}'.`);
   }
@@ -332,7 +332,7 @@ export async function handleUpdatePull(
   ctx: AgentContext, targetDid: string, repoName: string,
   number: string, reqBody: Record<string, unknown>, url: URL,
 ): Promise<JsonResponse> {
-  const repo = await getRepoRecord(ctx, targetDid);
+  const repo = await getRepoRecord(ctx, targetDid, repoName);
   if (!repo) {
     return jsonNotFound(`Repository '${repoName}' not found for DID '${targetDid}'.`);
   }
@@ -387,7 +387,7 @@ export async function handleMergePull(
   ctx: AgentContext, targetDid: string, repoName: string,
   number: string, reqBody: Record<string, unknown>, _url: URL,
 ): Promise<JsonResponse> {
-  const repo = await getRepoRecord(ctx, targetDid);
+  const repo = await getRepoRecord(ctx, targetDid, repoName);
   if (!repo) {
     return jsonNotFound(`Repository '${repoName}' not found for DID '${targetDid}'.`);
   }
@@ -447,7 +447,7 @@ export async function handleCreatePullReview(
   ctx: AgentContext, targetDid: string, repoName: string,
   number: string, reqBody: Record<string, unknown>, url: URL,
 ): Promise<JsonResponse> {
-  const repo = await getRepoRecord(ctx, targetDid);
+  const repo = await getRepoRecord(ctx, targetDid, repoName);
   if (!repo) {
     return jsonNotFound(`Repository '${repoName}' not found for DID '${targetDid}'.`);
   }

--- a/src/github-shim/releases.ts
+++ b/src/github-shim/releases.ts
@@ -75,7 +75,7 @@ function buildReleaseResponse(
 export async function handleListReleases(
   ctx: AgentContext, targetDid: string, repoName: string, url: URL,
 ): Promise<JsonResponse> {
-  const repo = await getRepoRecord(ctx, targetDid);
+  const repo = await getRepoRecord(ctx, targetDid, repoName);
   if (!repo) {
     return jsonNotFound(`Repository '${repoName}' not found for DID '${targetDid}'.`);
   }
@@ -116,7 +116,7 @@ export async function handleListReleases(
 export async function handleGetReleaseByTag(
   ctx: AgentContext, targetDid: string, repoName: string, tag: string, url: URL,
 ): Promise<JsonResponse> {
-  const repo = await getRepoRecord(ctx, targetDid);
+  const repo = await getRepoRecord(ctx, targetDid, repoName);
   if (!repo) {
     return jsonNotFound(`Repository '${repoName}' not found for DID '${targetDid}'.`);
   }
@@ -148,7 +148,7 @@ export async function handleCreateRelease(
   ctx: AgentContext, targetDid: string, repoName: string,
   reqBody: Record<string, unknown>, url: URL,
 ): Promise<JsonResponse> {
-  const repo = await getRepoRecord(ctx, targetDid);
+  const repo = await getRepoRecord(ctx, targetDid, repoName);
   if (!repo) {
     return jsonNotFound(`Repository '${repoName}' not found for DID '${targetDid}'.`);
   }

--- a/src/github-shim/repos.ts
+++ b/src/github-shim/repos.ts
@@ -1,10 +1,8 @@
 /**
  * GitHub API shim — `/repos/:did/:repo` endpoint.
  *
- * Maps the DWN singleton repo record to a GitHub REST API v3
- * repository response.  The `:repo` segment is validated against the
- * stored repo name but is otherwise informational — repos are singletons
- * per DID in gitd.
+ * Maps a DWN repo record to a GitHub REST API v3 repository response.
+ * The `:repo` URL segment is used to look up the repo by name.
  *
  * @module
  */
@@ -85,7 +83,7 @@ export function buildRepoResponse(
 export async function handleGetRepo(
   ctx: AgentContext, targetDid: string, repoName: string, url: URL,
 ): Promise<JsonResponse> {
-  const repo = await getRepoRecord(ctx, targetDid);
+  const repo = await getRepoRecord(ctx, targetDid, repoName);
   if (!repo) {
     return jsonNotFound(`Repository '${repoName}' not found for DID '${targetDid}'.`);
   }

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -128,9 +128,8 @@ export const ForgeRepoDefinition = {
   },
   structure: {
     repo: {
-      $recordLimit : { max: 1, strategy: 'reject' },
-      $actions     : [{ who: 'anyone', can: ['read'] }],
-      $tags        : {
+      $actions : [{ who: 'anyone', can: ['read'] }],
+      $tags    : {
         $requiredTags       : ['name', 'visibility'],
         $allowUndefinedTags : false,
         name                : { type: 'string', maxLength: 100 },

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -610,7 +610,9 @@ describe('E2E: authenticated push with DID-signed tokens', () => {
 
   it('should verify repo state via repo record query (repo info)', async () => {
     // Verify the DWN repo record matches expectations (equivalent to `gitd repo info`).
-    const { records } = await repoHandle.records.query('repo');
+    const { records } = await repoHandle.records.query('repo', {
+      filter: { tags: { name: 'auth-test-repo' } },
+    });
     expect(records.length).toBe(1);
 
     const record = records[0];

--- a/tests/hardening.spec.ts
+++ b/tests/hardening.spec.ts
@@ -402,8 +402,10 @@ describe('Web UI — XSS protection in notFound', () => {
     // call has safe content, but we verify the esc() wrapper is active.
     const mockCtx = { did: 'did:dht:test123' } as any;
 
-    // A valid DID prefix + non-matching route → 404.
-    const url = new URL('/did:dht:test123/nonexistent-route', 'http://localhost:3000');
+    // A valid DID prefix + repo name + non-matching sub-path → 404.
+    // (Under multi-repo routing, the first segment after the DID is the
+    // repo name, so we need a second segment to trigger 404.)
+    const url = new URL('/did:dht:test123/some-repo/nonexistent-route', 'http://localhost:3000');
     const result = await handleRequest(mockCtx, url);
     expect(result.status).toBe(404);
     // Verify the response is HTML (the notFound function produces HTML).
@@ -429,7 +431,7 @@ describe('Web UI — XSS protection in notFound', () => {
 
     // Use a DID that differs from ctx.did so the query is routed to
     // the "remote" DWN, which will throw and trigger didError.
-    const url = new URL('/did:dht:remoteuser/issues', 'http://localhost:3000');
+    const url = new URL('/did:dht:remoteuser/some-repo', 'http://localhost:3000');
     const result = await handleRequest(mockCtx, url);
     // Should be 502 (DID error page) or catch the error.
     expect(result.status).toBe(502);

--- a/tests/protocols.spec.ts
+++ b/tests/protocols.spec.ts
@@ -59,8 +59,8 @@ describe('@enbox/gitd', () => {
       expect(ForgeRepoDefinition.structure.repo.contributor.$role).toBe(true);
     });
 
-    it('should enforce $recordLimit on repo singleton', () => {
-      expect(ForgeRepoDefinition.structure.repo.$recordLimit).toEqual({ max: 1, strategy: 'reject' });
+    it('should NOT have $recordLimit on repo (multi-repo)', () => {
+      expect((ForgeRepoDefinition.structure.repo as any).$recordLimit).toBeUndefined();
     });
 
     it('should enforce $recordLimit on readme and license singletons', () => {


### PR DESCRIPTION
## Summary

- Remove the `$recordLimit` singleton constraint on repo records so a DID can own multiple repos (like GitHub orgs)
- All CLI commands, GitHub shim, web UI, and migration now resolve repos by name instead of assuming one per DID
- Web UI routes change from `/:did/...` to `/:did/:repo/...` with a new repo list page at `/:did`

## Changes

### Protocol
- **`src/repo.ts`** — Removed `$recordLimit: { max: 1, strategy: 'reject' }` from repo record type

### Core plumbing
- **`src/cli/repo-context.ts`** — Rewritten: `getRepoContext(ctx, repoName?)` queries by name tag or falls back to single-repo auto-select
- **`src/cli/flags.ts`** — Added `resolveRepoName()`: `--repo` flag → `GITD_REPO` env → `git config enbox.repo` → `undefined`

### CLI commands (all 11 updated)
- **init** — Duplicate-name check replaces singleton check
- **serve** — Per-push dynamic context resolution
- **social star** — Parses `did/repo` format for multi-repo targets
- **repo** — Added `repoList` subcommand, `repoInfo` accepts args
- **issue, patch, release, wiki, ci, log, migrate** — All pass `resolveRepoName(args)` to context functions

### GitHub shim
- **helpers** — `getRepoRecord` requires `repoName`, queries by name tag
- **issues, pulls, releases, repos** — All pass `repoName` through

### Web UI
- **server** — Routes changed to `/:did` (repo list) + `/:did/:repo/...` (repo pages)
- **routes** — All handlers accept `repoName`; added `repoListPage`

### Git server
- **bundle-restore** — Added optional `repoContextId` for scoped bundle queries

### Tests (all updated)
- `protocols.spec.ts` — Assert `$recordLimit` does NOT exist on repo
- `integration.spec.ts` — Multi-repo creation succeeds (was: second repo rejected)
- `cli.spec.ts` — Second repo allowed; duplicate name rejected; star uses `did/repo`; migrate tests use matching repo names
- `web.spec.ts` — All routes updated to `/:did/:repo/...`; added repo list tests
- `hardening.spec.ts` — XSS tests use new URL structure
- `e2e.spec.ts` — Repo query filters by name

## Verification

- `bun run build` — zero TypeScript errors
- `bun run lint` — zero ESLint warnings/errors
- `bun test .spec.ts` — 915 pass, 0 fail, 9 skip