### PR TITLE
test: verify git-server and git-remote sub-path exports

### DIFF
--- a/.changeset/export-modules-test.md
+++ b/.changeset/export-modules-test.md
@@ -1,0 +1,5 @@
+---
+'@enbox/gitd': patch
+---
+
+Add exports test verifying all public symbols from `@enbox/gitd/git-server` and `@enbox/gitd/git-remote` sub-paths

--- a/tests/exports.spec.ts
+++ b/tests/exports.spec.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests that all public sub-path exports are accessible.
+ *
+ * These tests import from the barrel `index.ts` files (not individual
+ * source modules) to verify that `@enbox/gitd/git-server` and
+ * `@enbox/gitd/git-remote` expose the expected public API.
+ */
+import { describe, expect, it } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// git-server
+// ---------------------------------------------------------------------------
+
+describe('@enbox/gitd/git-server exports', () => {
+  it('should export auth utilities', async () => {
+    const mod = await import('../src/git-server/index.js');
+    expect(mod.DID_AUTH_USERNAME).toBe('did-auth');
+    expect(typeof mod.createPushTokenPayload).toBe('function');
+    expect(typeof mod.encodePushToken).toBe('function');
+    expect(typeof mod.decodePushToken).toBe('function');
+    expect(typeof mod.formatAuthPassword).toBe('function');
+    expect(typeof mod.parseAuthPassword).toBe('function');
+    expect(typeof mod.createPushAuthenticator).toBe('function');
+  });
+
+  it('should export git backend', async () => {
+    const mod = await import('../src/git-server/index.js');
+    expect(typeof mod.GitBackend).toBe('function');
+  });
+
+  it('should export HTTP handler and server', async () => {
+    const mod = await import('../src/git-server/index.js');
+    expect(typeof mod.createGitHttpHandler).toBe('function');
+    expect(typeof mod.createGitServer).toBe('function');
+  });
+
+  it('should export ref sync utilities', async () => {
+    const mod = await import('../src/git-server/index.js');
+    expect(typeof mod.createRefSyncer).toBe('function');
+    expect(typeof mod.readGitRefs).toBe('function');
+  });
+
+  it('should export bundle sync utilities', async () => {
+    const mod = await import('../src/git-server/index.js');
+    expect(typeof mod.createBundleSyncer).toBe('function');
+    expect(typeof mod.createFullBundle).toBe('function');
+    expect(typeof mod.createIncrementalBundle).toBe('function');
+    expect(typeof mod.restoreFromBundles).toBe('function');
+  });
+
+  it('should export DID service utilities', async () => {
+    const mod = await import('../src/git-server/index.js');
+    expect(typeof mod.registerGitService).toBe('function');
+    expect(typeof mod.getDwnEndpoints).toBe('function');
+    expect(typeof mod.startDidRepublisher).toBe('function');
+  });
+
+  it('should export push authorizer and signature verifier', async () => {
+    const mod = await import('../src/git-server/index.js');
+    expect(typeof mod.createDwnPushAuthorizer).toBe('function');
+    expect(typeof mod.createDidSignatureVerifier).toBe('function');
+  });
+
+  it('should export exactly the expected number of symbols', async () => {
+    const mod = await import('../src/git-server/index.js');
+    const exported = Object.keys(mod);
+    // 19 functions + 1 constant + 1 class = 21 runtime exports
+    // (types are erased at runtime)
+    expect(exported.length).toBe(21);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// git-remote
+// ---------------------------------------------------------------------------
+
+describe('@enbox/gitd/git-remote exports', () => {
+  it('should export credential helper utilities', async () => {
+    const mod = await import('../src/git-remote/index.js');
+    expect(typeof mod.generatePushCredentials).toBe('function');
+    expect(typeof mod.parseCredentialRequest).toBe('function');
+    expect(typeof mod.formatCredentialResponse).toBe('function');
+  });
+
+  it('should export credential cache utilities', async () => {
+    const mod = await import('../src/git-remote/index.js');
+    expect(typeof mod.cacheKey).toBe('function');
+    expect(typeof mod.getCachedCredential).toBe('function');
+    expect(typeof mod.storeCachedCredential).toBe('function');
+    expect(typeof mod.eraseCachedCredential).toBe('function');
+  });
+
+  it('should export DID URL parser', async () => {
+    const mod = await import('../src/git-remote/index.js');
+    expect(typeof mod.parseDidUrl).toBe('function');
+  });
+
+  it('should export endpoint resolution', async () => {
+    const mod = await import('../src/git-remote/index.js');
+    expect(typeof mod.resolveGitEndpoint).toBe('function');
+    expect(typeof mod.assertNotPrivateUrl).toBe('function');
+  });
+
+  it('should export git transport service utilities', async () => {
+    const mod = await import('../src/git-remote/index.js');
+    expect(mod.GIT_TRANSPORT_SERVICE_TYPE).toBe('GitTransport');
+    expect(typeof mod.createGitTransportService).toBe('function');
+    expect(typeof mod.isGitTransportService).toBe('function');
+    expect(typeof mod.getGitTransportServices).toBe('function');
+  });
+
+  it('should export exactly the expected number of symbols', async () => {
+    const mod = await import('../src/git-remote/index.js');
+    const exported = Object.keys(mod);
+    // 12 functions + 2 constants = 14 runtime exports
+    // (types are erased at runtime)
+    expect(exported.length).toBe(14);
+  });
+
+  it('should NOT export CLI entry points', async () => {
+    const mod = await import('../src/git-remote/index.js') as Record<string, unknown>;
+    // The main.ts and credential-main.ts entry points should not be
+    // re-exported through the barrel.
+    expect(mod.main).toBeUndefined();
+    expect(mod.connectForCredentials).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Add `tests/exports.spec.ts` that verifies all public symbols exported from `@enbox/gitd/git-server` (21 symbols) and `@enbox/gitd/git-remote` (14 symbols) sub-paths
- Confirms barrel files correctly re-export all modules
- Verifies CLI entry points (`main.ts`, `credential-main.ts`) are **not** leaked through the barrel
- Locks down the symbol count so accidental additions/removals are caught

## Context

Issue #2 requested exporting these modules for downstream use. The sub-path exports (`./git-server`, `./git-remote`) and barrel files were already wired up across previous PRs. This PR adds the missing test coverage to lock down the public API surface.

## Checks

- `bun run build` — zero errors
- `bun run lint` — zero warnings
- `bun test .spec.ts` — 989 pass, 9 skip, 0 fail

Closes #2