### PR TITLE
feat: rename `gitd patch` to `gitd pr` for familiar UX

### DIFF
--- a/.changeset/rename-patch-to-pr.md
+++ b/.changeset/rename-patch-to-pr.md
@@ -1,0 +1,5 @@
+---
+'@enbox/gitd': minor
+---
+
+Rename `gitd patch` CLI command to `gitd pr` for a familiar GitHub-like UX. The `patch` subcommand is kept as an alias. All user-facing output now says "PR" instead of "patch". Internal protocol names (`repo/patch`, `ForgePatchesProtocol`) are unchanged.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1327,7 +1327,7 @@ The smallest useful forge — repos, issues, patches.
 - [x] **forge-patches**: PR CRUD, revisions, reviews, merge results — protocol definition complete, integration-tested (cross-protocol roles via `$ref`)
 - [x] Integration tests against a real DWN instance — 15 tests covering repo, issues, patches, CI, and role revocation (242 total tests, 738 assertions)
 - [x] **`$ref` wrapping**: all 5 composing protocols updated with `repo: { $ref: 'repo:repo' }` for cross-protocol role composition
-- [x] CLI prototype: `gitd init`, `gitd issue create/list`, `gitd patch create/list`, `gitd whoami` — 12 CLI tests (254 total, 762 assertions)
+- [x] CLI prototype: `gitd init`, `gitd issue create/list`, `gitd pr create/list`, `gitd whoami` — 12 CLI tests (254 total, 762 assertions)
 
 ### Phase 2: Git Transport (complete)
 

--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ gitd issue comment 1 "On it"
 gitd issue close 1
 gitd issue list
 
-# Patches (pull requests)
-gitd patch create "Add feature"
-gitd patch show 1
-gitd patch comment 1 "LGTM"
-gitd patch merge 1
-gitd patch list
+# Pull requests (alias: gitd patch)
+gitd pr create "Add feature"
+gitd pr show 1
+gitd pr comment 1 "LGTM"
+gitd pr merge 1
+gitd pr list
 
 # Releases
 gitd release create v1.0.0

