### PR TITLE
feat: populate GitHub shim PR fields from revision and mergeResult records

### DIFF
--- a/.changeset/shim-pr-fields.md
+++ b/.changeset/shim-pr-fields.md
@@ -1,0 +1,5 @@
+---
+'@enbox/gitd': minor
+---
+
+Populate GitHub shim PR response fields from DWN revision and mergeResult records. `head.sha`, `base.sha`, `commits`, `additions`, `deletions`, `changed_files` now come from the latest revision record; `merge_commit_sha` comes from the mergeResult record. The `user` field uses `sourceDid` when available. Also add `statusChange` audit trail records to `pr close`, `pr reopen`, and the shim merge endpoint, and fix the migrate command's `CHANGES_REQUESTED` → `reject` verdict mapping.

--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -741,7 +741,7 @@ async function migratePullsInner(ctx: AgentContext, owner: string, repo: string)
         let verdict: string;
         switch (ghReview.state) {
           case 'APPROVED': verdict = 'approve'; break;
-          case 'CHANGES_REQUESTED': verdict = 'request_changes'; break;
+          case 'CHANGES_REQUESTED': verdict = 'reject'; break;
           default: verdict = 'comment'; break;
         }
 

--- a/src/cli/commands/pr.ts
+++ b/src/cli/commands/pr.ts
@@ -530,6 +530,12 @@ async function prClose(ctx: AgentContext, args: string[]): Promise<void> {
     process.exit(1);
   }
 
+  // Audit trail.
+  await ctx.patches.records.create('repo/patch/statusChange' as any, {
+    data            : { reason: 'Closed by maintainer' },
+    parentContextId : patch.contextId,
+  } as any);
+
   console.log(`Closed PR #${numberStr}: "${data.title}"`);
 }
 
@@ -573,6 +579,12 @@ async function prReopen(ctx: AgentContext, args: string[]): Promise<void> {
     console.error(`Failed to reopen PR: ${status.code} ${status.detail}`);
     process.exit(1);
   }
+
+  // Audit trail.
+  await ctx.patches.records.create('repo/patch/statusChange' as any, {
+    data            : { reason: 'Reopened by maintainer' },
+    parentContextId : patch.contextId,
+  } as any);
 
   console.log(`Reopened PR #${numberStr}: "${data.title}"`);
 }


### PR DESCRIPTION
## Summary

Closes #95.

- **GitHub shim**: `buildPullResponse` now queries the latest `repo/patch/revision` record to populate `head.sha`, `base.sha`, `commits`, `additions`, `deletions`, `changed_files` from revision tags and diffStat JSON. Queries `repo/patch/mergeResult` to populate `merge_commit_sha` with the actual merge commit SHA. Uses `sourceDid` tag for the `user` field and sets `author_association` to `CONTRIBUTOR` when the PR author differs from the repo owner.
- **Audit trail**: `gitd pr close`, `gitd pr reopen`, and the shim merge endpoint now create `statusChange` child records for a complete audit trail of all status transitions.
- **Migrate fix**: `CHANGES_REQUESTED` now correctly maps to `'reject'` instead of the invalid `'request_changes'` verdict.

## Checks

- `bun run build` — zero errors
- `bun run lint` — zero warnings/errors
- `bun test .spec.ts` — 1023 pass, 9 skip, 0 fail