### PR TITLE
feat: complete gitd setup with credential helper, --check, --uninstall

### DIFF
--- a/.changeset/setup-credential-helper.md
+++ b/.changeset/setup-credential-helper.md
@@ -1,0 +1,5 @@
+---
+'@enbox/gitd': patch
+---
+
+Complete `gitd setup` command: configure git credential helper (`git config --global credential.helper`), add `--check` for dry-run validation, and `--uninstall` to reverse configuration.

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -116,7 +116,7 @@ function printUsage(): void {
   console.log('  auth list                                   List all profiles');
   console.log('  auth use <profile> [--global]               Set active profile');
   console.log('');
-  console.log('  setup                                       Configure git for DID-based remotes');
+  console.log('  setup [--check | --uninstall]                Configure git for DID-based remotes');
   console.log('  clone <did>/<repo>                          Clone a repository via DID');
   console.log('  init <name>                                 Create a repo record + bare git repo');
   console.log('  serve [--port <port>]                       Start the git transport server');

--- a/tests/cli.spec.ts
+++ b/tests/cli.spec.ts
@@ -741,13 +741,28 @@ describe('gitd CLI commands', () => {
   // =========================================================================
 
   describe('setup', () => {
-    it('should print setup instructions', async () => {
+    it('should print next steps on install', async () => {
       const { setupCommand } = await import('../src/cli/commands/setup.js');
       // Use a test-specific bin dir to avoid modifying the user's system.
       const logs = await captureLog(() => setupCommand(['--bin-dir', '__TESTDATA__/cli-bin']));
-      // Even if sources don't exist (not built at test time), setup should print messages.
       const allOutput = logs.join('\n');
-      expect(allOutput).toContain('clone repos via DID');
+      expect(allOutput).toContain('Next steps');
+      expect(allOutput).toContain('credential.helper');
+    });
+
+    it('--check should report status of binaries and credential helper', async () => {
+      const { setupCommand } = await import('../src/cli/commands/setup.js');
+      const logs = await captureLog(() => setupCommand(['--check', '--bin-dir', '__TESTDATA__/cli-bin']));
+      const allOutput = logs.join('\n');
+      expect(allOutput).toContain('Checking gitd setup');
+      expect(allOutput).toContain('git-remote-did');
+    });
+
+    it('--uninstall should remove symlinks', async () => {
+      const { setupCommand } = await import('../src/cli/commands/setup.js');
+      const logs = await captureLog(() => setupCommand(['--uninstall', '--bin-dir', '__TESTDATA__/cli-bin']));
+      const allOutput = logs.join('\n');
+      expect(allOutput).toContain('Removing gitd setup');
     });
   });
 


### PR DESCRIPTION
## Summary

- Configure `credential.helper` globally via `git config --global` during `gitd setup`, wiring in the `git-remote-did-credential` binary for DID-signed push auth
- Add `--check` flag for dry-run validation: reports status of symlinks, PATH, and credential helper without modifying anything
- Add `--uninstall` flag to reverse all configuration (removes symlinks and credential helper config)
- Detect and warn about existing conflicting credential helpers
- Print structured next-steps guidance after install

## Usage

```bash
gitd setup                    # Install symlinks + configure credential helper
gitd setup --check            # Validate current setup
gitd setup --uninstall        # Remove configuration
gitd setup --bin-dir ~/bin    # Custom bin directory
```

## Verification

- `bun run build` — zero TypeScript errors
- `bun run lint` — zero ESLint warnings/errors
- `bun test .spec.ts` — 936 pass, 0 fail, 9 skip

Closes #41