### PR TITLE
feat: local daemon auto-start and did:: remote resolution to localhost

### DIFF
--- a/.changeset/daemon-discovery.md
+++ b/.changeset/daemon-discovery.md
@@ -1,0 +1,5 @@
+---
+'@enbox/gitd': minor
+---
+
+Add daemon lockfile (`~/.enbox/daemon.lock`) so `gitd serve` advertises its PID and port, and `git-remote-did` resolves `did::` remotes to the local daemon before attempting DID document resolution. This removes the DID-resolution round-trip for local development.

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -37,6 +37,7 @@ import {
   registerGitService,
   startDidRepublisher,
 } from '../../git-server/did-service.js';
+import { removeLockfile, writeLockfile } from '../../daemon/lockfile.js';
 
 // ---------------------------------------------------------------------------
 // Public URL check
@@ -223,6 +224,9 @@ export async function serveCommand(ctx: AgentContext, args: string[]): Promise<v
   // Keep the DID document alive on the DHT network.
   const stopRepublisher = startDidRepublisher(ctx.web5);
 
+  // Register the daemon so git-remote-did can discover it.
+  writeLockfile(server.port);
+
   console.log(`gitd server listening on port ${server.port}`);
   console.log(`  DID:     ${ctx.did}`);
   console.log(`  Repos:   ${basePath}`);
