### PR TITLE
feat: add `repo/patch/revision/bundle` path to ForgePatchesProtocol

### DIFF
--- a/.changeset/revision-bundle.md
+++ b/.changeset/revision-bundle.md
@@ -1,0 +1,5 @@
+---
+'@enbox/gitd': minor
+---
+
+Add `repo/patch/revision/bundle` path to ForgePatchesProtocol for carrying git bundle binaries with PR revisions. Each revision can have at most one bundle (`$recordLimit: { max: 1 }`), immutable, with `tipCommit`/`baseCommit`/`refCount`/`size` tags. This enables cross-DWN PR submissions where contributors attach scoped git bundles to their patch revisions.


### PR DESCRIPTION
## Summary

Closes #90

- Add `revisionBundle` child path under `repo/patch/revision` in `ForgePatchesProtocol` for carrying git bundle binaries (`application/x-git-bundle`) with PR revisions.
- Each revision can have at most one bundle (`$recordLimit: { max: 1 }`), immutable, with `tipCommit`/`baseCommit`/`refCount`/`size` tags.
- Patch author can create bundles; contributors can read them.
- This enables cross-DWN PR submissions where contributors attach scoped git bundles to their patch revisions.

### Protocol structure

```
repo/patch
  └── repo/patch/revision
        └── repo/patch/revision/revisionBundle   ← NEW (application/x-git-bundle)
```

### Changed files
- `src/patches.ts` — new `RevisionBundleData` type, `revisionBundle` in schema map + types + structure
- `tests/protocols.spec.ts` — 6 new tests verifying bundle path, type, immutability, record limit, tags, and permissions

### Checks
- `bun run build` — zero errors
- `bun run lint` — zero warnings
- `bun test .spec.ts` — 1009 pass, 0 fail, 2414 assertions