### PR TITLE
feat: wire up provider-auth-v0 DWN registration with token persistence

### DIFF
--- a/.changeset/provider-auth-registration.md
+++ b/.changeset/provider-auth-registration.md
@@ -1,0 +1,5 @@
+---
+'@enbox/gitd': minor
+---
+
+Wire up provider-auth-v0 DWN registration so the agent can authenticate with DWN servers that require it. Registration tokens are cached on disk and refreshed automatically when they expire.


### PR DESCRIPTION
## Summary

- Wire up the SDK's `provider-auth-v0` registration flow so `connectAgent()` can authenticate with DWN servers that require it (e.g. `enbox-dwn.fly.dev` which requires `provider-auth-v0` instead of PoW)
- The Enbox DWN authorize endpoint returns `{ code, state }` directly via JSON (no interactive browser flow), so `handleProviderAuth()` simply fetches the URL and returns the code
- Registration tokens are cached to `~/.enbox/profiles/<name>/registration-tokens.json` and reused across sessions; the SDK handles token refresh automatically when they expire
- Both profile-based and legacy connect paths now pass the `registration` option to `Web5.connect()`

## Files Changed

| File | Change |
|------|--------|
| `src/cli/agent.ts` | Added `handleProviderAuth()`, token load/save helpers, `registration` option in both `Web5.connect()` calls |
| `tests/cli.spec.ts` | 3 new tests for token persistence and module exports |
| `.changeset/provider-auth-registration.md` | Minor version bump |

## Checks

- `bun run build` — zero errors
- `bun run lint` — zero warnings
- `bun test .spec.ts` — 928 pass, 0 fail, 9 skip