### PR TITLE
fix: scope ref and bundle sync queries to repo contextId

### DIFF
--- a/.changeset/multi-repo.md
+++ b/.changeset/multi-repo.md
@@ -2,4 +2,4 @@
 "@enbox/gitd": minor
 ---
 
-Multi-repo architecture: a DID can now own multiple repositories. Removes the `$recordLimit` singleton constraint on repo records. All CLI commands, the GitHub shim, the web UI, and migration resolve repos by name. Web UI routes change from `/:did/...` to `/:did/:repo/...` with a new repo list page at `/:did`. The `--repo` flag, `GITD_REPO` env, and `git config enbox.repo` select the active repo when multiple exist.
+Multi-repo architecture: a DID can now own multiple repositories. Removes the `$recordLimit` singleton constraint on repo records. All CLI commands, the GitHub shim, the web UI, and migration resolve repos by name. Web UI routes change from `/:did/...` to `/:did/:repo/...` with a new repo list page at `/:did`. The `--repo` flag, `GITD_REPO` env, and `git config enbox.repo` select the active repo when multiple exist. Ref and bundle sync queries are now scoped to the repo's contextId to prevent cross-repo interference. Bundle restore accepts an optional `repoContextId` for scoped restores.

--- a/src/git-server/bundle-sync.ts
+++ b/src/git-server/bundle-sync.ts
@@ -94,15 +94,15 @@ export function createBundleSyncer(options: BundleSyncOptions): OnPushComplete {
   const encrypt = visibility === 'private';
 
   return async (_did: string, _repoName: string, repoPath: string): Promise<void> => {
-    // Query existing bundle records, newest first.
+    // Query existing bundle records scoped to this repo, newest first.
     const { records: existingBundles } = await repo.records.query('repo/bundle', {
-      filter   : { tags: { isFull: true } },
+      filter   : { contextId: repoContextId, tags: { isFull: true } },
       dateSort : DateSort.CreatedDescending,
     });
 
-    // Also query incremental bundles.
+    // Also query incremental bundles scoped to this repo.
     const { records: incrementalBundles } = await repo.records.query('repo/bundle', {
-      filter   : { tags: { isFull: false } },
+      filter   : { contextId: repoContextId, tags: { isFull: false } },
       dateSort : DateSort.CreatedDescending,
     });
 

--- a/src/git-server/ref-sync.ts
+++ b/src/git-server/ref-sync.ts
@@ -68,9 +68,10 @@ export function createRefSyncer(options: RefSyncOptions): OnPushComplete {
     // Read current git refs from the bare repository.
     const gitRefs = await readGitRefs(repoPath);
 
-    // Query existing DWN ref records for this repo.
-    // The parentContextId links ref records to the repo context via $ref.
-    const { records: existingRecords } = await refs.records.query('repo/ref' as any);
+    // Query existing DWN ref records scoped to this repo.
+    const { records: existingRecords } = await refs.records.query('repo/ref' as any, {
+      filter: { contextId: repoContextId },
+    });
 
     // Build a map of existing DWN refs: name → { record, target }.
     const existingMap = new Map<string, { record: any; target: string }>();


### PR DESCRIPTION
## Summary

- **Fix cross-repo sync interference**: Ref sync (`ref-sync.ts`) and bundle sync (`bundle-sync.ts`) were querying ALL records in the DWN without scoping to the repo's `contextId`. When multiple repos exist under one DID, this caused the bundle syncer to see another repo's tip commit and attempt invalid incremental bundles. Both queries now include `contextId: repoContextId` in their filters.
- **Fix existing e2e bundle restore tests**: Suites 2 (bundle round-trip) and 4 (profile-based) now pass `repoContextId` to `restoreFromBundles()`, ensuring scoped restores.
- **Add multi-repo e2e test suite**: New 5-test suite that creates two repos under one DID, pushes distinct content to each, verifies ref isolation, verifies bundle isolation, and performs a cold-start restore of both repos from scoped DWN bundles — proving the full multi-repo architecture works end-to-end.

## Verification

- `bun run build` — zero errors
- `bun run lint` — zero warnings
- `bun test .spec.ts` — 920 pass, 0 fail, 9 skip