### PR TITLE
feat: implement `gitd pr checkout` to fetch PR bundle and create local branch

### DIFF
--- a/.changeset/pr-checkout.md
+++ b/.changeset/pr-checkout.md
@@ -1,0 +1,5 @@
+---
+'@enbox/gitd': minor
+---
+
+Add `gitd pr checkout <number>` (alias `co`) to fetch a PR's bundle from DWN, import git objects, and create a local branch at the tip commit. Supports `--branch` to override the local branch name and `--detach` for a detached HEAD.

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -15,6 +15,7 @@
  *   gitd issue close <number>               Close an issue
  *   gitd issue list [--status <open|closed>]
  *   gitd pr create <title>                  Open a pull request
+ *   gitd pr checkout <number>               Fetch bundle + create branch
  *   gitd pr show <number>                   Show PR details + reviews
  *   gitd pr comment <number> <body>         Add a comment/review
  *   gitd pr merge <number>                  Merge a PR


### PR DESCRIPTION
## Summary

Closes #93.

- Add `gitd pr checkout <number>` (alias `co`) command that queries a PR's latest revision from DWN, downloads the attached git bundle, imports objects via `git fetch`, and creates/switches to a local branch at the tip commit.
- Supports `--branch <name>` to override the local branch name (defaults to the PR's `headBranch` tag or `pr/<number>` fallback) and `--detach` for a detached HEAD checkout.
- Adds 3 tests: successful checkout with branch verification, failure for PR without revisions, and failure for non-existent PR.

## Checks

- `bun run build` — zero errors
- `bun run lint` — zero warnings/errors
- `bun test .spec.ts` — 1017 pass, 9 skip, 0 fail