### PR TITLE
feat: open ForgePatchesProtocol to external contributors

### DIFF
--- a/.changeset/submissions-inbox.md
+++ b/.changeset/submissions-inbox.md
@@ -1,0 +1,5 @@
+---
+'@enbox/gitd': minor
+---
+
+Open ForgePatchesProtocol to external contributors: anyone can now create patches, reviews, and review comments without needing a contributor role. All child paths (revision, revisionBundle, review, reviewComment, statusChange, mergeResult) are publicly readable. This enables open-source-style PR submissions from any DID.

--- a/src/patches.ts
+++ b/src/patches.ts
@@ -120,7 +120,7 @@ export const ForgePatchesDefinition = {
 
       patch: {
         $actions: [
-          { role: 'repo:repo/contributor', can: ['create', 'read'] },
+          { who: 'anyone', can: ['create', 'read'] },
           { role: 'repo:repo/maintainer', can: ['create', 'read', 'update', 'delete'] },
           { who: 'author', of: 'repo/patch', can: ['create', 'update'] },
         ],
@@ -137,7 +137,7 @@ export const ForgePatchesDefinition = {
         revision: {
           $immutable : true,
           $actions   : [
-            { role: 'repo:repo/contributor', can: ['read'] },
+            { who: 'anyone', can: ['read'] },
             { who: 'author', of: 'repo/patch', can: ['create'] },
           ],
           $tags: {
@@ -152,7 +152,7 @@ export const ForgePatchesDefinition = {
             $immutable   : true,
             $recordLimit : { max: 1, strategy: 'reject' },
             $actions     : [
-              { role: 'repo:repo/contributor', can: ['read'] },
+              { who: 'anyone', can: ['read'] },
               { who: 'author', of: 'repo/patch', can: ['create'] },
             ],
             $tags: {
@@ -169,7 +169,7 @@ export const ForgePatchesDefinition = {
         review: {
           $immutable : true,
           $actions   : [
-            { role: 'repo:repo/contributor', can: ['create', 'read'] },
+            { who: 'anyone', can: ['create', 'read'] },
             { role: 'repo:repo/maintainer', can: ['create', 'read'] },
           ],
           $tags: {
@@ -181,7 +181,7 @@ export const ForgePatchesDefinition = {
 
           reviewComment: {
             $actions: [
-              { role: 'repo:repo/contributor', can: ['create', 'read'] },
+              { who: 'anyone', can: ['create', 'read'] },
               { role: 'repo:repo/maintainer', can: ['create', 'read'] },
             ],
             $tags: {
@@ -196,7 +196,7 @@ export const ForgePatchesDefinition = {
         statusChange: {
           $immutable : true,
           $actions   : [
-            { role: 'repo:repo/contributor', can: ['read'] },
+            { who: 'anyone', can: ['read'] },
             { role: 'repo:repo/maintainer', can: ['create'] },
             { who: 'author', of: 'repo/patch', can: ['create'] },
           ],
@@ -206,7 +206,7 @@ export const ForgePatchesDefinition = {
           $immutable   : true,
           $recordLimit : { max: 1, strategy: 'reject' },
           $actions     : [
-            { role: 'repo:repo/contributor', can: ['read'] },
+            { who: 'anyone', can: ['read'] },
             { role: 'repo:repo/maintainer', can: ['create'] },
           ],
           $tags: {

--- a/tests/protocols.spec.ts
+++ b/tests/protocols.spec.ts
@@ -371,11 +371,11 @@ describe('@enbox/gitd', () => {
       expect(authorAction!.can).toContain('create');
     });
 
-    it('should allow contributors to read revisionBundle', () => {
+    it('should allow anyone to read revisionBundle', () => {
       const actions = ForgePatchesDefinition.structure.repo.patch.revision.revisionBundle.$actions!;
-      const contribAction = actions.find((a: { role?: string }) => a.role === 'repo:repo/contributor');
-      expect(contribAction).toBeDefined();
-      expect(contribAction!.can).toContain('read');
+      const anyoneAction = actions.find((a: { who?: string }) => a.who === 'anyone');
+      expect(anyoneAction).toBeDefined();
+      expect(anyoneAction!.can).toContain('read');
     });
 
     it('should nest reviewComment under review (3-level nesting)', () => {
@@ -401,6 +401,42 @@ describe('@enbox/gitd', () => {
     it('should restrict mergeResult strategy to merge, squash, rebase', () => {
       const strategy = ForgePatchesDefinition.structure.repo.patch.mergeResult.$tags?.strategy as { enum: string[] };
       expect(strategy.enum).toEqual(['merge', 'squash', 'rebase']);
+    });
+
+    it('should allow anyone to create and read patches (open submissions)', () => {
+      const actions = ForgePatchesDefinition.structure.repo.patch.$actions!;
+      const anyoneAction = actions.find((a) => a.who === 'anyone');
+      expect(anyoneAction).toBeDefined();
+      expect(anyoneAction!.can).toContain('create');
+      expect(anyoneAction!.can).toContain('read');
+    });
+
+    it('should allow anyone to read revisions, reviews, statusChanges, and mergeResults', () => {
+      const revisionActions = ForgePatchesDefinition.structure.repo.patch.revision.$actions!;
+      expect(revisionActions.find((a) => a.who === 'anyone')!.can).toContain('read');
+
+      const bundleActions = ForgePatchesDefinition.structure.repo.patch.revision.revisionBundle.$actions!;
+      expect(bundleActions.find((a: { who?: string }) => a.who === 'anyone')!.can).toContain('read');
+
+      const reviewActions = ForgePatchesDefinition.structure.repo.patch.review.$actions!;
+      expect(reviewActions.find((a) => a.who === 'anyone')!.can).toContain('read');
+
+      const commentActions = ForgePatchesDefinition.structure.repo.patch.review.reviewComment.$actions!;
+      expect(commentActions.find((a) => a.who === 'anyone')!.can).toContain('read');
+
+      const statusActions = ForgePatchesDefinition.structure.repo.patch.statusChange.$actions!;
+      expect(statusActions.find((a) => a.who === 'anyone')!.can).toContain('read');
+
+      const mergeActions = ForgePatchesDefinition.structure.repo.patch.mergeResult.$actions!;
+      expect(mergeActions.find((a) => a.who === 'anyone')!.can).toContain('read');
+    });
+
+    it('should allow anyone to create reviews and review comments', () => {
+      const reviewActions = ForgePatchesDefinition.structure.repo.patch.review.$actions!;
+      expect(reviewActions.find((a) => a.who === 'anyone')!.can).toContain('create');
+
+      const commentActions = ForgePatchesDefinition.structure.repo.patch.review.reviewComment.$actions!;
+      expect(commentActions.find((a) => a.who === 'anyone')!.can).toContain('create');
     });
 
     it('should allow patch author to create revisions and status changes', () => {


### PR DESCRIPTION
## Summary

Closes #91

Open the patches protocol so any DID can submit PRs, reviews, and review comments without needing a contributor role. This enables open-source-style contributions where strangers can propose changes to a repo owner's DWN — mirroring how GitHub accepts PRs from anyone who can fork.

### Permission changes

| Path | Before | After |
|------|--------|-------|
| `repo/patch` | `repo:repo/contributor` create+read | `anyone` create+read |
| `repo/patch/revision` | `repo:repo/contributor` read | `anyone` read |
| `repo/patch/revision/revisionBundle` | `repo:repo/contributor` read | `anyone` read |
| `repo/patch/review` | `repo:repo/contributor` create+read | `anyone` create+read |
| `repo/patch/review/reviewComment` | `repo:repo/contributor` create+read | `anyone` create+read |
| `repo/patch/statusChange` | `repo:repo/contributor` read | `anyone` read |
| `repo/patch/mergeResult` | `repo:repo/contributor` read | `anyone` read |

Maintainer-only operations (update, delete, merge, status changes) remain restricted to `repo:repo/maintainer`.

### Changed files
- `src/patches.ts` — all `$actions` updated
- `tests/protocols.spec.ts` — 3 new tests verifying anyone-can-create/read permissions, 1 updated test

### Checks
- `bun run build` — zero errors
- `bun run lint` — zero warnings
- `bun test .spec.ts` — 1012 pass, 0 fail, 2425 assertions