### PR TITLE
fix: eliminate CWD-relative path leaks

### DIFF
--- a/.changeset/fix-path-leaks.md
+++ b/.changeset/fix-path-leaks.md
@@ -1,0 +1,5 @@
+---
+'@enbox/gitd': patch
+---
+
+Eliminate CWD-relative path leaks: RESOLVERCACHE/, DATA/AGENT/, and ./repos no longer created in the working directory. All paths now resolve to ~/.enbox/profiles/default/ when no named profile is active.

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -75,10 +75,9 @@ export function parsePort(value: string): number {
  *   1. `--repos <path>` CLI flag
  *   2. `GITD_REPOS` environment variable
  *   3. Profile-based path: `~/.enbox/profiles/<name>/repos/`
- *   4. Fallback: `./repos` (CWD-relative, legacy behaviour)
+ *   4. Fallback: `~/.enbox/profiles/default/repos/`
  *
- * When a profile is active, repos are stored alongside the agent data
- * so they follow the identity rather than the working directory.
+ * All paths resolve to the home directory — no CWD-relative paths.
  */
 export function resolveReposPath(
   args: string[],
@@ -92,5 +91,7 @@ export function resolveReposPath(
 
   if (profileName) { return profileReposPath(profileName); }
 
-  return './repos';
+  // No profile — fall back to a well-known home directory path rather
+  // than polluting the current working directory.
+  return profileReposPath('default');
 }

--- a/src/git-remote/credential-main.ts
+++ b/src/git-remote/credential-main.ts
@@ -196,18 +196,17 @@ function handleErase(request: { protocol?: string; host?: string; path?: string 
  *
  * Resolves the active profile (env, git config, global default, or single
  * fallback) and connects using the profile's agent data path.  Falls back
- * to the legacy CWD-relative `DATA/AGENT` path when no profile exists.
+ * to `~/.enbox/profiles/default/DATA/AGENT` when no profile exists.
  */
 async function connectForCredentials(
   password: string,
 ): Promise<{ did: string; bearerDid: BearerDid }> {
   // Resolve profile (env, git config, global default, single fallback).
-  // When a profile exists, the agent lives at ~/.enbox/profiles/<name>/DATA/AGENT.
-  // Otherwise, fall back to the CWD-relative default path (legacy).
+  // Always use an absolute path — never fall back to CWD.
   const profileName = resolveProfile();
-  const dataPath = profileName ? profileDataPath(profileName) : undefined;
+  const dataPath = profileDataPath(profileName ?? 'default');
 
-  const agent = await Web5UserAgent.create(dataPath ? { dataPath } : undefined);
+  const agent = await Web5UserAgent.create({ dataPath });
   await agent.start({ password });
 
   const identities = await agent.identity.list();

--- a/tests/cli.spec.ts
+++ b/tests/cli.spec.ts
@@ -380,10 +380,13 @@ describe('gitd CLI commands', () => {
       }
     });
 
-    it('should fall back to ./repos when no profile', () => {
+    it('should fall back to ~/.enbox/profiles/default/repos without a profile', () => {
       const { resolveReposPath } = require('../src/cli/flags.js');
       const result = resolveReposPath([]);
-      expect(result).toBe('./repos');
+      expect(result).toContain('profiles');
+      expect(result).toContain('default');
+      expect(result).toContain('repos');
+      expect(result).not.toBe('./repos');
     });
   });
 


### PR DESCRIPTION
## Summary

- **RESOLVERCACHE/** no longer created in the working directory — `createSqliteDwnApi()` now constructs a `UniversalResolver` with a `DidResolverCacheLevel` scoped to `<dataPath>/DWN_RESOLVERCACHE`
- **DATA/AGENT/** no longer created in CWD — `connectAgent()` always resolves `dataPath` to `~/.enbox/profiles/default/DATA/AGENT` when no named profile is active (removes the legacy `Web5.connect()` code path entirely)
- **./repos/** no longer created in CWD — `resolveReposPath()` falls back to `profileReposPath('default')` instead of `'./repos'`
- **credential-main** uses `profileDataPath('default')` fallback instead of `undefined`

## Testing

- 7 new tests in `tests/profiles.spec.ts` verifying resolver cache scoping and `DATA/AGENT` isolation
- Updated `resolveReposPath` test in `tests/cli.spec.ts` to match new behaviour
- `bun run build` — zero errors
- `bun run lint` — zero warnings
- `bun test .spec.ts` — 996 pass, 0 fail