### PR TITLE
fix: accept full DID in remote URL (did::did:dht:.../repo)

### DIFF
--- a/.changeset/fix-did-url-parse.md
+++ b/.changeset/fix-did-url-parse.md
@@ -1,0 +1,5 @@
+---
+'@enbox/gitd': patch
+---
+
+Fix `did:` prefix doubling when remote URL contains the full DID (`did::did:dht:.../repo`). The URL parser now accepts both short (`dht:id/repo`) and full (`did:dht:id/repo`) forms.

--- a/src/git-remote/parse-url.ts
+++ b/src/git-remote/parse-url.ts
@@ -3,13 +3,12 @@
  *
  * Supported URL forms (all invoke `git-remote-did <remote> <url>`):
  *
- *   did::dht:abc123                → DID = did:dht:abc123, repo = undefined
- *   did::dht:abc123/my-repo       → DID = did:dht:abc123, repo = my-repo
- *   did://dht:abc123/my-repo      → DID = did:dht:abc123, repo = my-repo
+ *   did::dht:abc123/my-repo            → DID = did:dht:abc123, repo = my-repo
+ *   did::did:dht:abc123/my-repo        → DID = did:dht:abc123, repo = my-repo
+ *   did://dht:abc123/my-repo           → DID = did:dht:abc123, repo = my-repo
  *
- * The double-colon form (`did::<address>`) is recommended because it avoids
- * URL-parsing ambiguity.  Git strips the `did::` prefix and passes
- * `<address>` as the URL argument.
+ * Both `did::dht:abc123` (short) and `did::did:dht:abc123` (full DID) forms
+ * are accepted.  The parser normalizes both to a valid `did:method:id` URI.
  *
  * @module
  */
@@ -45,6 +44,14 @@ export function parseDidUrl(url: string): ParsedDidUrl {
   // Strip did:// prefix if present (the `://` form).
   if (stripped.startsWith('did://')) {
     stripped = stripped.slice('did://'.length);
+  }
+
+  // Strip bare `did:` prefix when the full DID was included in the URL.
+  // This handles `did::did:dht:abc123/repo` where Git passes
+  // `did:dht:abc123/repo` — without this, `did:` would be prepended
+  // again below, producing the invalid `did:did:dht:abc123`.
+  if (stripped.startsWith('did:')) {
+    stripped = stripped.slice('did:'.length);
   }
 
   // At this point, `stripped` is either:

--- a/tests/git-remote.spec.ts
+++ b/tests/git-remote.spec.ts
@@ -63,6 +63,33 @@ describe('parseDidUrl', () => {
     });
   });
 
+  describe('full-DID form (did::did:method:id)', () => {
+    it('should parse did:dht with repo when full DID is in URL', () => {
+      // Git strips "did::" prefix, passes "did:dht:abc123/my-repo"
+      const result = parseDidUrl('did:dht:abc123/my-repo');
+      expect(result.did).toBe('did:dht:abc123');
+      expect(result.repo).toBe('my-repo');
+    });
+
+    it('should parse did:dht without repo when full DID is in URL', () => {
+      const result = parseDidUrl('did:dht:abc123');
+      expect(result.did).toBe('did:dht:abc123');
+      expect(result.repo).toBeUndefined();
+    });
+
+    it('should parse did:web with repo when full DID is in URL', () => {
+      const result = parseDidUrl('did:web:example.com/my-repo');
+      expect(result.did).toBe('did:web:example.com');
+      expect(result.repo).toBe('my-repo');
+    });
+
+    it('should parse a real did:dht identifier with repo', () => {
+      const result = parseDidUrl('did:dht:n783djfui5qr4wrpgsgawzte6dmyp6qfarzarbr9yq1prboryjyy/hello');
+      expect(result.did).toBe('did:dht:n783djfui5qr4wrpgsgawzte6dmyp6qfarzarbr9yq1prboryjyy');
+      expect(result.repo).toBe('hello');
+    });
+  });
+
   describe('did:// form', () => {
     it('should parse did:// URL with repo', () => {
       const result = parseDidUrl('did://dht:abc123/my-repo');


### PR DESCRIPTION
## Summary

- Fix `did:` prefix doubling when the remote URL contains the full DID — `did::did:dht:abc123/repo` was being resolved as `did:did:dht:abc123` (invalid) instead of `did:dht:abc123`
- The URL parser now strips a leading `did:` when the full DID form is present, accepting both `did::dht:id/repo` (short) and `did::did:dht:id/repo` (full) forms
- This was the immediate blocker preventing `git push` after `gitd init`

## Root cause

`gitd init` constructs the remote URL as `did::${ctx.did}/${name}` where `ctx.did` is the full DID (`did:dht:...`). Git strips the `did::` prefix and passes `did:dht:.../repo` to the helper. The parser in `parse-url.ts` unconditionally prepended `did:` to reconstruct the full DID, producing `did:did:dht:...`.

## Testing

- 4 new tests for the full-DID URL form (dht, web, real identifier)
- All existing short-form tests continue to pass
- `bun run build` — zero errors
- `bun run lint` — zero warnings
- `bun test .spec.ts` — 1003 pass, 0 fail