### PR TITLE
feat: wire `gitd pr create` to generate revision + bundle from git context

### DIFF
--- a/.changeset/pr-create-wire.md
+++ b/.changeset/pr-create-wire.md
@@ -1,0 +1,5 @@
+---
+'@enbox/gitd': minor
+---
+
+Wire `gitd pr create` to automatically generate a revision record and attach a scoped git bundle when run from a git repo with commits ahead of the base branch. The command now computes merge-base, diff stats, commit count, and creates a `repo/patch/revision` + `repo/patch/revision/revisionBundle` in one shot. Use `--no-bundle` to skip git operations and create a metadata-only PR.


### PR DESCRIPTION
## Summary

Closes #92

When run from a git repo with commits ahead of the base branch, `gitd pr create` now automatically creates a full PR submission in one shot — metadata record, revision record with commit info, and a scoped git bundle attachment.

### What it does

1. Computes merge-base via `git merge-base HEAD <base>`
2. Counts commits via `git rev-list --count`
3. Parses diff stats via `git diff --stat`
4. Creates a `repo/patch/revision` record (headCommit, baseCommit, commitCount, diffStat)
5. Creates a scoped git bundle (`git bundle create <file> HEAD ^<base>`)
6. Attaches it as `repo/patch/revision/revisionBundle` with tipCommit/baseCommit/refCount/size tags

### Graceful degradation

- Not in a git repo → metadata-only PR (backward compatible)
- HEAD equals base (no new commits) → metadata-only PR
- `--no-bundle` flag → explicitly skip git operations

### Example output

```
Created PR #1: "Add dark mode" (main <- feat/dark-mode)
  Record ID: bafyrei...
  Revision: 3 commits (a1b2c3d..e4f5g6h)
  DiffStat: +150 -20 (5 files)
  Bundle: 4096 bytes, 1 ref
```

### Changed files
- `src/cli/commands/pr.ts` — git context detection, revision+bundle creation, `--no-bundle` flag
- `tests/cli.spec.ts` — 2 new tests (bundle creation from temp git repo, `--no-bundle` skip)

### Checks
- `bun run build` — zero errors
- `bun run lint` — zero warnings
- `bun test .spec.ts` — 1014 pass, 0 fail, 2433 assertions