### PR TITLE
feat: enable DWN sync, populate dwnEndpoints, and republish did:dht

### DIFF
--- a/.changeset/dwn-sync-endpoints.md
+++ b/.changeset/dwn-sync-endpoints.md
@@ -1,0 +1,5 @@
+---
+"@enbox/gitd": minor
+---
+
+Enable DWN sync and populate DWN endpoints in repo records. `connectAgent` now accepts a `sync` option (defaults to `'off'` for one-shot commands, `'30s'` for long-running commands like `serve`). Controlled via `GITD_SYNC` env var or `--sync`/`--no-sync` flags. `gitd init` auto-populates `dwnEndpoints` from the DID document's `DecentralizedWebNode` service, overridable with `--dwn-endpoint` flag or `GITD_DWN_ENDPOINT` env. `gitd serve` ensures all repo records have current DWN and git endpoints at startup, and periodically republishes `did:dht` documents to keep them alive on the DHT network.

--- a/src/git-server/did-service.ts
+++ b/src/git-server/did-service.ts
@@ -4,6 +4,9 @@
  * Adds or updates a `GitTransport` service entry in a DID document,
  * advertising the git smart HTTP endpoint for the `git-remote-did` helper.
  *
+ * Also provides a helper to read the DWN endpoint(s) from the DID
+ * document's `DecentralizedWebNode` service entry.
+ *
  * This module works with the agent's DID API to persist and publish
  * service updates. For `did:dht`, the updated document is republished
  * to the DHT network.
@@ -13,7 +16,19 @@
 
 import type { Web5 } from '@enbox/api';
 
+import { DidDht } from '@enbox/dids';
+
 import { GIT_TRANSPORT_SERVICE_TYPE } from '../git-remote/service.js';
+
+/** DID service type for Decentralized Web Nodes. */
+const DWN_SERVICE_TYPE = 'DecentralizedWebNode';
+
+/**
+ * Default interval for periodic DID DHT republishing (1 hour).
+ * The Mainline DHT TTL is ~2 hours; republishing every hour keeps
+ * the record alive with comfortable margin.
+ */
+const DEFAULT_REPUBLISH_INTERVAL_MS = 60 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -74,4 +89,73 @@ export async function registerGitService(web5: Web5, endpoint: string): Promise<
   portableDid.document.service = services;
 
   await agent.did.update({ portableDid });
+}
+
+/**
+ * Read the DWN service endpoint(s) from the agent's DID document.
+ *
+ * Returns an array of endpoint URLs, or an empty array if no
+ * `DecentralizedWebNode` service is found.
+ *
+ * @param web5 - The Web5 instance (provides agent DID document)
+ */
+export function getDwnEndpoints(web5: Web5): string[] {
+  const agent = web5.agent as any;
+  const doc = agent?.agentDid?.document;
+  if (!doc?.service) { return []; }
+
+  const svc = (doc.service as any[]).find(
+    (s) => s.type === DWN_SERVICE_TYPE,
+  );
+  if (!svc) { return []; }
+
+  const ep = svc.serviceEndpoint;
+  if (Array.isArray(ep)) { return ep as string[]; }
+  if (typeof ep === 'string') { return [ep]; }
+  return [];
+}
+
+/**
+ * Start a periodic timer that republishes the agent's DID document
+ * to the DHT network.
+ *
+ * `did:dht` records in the Mainline DHT expire after ~2 hours if not
+ * refreshed.  This function sets up an interval that keeps the record
+ * alive so remote clients can always resolve the DID.
+ *
+ * The first republish happens immediately, then repeats every
+ * `intervalMs` milliseconds (default: 1 hour).
+ *
+ * Only republishes `did:dht` DIDs.  For other methods (e.g. `did:jwk`)
+ * this is a safe no-op.
+ *
+ * @param web5 - The Web5 instance (provides the agent's bearer DID)
+ * @param intervalMs - Republish interval in ms (default: 1 hour)
+ * @returns A cleanup function that stops the timer
+ */
+export function startDidRepublisher(
+  web5: Web5,
+  intervalMs: number = DEFAULT_REPUBLISH_INTERVAL_MS,
+): () => void {
+  const agent = web5.agent as any;
+  const bearerDid = agent?.agentDid;
+
+  if (!bearerDid || !bearerDid.uri?.startsWith('did:dht:')) {
+    // Not a did:dht — nothing to republish.
+    return (): void => {};
+  }
+
+  const republish = async (): Promise<void> => {
+    try {
+      await DidDht.publish({ did: bearerDid });
+    } catch (err) {
+      console.warn(`DID republish failed: ${(err as Error).message}`);
+    }
+  };
+
+  // Publish immediately on startup, then periodically.
+  void republish();
+  const timer = setInterval(() => void republish(), intervalMs);
+
+  return (): void => { clearInterval(timer); };
 }


### PR DESCRIPTION
## Summary

- **DWN Sync** (#37): Adds `--sync <interval>` flag and `GITD_SYNC` env var to control DWN sync interval. Long-running commands (`serve`, `web`, `daemon`, `indexer`, `github-api`, `shim`) default to `30s` sync; one-shot commands default to `off`. The `--no-sync` flag disables sync explicitly.
- **DWN Endpoints** (#39): `gitd init` now accepts `--dwn-endpoint <url>` (or `GITD_DWN_ENDPOINT` env var) and auto-populates `dwnEndpoints` from the DID document's `DecentralizedWebNode` service. `gitd serve` ensures all repo records have up-to-date `dwnEndpoints` and `gitEndpoints` at startup.
- **DID DHT Republishing**: `startDidRepublisher()` periodically re-publishes `did:dht` records (default 1h interval) to prevent DHT expiry (~2h TTL). Starts on `serve`, stops on SIGINT. No-ops for non-`did:dht` DIDs.

## Files Changed

| File | Change |
|------|--------|
| `src/cli/agent.ts` | Added `SyncInterval` type, `sync` option to `ConnectOptions` |
| `src/cli/commands/init.ts` | `--dwn-endpoint` flag, `GITD_DWN_ENDPOINT` env, auto-populate from DID doc |
| `src/cli/commands/serve.ts` | Populate `dwnEndpoints`/`gitEndpoints` on repos at startup, start/stop DID republisher |
| `src/cli/main.ts` | Sync interval resolution (long-running vs one-shot), updated help text |
| `src/git-server/did-service.ts` | Added `getDwnEndpoints()` and `startDidRepublisher()` |
| `tests/cli.spec.ts` | 5 new tests covering endpoint population, sync options, and republisher |
| `.changeset/dwn-sync-endpoints.md` | Minor version bump |

## Checks

- `bun run build` — zero errors
- `bun run lint` — zero warnings
- `bun test .spec.ts` — 925 pass, 0 fail, 9 skip

Closes #37, closes #39