### PR TITLE
fix: perform DWN registration directly in profile mode, remove DATA/ dir leak

### DIFF
--- a/.changeset/fix-agent-registration.md
+++ b/.changeset/fix-agent-registration.md
@@ -1,0 +1,5 @@
+---
+'@enbox/gitd': patch
+---
+
+Fix DWN registration in profile mode and remove spurious DATA/ directory creation. The SDK ignores the `registration` option when an explicit agent is passed, so registration is now performed directly before `Web5.connect()`.


### PR DESCRIPTION
## Summary

- **DWN registration was silently broken in profile mode.** The SDK's `Web5.connect()` only processes the `registration` option inside `if (agent === undefined)`. When an explicit agent is passed (profile mode), registration was silently skipped — meaning DID tenants were never actually registered with the DWN server.
- **Fixed by calling `registerWithDwnServers()` directly** before `Web5.connect()`, using `DwnRegistrar` from `@enbox/dwn-clients`. This handles both `provider-auth-v0` (token-based) and PoW registration, with token caching to disk.
- **Removed spurious `DATA/` directory creation.** The legacy path constructed `join(process.cwd(), 'DATA', 'AGENT')` and called `saveRegistrationTokens()` which created `DATA/` in the user's working directory even when running with a profile. This code has been removed.
- **Simplified the legacy (non-profile) connect path** — just passes `{ password, sync }` to `Web5.connect()` without wiring up registration callbacks (the SDK handles it internally in that path).

## Root Cause

`@enbox/api/src/web5.ts` line 422-690: the entire registration + sync block is inside `if (agent === undefined)`. When `connectAgent()` passes an explicit `agent` to `Web5.connect()`, the SDK wraps it in a `Web5` object and returns immediately — no registration, no sync setup.

## Files Changed

| File | Change |
|------|--------|
| `src/cli/agent.ts` | Added `registerWithDwnServers()`, `agentDwnEndpoints()`. Removed `registration` option from `Web5.connect()` calls. Removed legacy `DATA/` path code. |
| `.changeset/fix-agent-registration.md` | Patch bump |

## Checks

- `bun run build` — zero errors
- `bun run lint` — zero warnings
- `bun test .spec.ts` — 934 pass, 0 fail, 9 skip