### PR TITLE
feat: gitd init sets up local working repo with origin remote

### DIFF
--- a/.changeset/init-local-repo.md
+++ b/.changeset/init-local-repo.md
@@ -1,0 +1,5 @@
+---
+'@enbox/gitd': minor
+---
+
+`gitd init` now initializes a local git repo in the current directory and adds the `origin` remote automatically, matching git/gh conventions. Pass `--no-local` to skip local setup and only create the server-side bare repo + DWN record.

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ dist/
 coverage/
 __TESTDATA__/
 DATA/
+RESOLVERCACHE/
 *.tsbuildinfo

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,17 +1,28 @@
 /**
- * `gitd init` — create a forge repository record on the local DWN
- * and initialize a bare git repository on the filesystem.
+ * `gitd init` — create a forge repository on the local DWN, initialize a
+ * bare git repository for the server, and set up the local working
+ * directory with the remote pre-configured.
  *
- * Usage: gitd init <name> [--description <text>] [--branch <name>] [--repos <path>]
+ * Usage: gitd init <name> [--description <text>] [--branch <name>]
+ *                         [--repos <path>] [--dwn-endpoint <url>]
+ *                         [--no-local]
+ *
+ * By default the command also initializes a git repository in the current
+ * working directory (if one does not already exist) and adds an `origin`
+ * remote pointing at `did::<did>/<name>`.  Pass `--no-local` to skip this
+ * step and only create the server-side bare repo + DWN record.
  *
  * @module
  */
+
+import { existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 
 import type { AgentContext } from '../agent.js';
 
 import { getDwnEndpoints } from '../../git-server/did-service.js';
 import { GitBackend } from '../../git-server/git-backend.js';
-import { flagValue, resolveReposPath } from '../flags.js';
+import { flagValue, hasFlag, resolveReposPath } from '../flags.js';
 
 // ---------------------------------------------------------------------------
 // Command
@@ -23,9 +34,10 @@ export async function initCommand(ctx: AgentContext, args: string[]): Promise<vo
   const branch = flagValue(args, '--branch') ?? flagValue(args, '-b') ?? 'main';
   const reposPath = resolveReposPath(args, ctx.profileName);
   const dwnEndpointFlag = flagValue(args, '--dwn-endpoint') ?? process.env.GITD_DWN_ENDPOINT;
+  const skipLocal = hasFlag(args, '--no-local');
 
   if (!name) {
-    console.error('Usage: gitd init <name> [--description <text>] [--branch <name>] [--repos <path>] [--dwn-endpoint <url>]');
+    console.error('Usage: gitd init <name> [--description <text>] [--branch <name>] [--repos <path>] [--dwn-endpoint <url>] [--no-local]');
     process.exit(1);
   }
 
@@ -38,7 +50,7 @@ export async function initCommand(ctx: AgentContext, args: string[]): Promise<vo
     process.exit(1);
   }
 
-  // Initialize the bare git repository on disk.
+  // Initialize the bare git repository on disk (server-side storage).
   const backend = new GitBackend({ basePath: reposPath });
   const gitPath = await backend.initRepo(ctx.did, name);
 
@@ -66,21 +78,42 @@ export async function initCommand(ctx: AgentContext, args: string[]): Promise<vo
     process.exit(1);
   }
 
+  const remoteUrl = `did::${ctx.did}/${name}`;
+
   console.log(`Initialized forge repo "${name}" (branch: ${branch})`);
   console.log(`  DID:       ${ctx.did}`);
   console.log(`  Record ID: ${record.id}`);
   console.log(`  Context:   ${record.contextId}`);
   console.log(`  Git path:  ${gitPath}`);
