### PR TITLE
feat: add GITD_ALLOW_PRIVATE env var to bypass SSRF for local dev

### DIFF
--- a/.changeset/ssrf-dev-bypass.md
+++ b/.changeset/ssrf-dev-bypass.md
@@ -1,0 +1,5 @@
+---
+'@enbox/gitd': patch
+---
+
+Add `GITD_ALLOW_PRIVATE=1` env var to bypass SSRF protection for local development with `did:web:localhost` and other local DID methods. Prints a warning to stderr when active. Also exports `assertNotPrivateUrl` and adds comprehensive SSRF tests replacing the previous stub.


### PR DESCRIPTION
## Summary

- Add `GITD_ALLOW_PRIVATE=1` env var to bypass SSRF protection in `git-remote-did`'s resolver, enabling local development with `did:web:localhost` and other local DID methods
- Print a visible warning to stderr on first use: `"WARNING: SSRF protection disabled (GITD_ALLOW_PRIVATE=1) — do not use in production"`
- Export `assertNotPrivateUrl` for direct testing
- Replace the previous stub test with 14 real tests covering all blocked IP ranges (localhost, 127.x, 10.x, 172.16-31.x, 192.168.x, 169.254.x, 0.x, ::1, fc/fd, fe80) plus public URL allowance, invalid URL rejection, bypass behavior, and strict `"1"` value checking

## Usage

```bash
# Clone from a local DID resolver
GITD_ALLOW_PRIVATE=1 git clone did::web:localhost/my-repo

# Only "1" activates the bypass — "true", "0", etc. do not
GITD_ALLOW_PRIVATE=true git clone did::web:localhost/my-repo  # still blocked
```

## Verification

- `bun run build` — zero TypeScript errors
- `bun run lint` — zero ESLint warnings/errors
- `bun test .spec.ts` — 948 pass, 0 fail, 9 skip

Closes #42