### PR TITLE
feat: implement `gitd pr merge` with actual git merge

### DIFF
--- a/.changeset/pr-merge.md
+++ b/.changeset/pr-merge.md
@@ -1,0 +1,5 @@
+---
+'@enbox/gitd': minor
+---
+
+Replace metadata-only `gitd pr merge` with actual git merge. The command now checks out the base branch, performs the merge with `--merge` (default), `--squash`, or `--rebase` strategy, records the real merge commit SHA in a `mergeResult` record, creates a `statusChange` audit trail record, and deletes the local PR branch (use `--no-delete-branch` to keep it).

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -136,7 +136,7 @@ function printUsage(): void {
   console.log('  pr create <title> [--base ...] [--head ...]     Open a pull request');
   console.log('  pr show <number>                               Show PR details and reviews');
   console.log('  pr comment <number> <body>                     Add a comment/review');
-  console.log('  pr merge <number>                              Merge a PR');
+  console.log('  pr merge <number> [--squash|--rebase]           Merge a PR with actual git merge');
   console.log('  pr close <number>                              Close a PR');
   console.log('  pr reopen <number>                             Reopen a closed PR');
   console.log('  pr list [--status <status>]                    List PRs');


### PR DESCRIPTION
## Summary

Closes #94.

- Replace metadata-only `gitd pr merge` with real git merge operations. The command now switches to the base branch, performs `git merge --no-ff` (default), `git merge --squash`, or `git rebase` based on the chosen strategy, and records the actual merge commit SHA.
- Create `mergeResult` record with real merge commit SHA and strategy, plus a `statusChange` audit trail record (previously never written).
- Auto-delete the local PR branch after merge (use `--no-delete-branch` to keep it).
- Require the PR branch to exist locally — error message guides users to run `gitd pr checkout` first.
- Add 7 new tests: default merge with branch verification, squash merge, rebase merge, `--no-delete-branch`, merge failure when branch missing, merge failure for closed PR, and updated existing merge status/re-merge tests.

## Checks

- `bun run build` — zero errors
- `bun run lint` — zero warnings/errors
- `bun test .spec.ts` — 1022 pass, 9 skip, 0 fail