### PR TITLE
fix: skip local daemon when cloning repos owned by a different DID

### DIFF
--- a/.changeset/fix-clone-remote-did.md
+++ b/.changeset/fix-clone-remote-did.md
@@ -1,0 +1,10 @@
+---
+'@enbox/gitd': patch
+---
+
+fix: skip local daemon when cloning repos owned by a different DID
+
+The local daemon resolver now checks `ownerDid` in the lockfile and
+only routes to `localhost` when the requested DID matches the daemon
+owner. Previously, cloning any DID would hit the local daemon — which
+does not have the remote user's repos — and fail with 404.

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -295,7 +295,7 @@ export async function serveCommand(ctx: AgentContext, args: string[]): Promise<v
   const stopRepublisher = startDidRepublisher(ctx.enbox);
 
   // Register the daemon so git-remote-did can discover it.
-  writeLockfile(server.port, getVersion() ?? undefined);
+  writeLockfile(server.port, getVersion() ?? undefined, ctx.did);
 
   // Wire up the idle shutdown function now that we have all the pieces.
   shutdown.fn = async (): Promise<void> => {

--- a/src/daemon/lockfile.ts
+++ b/src/daemon/lockfile.ts
@@ -2,7 +2,7 @@
  * Daemon lockfile — discovery mechanism for the local gitd server.
  *
  * When `gitd serve` starts, it writes a JSON lockfile to
- * `~/.enbox/daemon.lock` containing `{ pid, port, startedAt }`.
+ * `~/.enbox/daemon.lock` containing `{ pid, port, startedAt, ownerDid }`.
  * `git-remote-did` reads this file to discover a running local daemon
  * and resolve `did::` remotes to `http://localhost:<port>/...` instead
  * of performing DID document resolution.
@@ -35,6 +35,9 @@ export type DaemonLock = {
 
   /** The gitd version that started this daemon (for upgrade detection). */
   version?: string;
+
+  /** The DID of the identity that owns this daemon. */
+  ownerDid?: string;
 };
 
 // ---------------------------------------------------------------------------
@@ -51,12 +54,13 @@ export function lockfilePath(): string {
 // ---------------------------------------------------------------------------
 
 /** Write the daemon lockfile. Overwrites any existing file. */
-export function writeLockfile(port: number, version?: string): void {
+export function writeLockfile(port: number, version?: string, ownerDid?: string): void {
   const lock: DaemonLock = {
     pid       : process.pid,
     port,
     startedAt : new Date().toISOString(),
     ...(version ? { version } : {}),
+    ...(ownerDid ? { ownerDid } : {}),
   };
   const path = lockfilePath();
   mkdirSync(dirname(path), { recursive: true });

--- a/src/git-remote/resolve.ts
+++ b/src/git-remote/resolve.ts
@@ -134,6 +134,15 @@ async function resolveLocalDaemon(did: string, repo?: string): Promise<GitEndpoi
   // Fast path: check for an already-running daemon.
   const lock = readLockfile();
   if (lock) {
+    // Only use the local daemon when the requested DID matches the
+    // daemon's owner.  Cloning someone else's repo must fall through
+    // to DID document resolution so the request reaches the correct
+    // remote server.  Lockfiles without `ownerDid` (written by older
+    // versions) are treated as matching for backwards compatibility.
+    if (lock.ownerDid && lock.ownerDid !== did) {
+      return null;
+    }
+
     const healthUrl = `http://localhost:${lock.port}/health`;
     try {
       const controller = new AbortController();

--- a/tests/daemon-lifecycle.spec.ts
+++ b/tests/daemon-lifecycle.spec.ts
@@ -41,6 +41,22 @@ describe('lockfile version field', () => {
     expect(lock!.version).toBeUndefined();
     removeLockfile();
   });
+
+  it('should write ownerDid to lockfile when provided', () => {
+    writeLockfile(9418, '1.0.0', 'did:dht:owner123');
+    const lock = readLockfile();
+    expect(lock).not.toBeNull();
+    expect(lock!.ownerDid).toBe('did:dht:owner123');
+    removeLockfile();
+  });
+
+  it('should omit ownerDid when not provided', () => {
+    writeLockfile(9418, '1.0.0');
+    const lock = readLockfile();
+    expect(lock).not.toBeNull();
+    expect(lock!.ownerDid).toBeUndefined();
+    removeLockfile();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/git-remote.spec.ts
+++ b/tests/git-remote.spec.ts
@@ -462,7 +462,7 @@ describe('resolveGitEndpoint with local daemon', () => {
     server.close();
   });
 
-  it('should resolve via local daemon when lockfile exists', async () => {
+  it('should resolve via local daemon when lockfile has no ownerDid (backwards compat)', async () => {
     const result = await resolveGitEndpoint('did:dht:abc123', 'my-repo');
     expect(result.source).toBe('LocalDaemon');
     expect(result.url).toBe(`http://localhost:${port}/did:dht:abc123/my-repo`);
@@ -472,5 +472,50 @@ describe('resolveGitEndpoint with local daemon', () => {
     const result = await resolveGitEndpoint('did:dht:abc123');
     expect(result.source).toBe('LocalDaemon');
     expect(result.url).toBe(`http://localhost:${port}/did:dht:abc123`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Local daemon DID ownership check
+// ---------------------------------------------------------------------------
+
+describe('resolveGitEndpoint skips local daemon for non-owner DID', () => {
+  let server: ReturnType<typeof createServer>;
+  let port: number;
+
+  const ownerDid = 'did:dht:localowner';
+  const remoteDid = 'did:dht:remoteuser';
+
+  beforeAll(async () => {
+    server = createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'ok' }));
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, () => {
+        port = (server.address() as any).port;
+        resolve();
+      });
+    });
+    // Write a lockfile with ownerDid set.
+    writeLockfile(port, '1.0.0', ownerDid);
+  });
+
+  afterAll(() => {
+    removeLockfile();
+    server.close();
+  });
+
+  it('should use local daemon when requested DID matches ownerDid', async () => {
+    const result = await resolveGitEndpoint(ownerDid, 'my-repo');
+    expect(result.source).toBe('LocalDaemon');
+    expect(result.url).toBe(`http://localhost:${port}/${ownerDid}/my-repo`);
+  });
+
+  it('should skip local daemon when requested DID differs from ownerDid', async () => {
+    // The remote DID is not resolvable, so this should throw after
+    // skipping the local daemon — confirming it didn't short-circuit.
+    await expect(resolveGitEndpoint(remoteDid, 'their-repo'))
+      .rejects.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

Fixes cloning repos from another user's DID. Previously, `resolveLocalDaemon()` unconditionally routed **all** DID requests to `localhost`, so cloning `did::did:dht:machineA/repo` on machine B would hit machine B's own daemon (which doesn't have the repo) and fail with 404.

**Root cause:** The lockfile had no concept of which DID the daemon serves, so `resolveLocalDaemon()` had no way to distinguish "my DID" from "someone else's DID."

**Changes:**

- Add `ownerDid` field to `DaemonLock` type and `writeLockfile()` (`src/daemon/lockfile.ts`)
- Pass `ctx.did` from `serve.ts` so the lockfile records the daemon owner
- In `resolveLocalDaemon()`, compare requested DID against `lock.ownerDid` — only use local daemon when they match; otherwise fall through to DID document resolution
- Lockfiles without `ownerDid` (written by older versions) are treated as matching for backwards compatibility

**Tests added:**
- Lockfile `ownerDid` write/read
- `resolveGitEndpoint` uses local daemon when owner matches
- `resolveGitEndpoint` skips local daemon when owner differs

Build, test, and lint all pass.