--- a/src/cli/commands/log.ts
+++ b/src/cli/commands/log.ts
@@ -1,7 +1,7 @@
 /**
  * `gitd log` — show recent forge activity.
  *
- * Displays recent issues, patches, and ref updates in reverse chronological
+ * Displays recent issues, PRs, and ref updates in reverse chronological
  * order, giving a unified activity feed for the repository.
  *
  * Usage: gitd log [--limit <n>]
@@ -19,7 +19,7 @@ import { flagValue, resolveRepoName } from '../flags.js';
 // ---------------------------------------------------------------------------
 
 type ActivityEntry = {
-  type : 'issue' | 'patch' | 'ref';
+  type : 'issue' | 'pr' | 'ref';
   date : string;
   line : string;
 };
@@ -53,7 +53,7 @@ export async function logCommand(ctx: AgentContext, args: string[]): Promise<voi
     });
   }
 
-  // Fetch recent patches.
+  // Fetch recent PRs.
   const { records: patches } = await ctx.patches.records.query('repo/patch', {
     filter: { contextId: repoContextId },
   });
@@ -64,9 +64,9 @@ export async function logCommand(ctx: AgentContext, args: string[]): Promise<voi
     const st = tags?.status ?? '?';
     const num = data.number ?? tags?.number ?? '?';
     entries.push({
-      type : 'patch',
+      type : 'pr',
       date : rec.dateCreated ?? '',
-      line : `patch  #${String(num).padEnd(4)} [${st.toUpperCase().padEnd(6)}] ${data.title}`,
+      line : `pr     #${String(num).padEnd(4)} [${st.toUpperCase().padEnd(6)}] ${data.title}`,
     });
   }
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -14,11 +14,11 @@
  *   gitd issue comment <number> <body>      Add a comment to an issue
  *   gitd issue close <number>               Close an issue
  *   gitd issue list [--status <open|closed>]
- *   gitd patch create <title>               Open a patch (PR)
- *   gitd patch show <number>                Show patch details + reviews
- *   gitd patch comment <number> <body>      Add a comment/review
- *   gitd patch merge <number>               Merge a patch
- *   gitd patch list [--status <status>]
+ *   gitd pr create <title>                  Open a pull request
+ *   gitd pr show <number>                   Show PR details + reviews
+ *   gitd pr comment <number> <body>         Add a comment/review
+ *   gitd pr merge <number>                  Merge a PR
+ *   gitd pr list [--status <status>]
  *   gitd release create <tag>               Create a release
  *   gitd release show <tag>                 Show release details
  *   gitd release list                       List releases
@@ -84,7 +84,7 @@ import { logCommand } from './commands/log.js';
 import { migrateCommand } from './commands/migrate.js';
 import { notificationCommand } from './commands/notification.js';
 import { orgCommand } from './commands/org.js';
-import { patchCommand } from './commands/patch.js';
+import { prCommand } from './commands/pr.js';
 import { registryCommand } from './commands/registry.js';
 import { releaseCommand } from './commands/release.js';
 import { repoCommand } from './commands/repo.js';
@@ -132,13 +132,13 @@ function printUsage(): void {
   console.log('  issue reopen <number>                       Reopen a closed issue');
   console.log('  issue list [--status <open|closed>]         List issues');
   console.log('');
-  console.log('  patch create <title> [--base ...] [--head ...]  Open a patch (PR)');
-  console.log('  patch show <number>                         Show patch details and reviews');
-  console.log('  patch comment <number> <body>               Add a comment/review');
-  console.log('  patch merge <number>                        Merge a patch');
-  console.log('  patch close <number>                        Close a patch');
-  console.log('  patch reopen <number>                       Reopen a closed patch');
-  console.log('  patch list [--status <status>]              List patches');
+  console.log('  pr create <title> [--base ...] [--head ...]     Open a pull request');
+  console.log('  pr show <number>                               Show PR details and reviews');
+  console.log('  pr comment <number> <body>                     Add a comment/review');
+  console.log('  pr merge <number>                              Merge a PR');
+  console.log('  pr close <number>                              Close a PR');
+  console.log('  pr reopen <number>                             Reopen a closed PR');
+  console.log('  pr list [--status <status>]                    List PRs');
   console.log('');
   console.log('  release create <tag> [--name ...] [--body ...]  Create a release');
   console.log('  release show <tag>                          Show release details + assets');
@@ -185,7 +185,7 @@ function printUsage(): void {
   console.log('  migrate all [owner/repo]                    Import everything from GitHub');
   console.log('  migrate repo [owner/repo]                   Import repo metadata');
   console.log('  migrate issues [owner/repo]                 Import issues + comments');
-  console.log('  migrate pulls [owner/repo]                  Import PRs as patches + reviews');
+  console.log('  migrate pulls [owner/repo]                  Import PRs + reviews');
   console.log('  migrate releases [owner/repo]               Import releases');
   console.log('');
   console.log('  web [--port <port>]                         Start read-only web UI (default: 8080)');
@@ -361,8 +361,9 @@ async function main(): Promise<void> {
       await issueCommand(ctx, rest);
       break;
 
+    case 'pr':
     case 'patch':
-      await patchCommand(ctx, rest);
+      await prCommand(ctx, rest);
       break;
 
     case 'repo':

--- a/tests/cli.spec.ts
+++ b/tests/cli.spec.ts
@@ -646,131 +646,131 @@ describe('gitd CLI commands', () => {
   });
 
   // =========================================================================
-  // patch commands
+  // pr commands
   // =========================================================================
 
-  describe('patch', () => {
+  describe('pr', () => {
     it('should fail create without a title', async () => {
-      const { patchCommand } = await import('../src/cli/commands/patch.js');
-      const { errors, exitCode } = await captureError(() => patchCommand(ctx, ['create']));
+      const { prCommand } = await import('../src/cli/commands/pr.js');
+      const { errors, exitCode } = await captureError(() => prCommand(ctx, ['create']));
       expect(exitCode).toBe(1);
       expect(errors[0]).toContain('Usage');
     });
 
-    it('should create patch #1 with sequential numbering', async () => {
-      const { patchCommand } = await import('../src/cli/commands/patch.js');
+    it('should create PR #1 with sequential numbering', async () => {
+      const { prCommand } = await import('../src/cli/commands/pr.js');
       const logs = await captureLog(() =>
-        patchCommand(ctx, ['create', 'Add feature X', '--body', 'This adds X', '--base', 'main', '--head', 'feature-x']),
+        prCommand(ctx, ['create', 'Add feature X', '--body', 'This adds X', '--base', 'main', '--head', 'feature-x']),
       );
-      expect(logs.some((l) => l.includes('Created patch #1'))).toBe(true);
+      expect(logs.some((l) => l.includes('Created PR #1'))).toBe(true);
       expect(logs.some((l) => l.includes('Add feature X'))).toBe(true);
     });
 
-    it('should create patch #2 with next number', async () => {
-      const { patchCommand } = await import('../src/cli/commands/patch.js');
-      const logs = await captureLog(() => patchCommand(ctx, ['create', 'Fix typo']));
-      expect(logs.some((l) => l.includes('Created patch #2'))).toBe(true);
+    it('should create PR #2 with next number', async () => {
+      const { prCommand } = await import('../src/cli/commands/pr.js');
+      const logs = await captureLog(() => prCommand(ctx, ['create', 'Fix typo']));
+      expect(logs.some((l) => l.includes('Created PR #2'))).toBe(true);
     });
 
-    it('should show patch details by number', async () => {
-      const { patchCommand } = await import('../src/cli/commands/patch.js');
-      const logs = await captureLog(() => patchCommand(ctx, ['show', '1']));
-      expect(logs.some((l) => l.includes('Patch #1: Add feature X'))).toBe(true);
+    it('should show PR details by number', async () => {
+      const { prCommand } = await import('../src/cli/commands/pr.js');
+      const logs = await captureLog(() => prCommand(ctx, ['show', '1']));
+      expect(logs.some((l) => l.includes('PR #1: Add feature X'))).toBe(true);
       expect(logs.some((l) => l.includes('Status:   OPEN'))).toBe(true);
       expect(logs.some((l) => l.includes('main <- feature-x'))).toBe(true);
     });
 
-    it('should merge a patch', async () => {
-      const { patchCommand } = await import('../src/cli/commands/patch.js');
-      const logs = await captureLog(() => patchCommand(ctx, ['merge', '1']));
-      expect(logs.some((l) => l.includes('Merged patch #1'))).toBe(true);
+    it('should merge a PR', async () => {
+      const { prCommand } = await import('../src/cli/commands/pr.js');
+      const logs = await captureLog(() => prCommand(ctx, ['merge', '1']));
+      expect(logs.some((l) => l.includes('Merged PR #1'))).toBe(true);
       expect(logs.some((l) => l.includes('strategy: merge'))).toBe(true);
     });
 
     it('should show merged status after merging', async () => {
-      const { patchCommand } = await import('../src/cli/commands/patch.js');
-      const logs = await captureLog(() => patchCommand(ctx, ['show', '1']));
+      const { prCommand } = await import('../src/cli/commands/pr.js');
+      const logs = await captureLog(() => prCommand(ctx, ['show', '1']));
       expect(logs.some((l) => l.includes('Status:   MERGED'))).toBe(true);
     });
 
-    it('should not re-merge an already merged patch', async () => {
-      const { patchCommand } = await import('../src/cli/commands/patch.js');
-      const logs = await captureLog(() => patchCommand(ctx, ['merge', '1']));
+    it('should not re-merge an already merged PR', async () => {
+      const { prCommand } = await import('../src/cli/commands/pr.js');
+      const logs = await captureLog(() => prCommand(ctx, ['merge', '1']));
       expect(logs.some((l) => l.includes('already merged'))).toBe(true);
     });
 
-    it('should add a comment to a patch', async () => {
-      const { patchCommand } = await import('../src/cli/commands/patch.js');
-      const logs = await captureLog(() => patchCommand(ctx, ['comment', '2', 'Looks good to me']));
-      expect(logs.some((l) => l.includes('Added comment to patch #2'))).toBe(true);
+    it('should add a comment to a PR', async () => {
+      const { prCommand } = await import('../src/cli/commands/pr.js');
+      const logs = await captureLog(() => prCommand(ctx, ['comment', '2', 'Looks good to me']));
+      expect(logs.some((l) => l.includes('Added comment to PR #2'))).toBe(true);
     });
 
-    it('should show review comments in patch detail', async () => {
-      const { patchCommand } = await import('../src/cli/commands/patch.js');
-      const logs = await captureLog(() => patchCommand(ctx, ['show', '2']));
+    it('should show review comments in PR detail', async () => {
+      const { prCommand } = await import('../src/cli/commands/pr.js');
+      const logs = await captureLog(() => prCommand(ctx, ['show', '2']));
       expect(logs.some((l) => l.includes('Reviews (1)'))).toBe(true);
       expect(logs.some((l) => l.includes('COMMENTED'))).toBe(true);
       expect(logs.some((l) => l.includes('Looks good to me'))).toBe(true);
     });
 
     it('should fail comment without body', async () => {
-      const { patchCommand } = await import('../src/cli/commands/patch.js');
-      const { errors, exitCode } = await captureError(() => patchCommand(ctx, ['comment', '2']));
+      const { prCommand } = await import('../src/cli/commands/pr.js');
+      const { errors, exitCode } = await captureError(() => prCommand(ctx, ['comment', '2']));
       expect(exitCode).toBe(1);
       expect(errors[0]).toContain('Usage');
     });
 
-    it('should fail comment for non-existent patch', async () => {
-      const { patchCommand } = await import('../src/cli/commands/patch.js');
-      const { errors, exitCode } = await captureError(() => patchCommand(ctx, ['comment', '99', 'hello']));
+    it('should fail comment for non-existent PR', async () => {
+      const { prCommand } = await import('../src/cli/commands/pr.js');
+      const { errors, exitCode } = await captureError(() => prCommand(ctx, ['comment', '99', 'hello']));
       expect(exitCode).toBe(1);
       expect(errors[0]).toContain('not found');
     });
 
-    it('should close a patch', async () => {
-      const { patchCommand } = await import('../src/cli/commands/patch.js');
-      const logs = await captureLog(() => patchCommand(ctx, ['close', '2']));
-      expect(logs.some((l) => l.includes('Closed patch #2'))).toBe(true);
+    it('should close a PR', async () => {
+      const { prCommand } = await import('../src/cli/commands/pr.js');
+      const logs = await captureLog(() => prCommand(ctx, ['close', '2']));
+      expect(logs.some((l) => l.includes('Closed PR #2'))).toBe(true);
     });
 
-    it('should reopen a closed patch', async () => {
-      const { patchCommand } = await import('../src/cli/commands/patch.js');
-      const logs = await captureLog(() => patchCommand(ctx, ['reopen', '2']));
-      expect(logs.some((l) => l.includes('Reopened patch #2'))).toBe(true);
+    it('should reopen a closed PR', async () => {
+      const { prCommand } = await import('../src/cli/commands/pr.js');
+      const logs = await captureLog(() => prCommand(ctx, ['reopen', '2']));
+      expect(logs.some((l) => l.includes('Reopened PR #2'))).toBe(true);
     });
 
-    it('should not reopen an already open patch', async () => {
-      const { patchCommand } = await import('../src/cli/commands/patch.js');
-      const logs = await captureLog(() => patchCommand(ctx, ['reopen', '2']));
+    it('should not reopen an already open PR', async () => {
+      const { prCommand } = await import('../src/cli/commands/pr.js');
+      const logs = await captureLog(() => prCommand(ctx, ['reopen', '2']));
       expect(logs.some((l) => l.includes('already open'))).toBe(true);
     });
 
-    it('should not reopen a merged patch', async () => {
-      const { patchCommand } = await import('../src/cli/commands/patch.js');
-      const logs = await captureLog(() => patchCommand(ctx, ['reopen', '1']));
+    it('should not reopen a merged PR', async () => {
+      const { prCommand } = await import('../src/cli/commands/pr.js');
+      const logs = await captureLog(() => prCommand(ctx, ['reopen', '1']));
       expect(logs.some((l) => l.includes('cannot be reopened'))).toBe(true);
     });
 
-    it('should fail reopen for non-existent patch', async () => {
-      const { patchCommand } = await import('../src/cli/commands/patch.js');
-      const { errors, exitCode } = await captureError(() => patchCommand(ctx, ['reopen', '99']));
+    it('should fail reopen for non-existent PR', async () => {
+      const { prCommand } = await import('../src/cli/commands/pr.js');
+      const { errors, exitCode } = await captureError(() => prCommand(ctx, ['reopen', '99']));
       expect(exitCode).toBe(1);
       expect(errors[0]).toContain('not found');
     });
 
-    it('should list all patches with numbers', async () => {
-      const { patchCommand } = await import('../src/cli/commands/patch.js');
-      const logs = await captureLog(() => patchCommand(ctx, ['list']));
-      expect(logs.some((l) => l.includes('Patches (2)'))).toBe(true);
+    it('should list all PRs with numbers', async () => {
+      const { prCommand } = await import('../src/cli/commands/pr.js');
+      const logs = await captureLog(() => prCommand(ctx, ['list']));
+      expect(logs.some((l) => l.includes('PRs (2)'))).toBe(true);
       expect(logs.some((l) => l.includes('#1'))).toBe(true);
       expect(logs.some((l) => l.includes('#2'))).toBe(true);
       expect(logs.some((l) => l.includes('Add feature X'))).toBe(true);
       expect(logs.some((l) => l.includes('Fix typo'))).toBe(true);
     });
 
-    it('should fail show for non-existent patch', async () => {
-      const { patchCommand } = await import('../src/cli/commands/patch.js');
-      const { errors, exitCode } = await captureError(() => patchCommand(ctx, ['show', '99']));
+    it('should fail show for non-existent PR', async () => {
+      const { prCommand } = await import('../src/cli/commands/pr.js');
+      const { errors, exitCode } = await captureError(() => prCommand(ctx, ['show', '99']));
       expect(exitCode).toBe(1);
       expect(errors[0]).toContain('not found');
     });
@@ -785,9 +785,9 @@ describe('gitd CLI commands', () => {
       const { logCommand } = await import('../src/cli/commands/log.js');
       const logs = await captureLog(() => logCommand(ctx, []));
       expect(logs.some((l) => l.includes('Recent activity'))).toBe(true);
-      // Should have both issues and patches.
+      // Should have both issues and PRs.
       expect(logs.some((l) => l.includes('issue'))).toBe(true);
-      expect(logs.some((l) => l.includes('patch'))).toBe(true);
+      expect(logs.some((l) => l.includes('pr'))).toBe(true);
     });
 
     it('should respect --limit flag', async () => {
@@ -1816,7 +1816,7 @@ describe('gitd CLI commands', () => {
       expect(logs.some((l) => l.includes('1 review'))).toBe(true);
       expect(logs.some((l) => l.includes('#201'))).toBe(true);
       expect(logs.some((l) => l.includes('open'))).toBe(true);
-      expect(logs.some((l) => l.includes('Imported 2 patches'))).toBe(true);
+      expect(logs.some((l) => l.includes('Imported 2 PRs'))).toBe(true);
     });
 
     it('should handle no pull requests gracefully', async () => {


### PR DESCRIPTION
## Summary

Closes #97

- Rename `gitd patch` CLI command to `gitd pr` so the UX mirrors `gh pr`. The `patch` subcommand is kept as an alias for kernel/b4-minded users.
- All user-facing output now says "PR" instead of "patch" (e.g. `Created PR #1`, `Merged PR #1`, `PRs (2)`).
- Protocol-layer names (`repo/patch`, `ForgePatchesProtocol`, `ctx.patches`) remain unchanged — only CLI strings and the command file are renamed.

### Changed files
- `src/cli/commands/patch.ts` → `src/cli/commands/pr.ts` (renamed, all functions/strings updated)
- `src/cli/main.ts` (import, help text, routing with `patch` alias)
- `src/cli/commands/log.ts` (activity type + output prefix)
- `src/cli/commands/migrate.ts` (output strings + internal variables)
- `tests/cli.spec.ts` (all describe/it labels + assertion strings)
- `README.md` (section header + example commands)
- `PLAN.md` (one line updated)

### Checks
- `bun run build` — zero errors
- `bun run lint` — zero warnings
- `bun test .spec.ts` — 1003 pass, 0 fail, 2399 assertions