+
+  // -----------------------------------------------------------------------
+  // Local working directory setup
+  // -----------------------------------------------------------------------
+
+  if (!skipLocal) {
+    const localResult = setupLocalRepo(branch, remoteUrl);
+    console.log('');
+    if (localResult.initialized) {
+      console.log(`Initialized local git repo (branch: ${branch})`);
+    }
+    if (localResult.remoteAdded) {
+      console.log(`Remote "origin" set to ${remoteUrl}`);
+    } else if (localResult.remoteExists) {
+      console.log(`Remote "origin" already exists — skipped.`);
+      console.log(`  To add manually:  git remote add forge ${remoteUrl}`);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Next steps
+  // -----------------------------------------------------------------------
+
   console.log('');
-  console.log('Next steps — push an existing repository:');
+  console.log('Next steps:');
   console.log('');
-  console.log(`  git remote add origin did::${ctx.did}/${name}`);
-  console.log(`  git push -u origin ${branch}`);
-  console.log('');
-  console.log('Or start from scratch:');
-  console.log('');
-  console.log('  git init');
-  console.log(`  git remote add origin did::${ctx.did}/${name}`);
+  if (skipLocal) {
+    console.log(`  git remote add origin ${remoteUrl}`);
+  }
   console.log('  git add .');
   console.log('  git commit -m "initial commit"');
   console.log(`  git push -u origin ${branch}`);
@@ -94,6 +127,61 @@ export async function initCommand(ctx: AgentContext, args: string[]): Promise<vo
   console.log('  gitd serve --public-url https://git.example.com');
   console.log('');
   console.log('See DEPLOY.md for reverse proxy and deployment guidance.');
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type LocalSetupResult = {
+  initialized: boolean;
+  remoteAdded: boolean;
+  remoteExists: boolean;
+};
+
+/**
+ * Initialize a git repo in CWD (if needed) and add the `origin` remote.
+ *
+ * @param branch - Default branch name for `git init -b`.
+ * @param remoteUrl - Remote URL to set as `origin`.
+ * @returns What actions were performed.
+ */
+function setupLocalRepo(branch: string, remoteUrl: string): LocalSetupResult {
+  const result: LocalSetupResult = {
+    initialized  : false,
+    remoteAdded  : false,
+    remoteExists : false,
+  };
+
+  // Initialize a new git repo if CWD is not already one.
+  if (!existsSync('.git')) {
+    const init = spawnSync('git', ['init', '-b', branch], { stdio: 'pipe' });
+    if (init.status !== 0) {
+      const msg = init.stderr?.toString().trim() || 'unknown error';
+      console.error(`Warning: failed to initialize local git repo: ${msg}`);
+      return result;
+    }
+    result.initialized = true;
+  }
+
+  // Check whether an "origin" remote already exists.
+  const remoteCheck = spawnSync('git', ['remote', 'get-url', 'origin'], { stdio: 'pipe' });
+  if (remoteCheck.status === 0) {
+    // Remote already exists — don't overwrite.
+    result.remoteExists = true;
+    return result;
+  }
+
+  // Add the remote.
+  const addRemote = spawnSync('git', ['remote', 'add', 'origin', remoteUrl], { stdio: 'pipe' });
+  if (addRemote.status !== 0) {
+    const msg = addRemote.stderr?.toString().trim() || 'unknown error';
+    console.error(`Warning: failed to add remote: ${msg}`);
+    return result;
+  }
+  result.remoteAdded = true;
+
+  return result;
 }
 
 

--- a/tests/cli.spec.ts
+++ b/tests/cli.spec.ts
@@ -9,9 +9,10 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 
 import { createHash } from 'node:crypto';
 import { gzipSync } from 'node:zlib';
-import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
-import { existsSync, rmSync, writeFileSync } from 'node:fs';
+
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 
 import { Web5 } from '@enbox/api';
 import { Web5UserAgent } from '@enbox/agent';
@@ -407,10 +408,9 @@ describe('gitd CLI commands', () => {
         initCommand(ctx, ['post-init-test', '--repos', REPOS_PATH]),
       );
       expect(logs.some((l) => l.includes('Next steps'))).toBe(true);
-      expect(logs.some((l) => l.includes('git remote add origin'))).toBe(true);
       expect(logs.some((l) => l.includes('git push'))).toBe(true);
       expect(logs.some((l) => l.includes('gitd serve'))).toBe(true);
-      // Should include the DID in the remote URL.
+      // Should include the DID somewhere in the output.
       expect(logs.some((l) => l.includes(ctx.did))).toBe(true);
     });
 
@@ -421,6 +421,56 @@ describe('gitd CLI commands', () => {
       );
       expect(logs.some((l) => l.includes('--public-url'))).toBe(true);
       expect(logs.some((l) => l.includes('DEPLOY.md'))).toBe(true);
+    });
+
+    it('should report origin already exists when run inside a repo with origin', async () => {
+      // Tests run inside the gitd project which already has an origin remote.
+      const { initCommand } = await import('../src/cli/commands/init.js');
+      const logs = await captureLog(() =>
+        initCommand(ctx, ['origin-exists-test', '--repos', REPOS_PATH]),
+      );
+      expect(logs.some((l) => l.includes('origin'))).toBe(true);
+      expect(logs.some((l) => l.includes('already exists'))).toBe(true);
+    });
+
+    it('should print git remote add when --no-local is used', async () => {
+      const { initCommand } = await import('../src/cli/commands/init.js');
+      const logs = await captureLog(() =>
+        initCommand(ctx, ['no-local-test', '--repos', REPOS_PATH, '--no-local']),
+      );
+      expect(logs.some((l) => l.includes('git remote add origin'))).toBe(true);
+      // Should NOT report local repo setup.
+      expect(logs.some((l) => l.includes('Initialized local git repo'))).toBe(false);
+    });
+  });
+
+  describe('init local repo setup', () => {
+    it('should initialize git repo and add remote in a fresh directory', async () => {
+      const { initCommand } = await import('../src/cli/commands/init.js');
+      const absReposPath = resolve(REPOS_PATH);
+      const tmpDir = join(absReposPath, '__local-test');
+      mkdirSync(tmpDir, { recursive: true });
+      const origCwd = process.cwd();
+      try {
+        process.chdir(tmpDir);
+        const logs = await captureLog(() =>
+          initCommand(ctx, ['local-init-test', '--repos', absReposPath]),
+        );
+        expect(logs.some((l) => l.includes('Initialized local git repo'))).toBe(true);
+        expect(logs.some((l) => l.includes('Remote "origin" set to'))).toBe(true);
+        // Verify .git directory was created.
+        expect(existsSync(join(tmpDir, '.git'))).toBe(true);
+        // Verify the remote was added.
+        const remoteCheck = spawnSync('git', ['remote', 'get-url', 'origin'], {
+          cwd   : tmpDir,
+          stdio : 'pipe',
+        });
+        expect(remoteCheck.status).toBe(0);
+        expect(remoteCheck.stdout.toString().trim()).toContain(ctx.did);
+      } finally {
+        process.chdir(origCwd);
+        rmSync(tmpDir, { recursive: true, force: true });
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

- `gitd init <name>` now initializes a git repo in the current directory (if not already one) and adds an `origin` remote pointing at `did::<did>/<name>` — matching how `git init` + `gh repo create` behave
- New `--no-local` flag skips local setup for server-only use cases
- Gracefully handles existing `origin` remote (warns, suggests `forge` as alternative name)
- Adds `RESOLVERCACHE/` to `.gitignore` (leaked by DWN SDK, fixed properly in PR #85)

## Motivation

Previously `gitd init hello` only created a bare repo deep inside `~/.enbox/` and a DWN record, then told the user to manually run `git init`, `git remote add origin`, etc. This was confusing — git users expect `init` to leave them with a ready-to-use repo.

## Testing

- New tests: `--no-local` flag, origin-already-exists detection, fresh-directory init with `.git` + remote verification
- Updated existing post-init instruction tests for new output format
- `bun run build` — zero errors
- `bun run lint` — zero warnings
- `bun test .spec.ts` — 992 pass, 0 fail