@@ -244,6 +248,7 @@ export async function serveCommand(ctx: AgentContext, args: string[]): Promise<v
   await new Promise<void>(() => {
     process.on('SIGINT', async () => {
       console.log('\nShutting down...');
+      removeLockfile();
       stopRepublisher();
       await server.stop();
       process.exit(0);

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -10,6 +10,9 @@ export type { DaemonInstance, DaemonOptions } from './server.js';
 export { createAdapterServer, resolveConfig, startDaemon } from './server.js';
 export { builtinAdapters, findAdapter } from './adapters/index.js';
 
+export type { DaemonLock } from './lockfile.js';
+export { lockfilePath, readLockfile, removeLockfile, writeLockfile } from './lockfile.js';
+
 export { githubAdapter } from './adapters/github.js';
 export { goAdapter } from './adapters/go.js';
 export { npmAdapter } from './adapters/npm.js';

--- a/src/daemon/lockfile.ts
+++ b/src/daemon/lockfile.ts
@@ -1,0 +1,114 @@
+/**
+ * Daemon lockfile — discovery mechanism for the local gitd server.
+ *
+ * When `gitd serve` starts, it writes a JSON lockfile to
+ * `~/.enbox/daemon.lock` containing `{ pid, port, startedAt }`.
+ * `git-remote-did` reads this file to discover a running local daemon
+ * and resolve `did::` remotes to `http://localhost:<port>/...` instead
+ * of performing DID document resolution.
+ *
+ * The lockfile is removed on graceful shutdown and validated (PID check)
+ * on read to handle stale files from crashed processes.
+ *
+ * @module
+ */
+
+import { dirname, join } from 'node:path';
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+
+import { enboxHome } from '../profiles/config.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Data stored in the daemon lockfile. */
+export type DaemonLock = {
+  /** The PID of the daemon process. */
+  pid: number;
+
+  /** The HTTP port the git server is listening on. */
+  port: number;
+
+  /** ISO 8601 timestamp of when the daemon started. */
+  startedAt: string;
+};
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+/** Path to the daemon lockfile. */
+export function lockfilePath(): string {
+  return join(enboxHome(), 'daemon.lock');
+}
+
+// ---------------------------------------------------------------------------
+// Write / remove
+// ---------------------------------------------------------------------------
+
+/** Write the daemon lockfile. Overwrites any existing file. */
+export function writeLockfile(port: number): void {
+  const lock: DaemonLock = {
+    pid       : process.pid,
+    port,
+    startedAt : new Date().toISOString(),
+  };
+  const path = lockfilePath();
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(lock, null, 2) + '\n', { mode: 0o644 });
+}
+
+/** Remove the daemon lockfile if it exists and belongs to this process. */
+export function removeLockfile(): void {
+  const path = lockfilePath();
+  if (!existsSync(path)) { return; }
+
+  try {
+    const raw = readFileSync(path, 'utf-8');
+    const lock = JSON.parse(raw) as DaemonLock;
+    // Only remove if this process wrote the file.
+    if (lock.pid === process.pid) {
+      unlinkSync(path);
+    }
+  } catch {
+    // If the file is corrupt or unreadable, remove it anyway.
+    try { unlinkSync(path); } catch { /* ignore */ }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Read / discover
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the daemon lockfile and return the lock data if the daemon
+ * process is still alive.
+ *
+ * Returns `null` if the lockfile doesn't exist, is corrupt, or the
+ * recorded PID is no longer running (stale lockfile).
+ */
+export function readLockfile(): DaemonLock | null {
+  const path = lockfilePath();
+  if (!existsSync(path)) { return null; }
+
+  try {
+    const raw = readFileSync(path, 'utf-8');
+    const lock = JSON.parse(raw) as DaemonLock;
+
+    if (!lock.pid || !lock.port) { return null; }
+
+    // Check if the process is still alive.
+    try {
+      process.kill(lock.pid, 0); // Signal 0 = existence check, no signal sent.
+    } catch {
+      // Process not found — stale lockfile. Clean it up.
+      try { unlinkSync(path); } catch { /* ignore */ }
+      return null;
+    }
+
+    return lock;
+  } catch {
+    return null;
+  }
+}

--- a/src/git-remote/main.ts
+++ b/src/git-remote/main.ts
@@ -58,8 +58,12 @@ async function main(): Promise<void> {
 
   console.error(`git-remote-did: resolved ${parsed.did} → ${endpoint.url} (via ${endpoint.source})`);
 
-  // Delegate to git-remote-https — it handles all the transport complexity.
-  const child = spawn('git', ['remote-https', remoteName, endpoint.url], {
+  // Pick the right transport helper based on the URL scheme.
+  const helper = endpoint.url.startsWith('https://')
+    ? 'remote-https'
+    : 'remote-http';
+
+  const child = spawn('git', [helper, remoteName, endpoint.url], {
     stdio: 'inherit',
   });
 


### PR DESCRIPTION
## Summary

Implements #96 — local daemon discovery via lockfile so `git-remote-did` resolves `did::` remotes to the local daemon without a DID-resolution round-trip.

### Changes

- **`src/daemon/lockfile.ts`** (new): Lockfile module (`writeLockfile`, `readLockfile`, `removeLockfile`) that writes `{ pid, port, startedAt }` to `~/.enbox/daemon.lock` and validates PID liveness on read, cleaning up stale files automatically.
- **`src/cli/commands/serve.ts`**: Calls `writeLockfile(port)` after server starts, `removeLockfile()` on SIGINT shutdown.
- **`src/git-remote/resolve.ts`**: Adds `resolveLocalDaemon()` as Priority 0 in `resolveGitEndpoint()` — reads the lockfile, probes a health endpoint (2s timeout), and returns `http://localhost:<port>/...` URL with `source: 'LocalDaemon'`.
- **`src/git-remote/main.ts`**: Picks `remote-http` or `remote-https` helper based on resolved URL scheme (was hardcoded to `remote-https`).
- **`src/daemon/index.ts`**: Exports lockfile types and functions.
- **`tests/git-remote.spec.ts`**: New test suites for lockfile CRUD (write/read/remove/stale PID cleanup) and local daemon resolution via a temporary HTTP server.

### Verification

- `bun run build` — zero errors
- `bun run lint` — zero warnings/errors
- `bun test .spec.ts` — 1029 pass, 9 skip, 0 fail

Closes #96