### PR TITLE
feat: preflight git dependency check

### DIFF
--- a/.changeset/git-preflight.md
+++ b/.changeset/git-preflight.md
@@ -1,0 +1,5 @@
+---
+'@enbox/gitd': minor
+---
+
+Add preflight git dependency check: all CLI commands (except `--version` and `help`) now verify that `git >= 2.28.0` is installed, with clear error messages when it is missing or outdated. Version and help commands print a warning instead of blocking.

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -95,6 +95,7 @@ import { shimCommand } from './commands/shim.js';
 import { socialCommand } from './commands/social.js';
 import { webCommand } from './commands/web.js';
 import { wikiCommand } from './commands/wiki.js';
+import { checkGit, requireGit, warnGit } from './preflight.js';
 import { profileDataPath, resolveProfile } from '../profiles/config.js';
 
 // ---------------------------------------------------------------------------
@@ -311,13 +312,18 @@ function printVersion(): void {
 async function main(): Promise<void> {
   if (command === '--version' || command === '-v' || command === 'version') {
     printVersion();
+    warnGit(checkGit());
     return;
   }
 
   if (!command || command === 'help' || command === '--help' || command === '-h') {
     printUsage();
+    warnGit(checkGit());
     return;
   }
+
+  // All functional commands require git.
+  requireGit();
 
   // Commands that don't require the Web5 agent.
   switch (command) {

--- a/src/cli/preflight.ts
+++ b/src/cli/preflight.ts
@@ -1,0 +1,148 @@
+/**
+ * Preflight checks — verify external dependencies before running commands.
+ *
+ * `checkGit()` verifies that `git` is on `$PATH` and meets the minimum
+ * version requirement (>= 2.28.0, needed for `git init -b`).
+ *
+ * @module
+ */
+
+import { spawnSync } from 'node:child_process';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Minimum git version required by gitd (`git init -b` support). */
+const MIN_GIT_VERSION = '2.28.0';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Result of a git preflight check. */
+export type GitCheck = {
+  /** Whether `git` was found on `$PATH`. */
+  installed: boolean;
+
+  /** Parsed version string (e.g. `"2.39.2"`), or `null` if not found. */
+  version: string | null;
+
+  /** Whether the installed version meets the minimum requirement. */
+  meetsMinimum: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Version parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Compare two semver-style version strings (major.minor.patch).
+ *
+ * Returns a negative number if `a < b`, zero if equal, positive if `a > b`.
+ */
+function compareVersions(a: string, b: string): number {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  const len = Math.max(pa.length, pb.length);
+
+  for (let i = 0; i < len; i++) {
+    const na = pa[i] ?? 0;
+    const nb = pb[i] ?? 0;
+    if (na !== nb) { return na - nb; }
+  }
+  return 0;
+}
+
+/**
+ * Parse the version string from `git --version` output.
+ *
+ * Handles common formats:
+ * - `git version 2.39.2`
+ * - `git version 2.39.2.windows.1`
+ * - `git version 2.39.2 (Apple Git-143)`
+ */
+export function parseGitVersion(output: string): string | null {
+  const match = output.match(/(\d+\.\d+\.\d+)/);
+  return match ? match[1] : null;
+}
+
+// ---------------------------------------------------------------------------
+// Check
+// ---------------------------------------------------------------------------
+
+/** Check whether `git` is installed and meets the minimum version. */
+export function checkGit(): GitCheck {
+  try {
+    const result = spawnSync('git', ['--version'], {
+      encoding : 'utf-8',
+      timeout  : 5_000,
+      stdio    : ['ignore', 'pipe', 'pipe'],
+    });
+
+    if (result.error || result.status !== 0) {
+      return { installed: false, version: null, meetsMinimum: false };
+    }
+
+    const version = parseGitVersion(result.stdout ?? '');
+    if (!version) {
+      // git ran but we couldn't parse the version — treat as installed
+      // but we can't verify the minimum.
+      return { installed: true, version: null, meetsMinimum: false };
+    }
+
+    return {
+      installed    : true,
+      version,
+      meetsMinimum : compareVersions(version, MIN_GIT_VERSION) >= 0,
+    };
+  } catch {
+    return { installed: false, version: null, meetsMinimum: false };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Print a warning to stderr about a missing or outdated git installation.
+ * Used by commands that bypass the hard gate (--version, help).
+ */
+export function warnGit(check: GitCheck): void {
+  if (!check.installed) {
+    console.error(
+      'Warning: git not found on PATH. gitd requires git >= 2.28.0.\n'
+      + '  Install git: https://git-scm.com/downloads\n',
+    );
+  } else if (!check.meetsMinimum) {
+    console.error(
+      `Warning: git ${check.version} detected, but gitd requires >= 2.28.0.\n`
+      + '  Upgrade git: https://git-scm.com/downloads\n',
+    );
+  }
+}
+
+/**
+ * Require git to be installed and meet the minimum version.
+ * Exits the process with a clear error message if the check fails.
+ */
+export function requireGit(): void {
+  const check = checkGit();
+
+  if (!check.installed) {
+    console.error(
+      'Fatal: git not found on PATH. gitd requires git >= 2.28.0.\n'
+      + '  Install git: https://git-scm.com/downloads',
+    );
+    process.exit(1);
+  }
+
+  if (!check.meetsMinimum) {
+    console.error(
+      `Fatal: git ${check.version} detected, but gitd requires >= 2.28.0.\n`
+      + '  Upgrade git: https://git-scm.com/downloads',
+    );
+    process.exit(1);
+  }
+}

--- a/tests/preflight.spec.ts
+++ b/tests/preflight.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * Preflight check tests — git dependency detection and version parsing.
+ */
+import { describe, expect, it } from 'bun:test';
+
+import { checkGit, parseGitVersion } from '../src/cli/preflight.js';
+
+import type { GitCheck } from '../src/cli/preflight.js';
+
+// ---------------------------------------------------------------------------
+// parseGitVersion
+// ---------------------------------------------------------------------------
+
+describe('parseGitVersion', () => {
+  it('should parse standard git version output', () => {
+    expect(parseGitVersion('git version 2.39.2')).toBe('2.39.2');
+  });
+
+  it('should parse Windows git version output', () => {
+    expect(parseGitVersion('git version 2.39.2.windows.1')).toBe('2.39.2');
+  });
+
+  it('should parse Apple Git version output', () => {
+    expect(parseGitVersion('git version 2.39.2 (Apple Git-143)')).toBe('2.39.2');
+  });
+
+  it('should parse old git version', () => {
+    expect(parseGitVersion('git version 1.8.3')).toBe('1.8.3');
+  });
+
+  it('should return null for unparseable output', () => {
+    expect(parseGitVersion('not a version string')).toBeNull();
+  });
+
+  it('should return null for empty string', () => {
+    expect(parseGitVersion('')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkGit (live — runs against the real system)
+// ---------------------------------------------------------------------------
+
+describe('checkGit', () => {
+  it('should detect the system git installation', () => {
+    // This test runs in CI / dev environments where git is always present.
+    const result: GitCheck = checkGit();
+
+    expect(result.installed).toBe(true);
+    expect(result.version).not.toBeNull();
+    expect(result.version).toMatch(/^\d+\.\d+\.\d+$/);
+
+    // Any modern git should meet the 2.28.0 minimum.
+    expect(result.meetsMinimum).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Implements #107 — all CLI commands now verify that `git >= 2.28.0` is installed before proceeding, with clear error messages for missing or outdated installations.

### Changes

- **`src/cli/preflight.ts`** (new): Preflight module with:
  - `checkGit()` — runs `git --version`, parses output, validates minimum version
  - `requireGit()` — hard gate that exits with a clear `Fatal:` message if git is missing/outdated
  - `warnGit()` — soft warning for commands that bypass the gate
  - `parseGitVersion()` — extracts semver from various `git --version` output formats (standard, Windows, Apple Git)
- **`src/cli/main.ts`** — calls `requireGit()` before all functional commands; `--version` and `help` call `warnGit()` instead
- **`tests/preflight.spec.ts`** (new): Tests for version parsing (6 cases) and live system git detection (1 case)

### Behavior

| Command | Git missing | Git too old | Git OK |
|---|---|---|---|
| `gitd --version` | Prints version + warning | Prints version + warning | Prints version |
| `gitd help` | Prints help + warning | Prints help + warning | Prints help |
| `gitd init`, `gitd serve`, etc. | `Fatal: git not found...` (exit 1) | `Fatal: git 2.17.1 detected...` (exit 1) | Proceeds normally |

### Verification

- `bun run build` — zero errors
- `bun run lint` — zero warnings/errors
- `bun test .spec.ts` — 1036 pass, 9 skip, 0 fail (7 new tests)

Closes #107