### PR TITLE
fix: store bare repos under profile directory and print post-init instructions

### DIFF
--- a/.changeset/repos-path-post-init.md
+++ b/.changeset/repos-path-post-init.md
@@ -1,0 +1,5 @@
+---
+'@enbox/gitd': minor
+---
+
+Store bare git repos under the profile directory (~/.enbox/profiles/<name>/repos/) instead of CWD-relative ./repos, and print post-init instructions showing how to set up a git working tree and push.

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -51,6 +51,8 @@ import { ForgeWikiProtocol } from '../wiki.js';
 /** Context returned by `connectAgent()` — provides typed protocol handles. */
 export type AgentContext = {
   did : string;
+  /** Active profile name, or `undefined` when running in legacy (CWD) mode. */
+  profileName? : string;
   repo : TypedWeb5<typeof ForgeRepoProtocol.definition, ForgeRepoSchemaMap>;
   refs : TypedWeb5<typeof ForgeRefsProtocol.definition, ForgeRefsSchemaMap>;
   issues : TypedWeb5<typeof ForgeIssuesProtocol.definition, ForgeIssuesSchemaMap>;

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -9,9 +9,9 @@
 
 import type { AgentContext } from '../agent.js';
 
-import { flagValue } from '../flags.js';
 import { getDwnEndpoints } from '../../git-server/did-service.js';
 import { GitBackend } from '../../git-server/git-backend.js';
+import { flagValue, resolveReposPath } from '../flags.js';
 
 // ---------------------------------------------------------------------------
 // Command
@@ -21,7 +21,7 @@ export async function initCommand(ctx: AgentContext, args: string[]): Promise<vo
   const name = args[0];
   const description = flagValue(args, '--description') ?? flagValue(args, '-d');
   const branch = flagValue(args, '--branch') ?? flagValue(args, '-b') ?? 'main';
-  const reposPath = flagValue(args, '--repos') ?? process.env.GITD_REPOS ?? './repos';
+  const reposPath = resolveReposPath(args, ctx.profileName);
   const dwnEndpointFlag = flagValue(args, '--dwn-endpoint') ?? process.env.GITD_DWN_ENDPOINT;
 
   if (!name) {
@@ -71,6 +71,23 @@ export async function initCommand(ctx: AgentContext, args: string[]): Promise<vo
   console.log(`  Record ID: ${record.id}`);
   console.log(`  Context:   ${record.contextId}`);
   console.log(`  Git path:  ${gitPath}`);
+  console.log('');
+  console.log('Next steps — push an existing repository:');
+  console.log('');
+  console.log(`  git remote add origin did::${ctx.did}/${name}`);
+  console.log(`  git push -u origin ${branch}`);
+  console.log('');
+  console.log('Or start from scratch:');
+  console.log('');
+  console.log('  git init');
+  console.log(`  git remote add origin did::${ctx.did}/${name}`);
+  console.log('  git add .');
+  console.log('  git commit -m "initial commit"');
+  console.log(`  git push -u origin ${branch}`);
+  console.log('');
+  console.log('To serve this repo:');
+  console.log('');
+  console.log('  gitd serve');
 }
 
 

--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -37,7 +37,7 @@ import { getRepoContext } from '../repo-context.js';
 import { getRepoContextId } from '../repo-context.js';
 import { GitBackend } from '../../git-server/git-backend.js';
 import { readGitRefs } from '../../git-server/ref-sync.js';
-import { flagValue, hasFlag } from '../flags.js';
+import { hasFlag, resolveReposPath } from '../flags.js';
 import { readFile, unlink } from 'node:fs/promises';
 import { spawn, spawnSync } from 'node:child_process';
 
@@ -342,19 +342,9 @@ function prependAuthor(body: string, ghLogin: string): string {
 // migrate all
 // ---------------------------------------------------------------------------
 
-/**
- * Resolve the repos base path from CLI flags, environment, or default.
- *
- * Priority: `--repos <path>` > `GITD_REPOS` env > `./repos` (same default
- * as `gitd serve`).
- */
-function resolveReposPath(args: string[]): string {
-  return flagValue(args, '--repos') ?? process.env.GITD_REPOS ?? './repos';
-}
-
 async function migrateAll(ctx: AgentContext, args: string[]): Promise<void> {
   const { owner, repo } = resolveGhRepo(args);
-  const reposPath = resolveReposPath(args);
+  const reposPath = resolveReposPath(args, ctx.profileName);
   const skipGit = hasFlag(args, '--no-git');
   const slug = `${owner}/${repo}`;
 
@@ -408,7 +398,7 @@ async function migrateAll(ctx: AgentContext, args: string[]): Promise<void> {
 
 async function migrateRepo(ctx: AgentContext, args: string[]): Promise<void> {
   const { owner, repo } = resolveGhRepo(args);
-  const reposPath = resolveReposPath(args);
+  const reposPath = resolveReposPath(args, ctx.profileName);
   const skipGit = hasFlag(args, '--no-git');
   try {
     await migrateRepoInner(ctx, owner, repo);

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -31,7 +31,7 @@ import { createPushAuthenticator } from '../../git-server/auth.js';
 import { createRefSyncer } from '../../git-server/ref-sync.js';
 import { getRepoContext } from '../repo-context.js';
 import { restoreFromBundles } from '../../git-server/bundle-restore.js';
-import { flagValue, parsePort } from '../flags.js';
+import { flagValue, parsePort, resolveReposPath } from '../flags.js';
 import {
   getDwnEndpoints,
   registerGitService,
@@ -44,7 +44,7 @@ import {
 
 export async function serveCommand(ctx: AgentContext, args: string[]): Promise<void> {
   const port = parsePort(flagValue(args, '--port') ?? process.env.GITD_PORT ?? '9418');
-  const basePath = flagValue(args, '--repos') ?? process.env.GITD_REPOS ?? './repos';
+  const basePath = resolveReposPath(args, ctx.profileName);
   const pathPrefix = flagValue(args, '--prefix') ?? process.env.GITD_PREFIX;
   const publicUrl = flagValue(args, '--public-url') ?? process.env.GITD_PUBLIC_URL;
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -209,7 +209,7 @@ function printUsage(): void {
   console.log('  GITD_PASSWORD      vault password (prompted if not set)');
   console.log('  GITD_PORT          server port for `serve` (default: 9418)');
   console.log('  GITD_WEB_PORT      web UI port for `web` (default: 8080)');
-  console.log('  GITD_REPOS         base path for bare repos (default: ./repos)');
+  console.log('  GITD_REPOS         base path for bare repos (default: ~/.enbox/profiles/<name>/repos/)');
   console.log('  GITD_SYNC          DWN sync interval: off|5s|30s|1m (default: 30s for serve, off otherwise)');
   console.log('  GITD_DWN_ENDPOINT  DWN endpoint URL for repo records');
   console.log('  GITD_INDEXER_PORT      indexer API port (default: 8090)');
@@ -349,6 +349,7 @@ async function main(): Promise<void> {
   const sync = noSync ? 'off' : (syncFlag ?? syncEnv ?? syncDefault);
 
   const ctx = await connectAgent({ password, dataPath, sync: sync as any });
+  ctx.profileName = profileName ?? undefined;
 
   switch (command) {
     case 'init':

--- a/src/profiles/config.ts
+++ b/src/profiles/config.ts
@@ -10,6 +10,7 @@
  *     config.json               Global config (this module)
  *     profiles/
  *       <name>/DATA/AGENT/...   Per-profile Web5 agent stores
+ *       <name>/repos/...        Per-profile bare git repos
  *
  * @module
  */
@@ -41,6 +42,11 @@ export function profilesDir(): string {
 /** Path to a specific profile's agent data directory. */
 export function profileDataPath(name: string): string {
   return join(profilesDir(), name, 'DATA', 'AGENT');
+}
+
+/** Path to a specific profile's bare git repos directory. */
+export function profileReposPath(name: string): string {
+  return join(profilesDir(), name, 'repos');
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Bare repos now default to `~/.enbox/profiles/<name>/repos/`** instead of `./repos` (CWD-relative). This means repos follow the identity profile, not the working directory. Running `gitd init` from a project folder no longer dumps server-side bare repo data into the project tree.
- **Post-init instructions** are printed after `gitd init`, showing the user how to add a DID remote, push, and start serving — similar to GitHub's "push an existing repository" flow.
- **Centralized `resolveReposPath()`** with priority chain: `--repos` flag > `GITD_REPOS` env > profile path > `./repos` fallback. Replaces duplicated logic across init, serve, and migrate.

## Files Changed

| File | Change |
|------|--------|
| `src/profiles/config.ts` | Added `profileReposPath()`, updated storage layout comment |
| `src/cli/flags.ts` | Added centralized `resolveReposPath(args, profileName?)` |
| `src/cli/agent.ts` | Added `profileName?` to `AgentContext` type |
| `src/cli/main.ts` | Set `ctx.profileName` after connect, updated help text |
| `src/cli/commands/init.ts` | Use `resolveReposPath()`, print post-init instructions |
| `src/cli/commands/serve.ts` | Use `resolveReposPath()` |
| `src/cli/commands/migrate.ts` | Use centralized `resolveReposPath()`, removed local duplicate |
| `tests/cli.spec.ts` | 6 new tests for path resolution and post-init output |
| `.changeset/repos-path-post-init.md` | Minor version bump |

## Checks

- `bun run build` — zero errors
- `bun run lint` — zero warnings
- `bun test .spec.ts` — 934 pass, 0 fail, 9 skip

Closes #43